### PR TITLE
Changed .travis.yml for workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ os: linux
 compiler: gcc
 dist: trusty
 sudo: required
+group: deprecated-2017Q3
 
 before_install:
     - sudo apt-get update -q;


### PR DESCRIPTION
New travis image provides less disk space resulting in an error.
Workaround uses old image until next image provides more disk space again.