### PR TITLE
Don't force std=c++11 flag in neuland. One: It is 2017 already. Two: …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ If(NOT _HAS_CXX11_FLAG)
 EndIf()
 
 Execute_process(COMMAND $ENV{SIMPATH}/bin/fairsoft-config --cxxflags OUTPUT_VARIABLE _res_fairsoft_config OUTPUT_STRIP_TRAILING_WHITESPACE)
-String(FIND ${_res_fairsoft_config} "-std=c++11" POS_C++11)
+String(FIND ${_res_fairsoft_config} "-std=c++1y" POS_C++11)
 If(${POS_C++11} EQUAL -1)
   Message(FATAL_ERROR "FairSoft wasn't compiled with c++11 support. Please recompile FairSoft with a compiler which supports c++11.")
 EndIf()

--- a/neuland/CMakeLists.txt
+++ b/neuland/CMakeLists.txt
@@ -28,7 +28,7 @@ set(DEPENDENCIES
 )
 
 # -pthread for gtest
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wformat-security -pthread -march=native -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wformat-security -pthread -march=native -O3")
 
 
 set(SYSTEM_INCLUDE_DIRECTORIES

--- a/neuland/clustering/CMakeLists.txt
+++ b/neuland/clustering/CMakeLists.txt
@@ -16,7 +16,7 @@ set(DEPENDENCIES
 )
 
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wformat-security -pthread -march=native -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wformat-security -pthread -march=native -O3")
 
 
 set(SYSTEM_INCLUDE_DIRECTORIES

--- a/neuland/digitizing/CMakeLists.txt
+++ b/neuland/digitizing/CMakeLists.txt
@@ -16,7 +16,7 @@ set(DEPENDENCIES
 )
 
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wformat-security -pthread -march=native -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wformat-security -pthread -march=native -O3")
 
 
 set(SYSTEM_INCLUDE_DIRECTORIES

--- a/neuland/reconstruction/CMakeLists.txt
+++ b/neuland/reconstruction/CMakeLists.txt
@@ -27,7 +27,7 @@ set(DEPENDENCIES
 )
 
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wformat-security -pthread -march=native -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wformat-security -pthread -march=native -O3")
 
 
 set(SYSTEM_INCLUDE_DIRECTORIES


### PR DESCRIPTION
Don't force std=c++11 flag in neuland. One: It is 2017 already. Two: Setting something else (i.e. std=c++1y) in cmake gets overwritten.