### PR TITLE
removed include to fix compile error on mac

### DIFF
--- a/land/unpack/R3BLandCosmic1.cxx
+++ b/land/unpack/R3BLandCosmic1.cxx
@@ -123,7 +123,6 @@ namespace __gnu_cxx {
 # include <cmath>
 # define ISNAN(x)      std::isnan(x)
 # define ISFINITE(x)   std::isfinite(x)
-# include "util_c99.h"
 #else
 # define ISNAN(x)     isnan(x)
 # define ISFINITE(x)  isfinite(x)


### PR DESCRIPTION
Removed an include in R3BLandCosmic1.cxx which caused problems on a mac.