### PR TITLE
Some restructuring of standard macros for simulation.

### DIFF
--- a/macros/r3b/CMakeLists.txt
+++ b/macros/r3b/CMakeLists.txt
@@ -1,10 +1,8 @@
 
 GENERATE_ROOT_TEST_SCRIPT(${R3BROOT_SOURCE_DIR}/macros/r3b/r3bsim.C)
-GENERATE_ROOT_TEST_SCRIPT(${R3BROOT_SOURCE_DIR}/macros/r3b/run_digi.C)
-configure_file(${R3BROOT_SOURCE_DIR}/macros/r3b/run_test.sh.in ${R3BROOT_BINARY_DIR}/macros/r3b/run_test.sh)
-add_test(r3bsim ${R3BROOT_BINARY_DIR}/macros/r3b/run_test.sh)
+add_test(r3bsim ${R3BROOT_BINARY_DIR}/macros/r3b/r3bsim.sh)
 SET_TESTS_PROPERTIES(r3bsim PROPERTIES TIMEOUT "100")
-SET_TESTS_PROPERTIES(r3bsim PROPERTIES PASS_REGULAR_EXPRESSION "Digitization successful")
+SET_TESTS_PROPERTIES(r3bsim PROPERTIES PASS_REGULAR_EXPRESSION "TestPassed;All ok")
 
 
 GENERATE_ROOT_TEST_SCRIPT(${R3BROOT_SOURCE_DIR}/macros/r3b/r3bsim_gen.C)
@@ -20,11 +18,25 @@ SET_TESTS_PROPERTIES(r3bsim_g4 PROPERTIES PASS_REGULAR_EXPRESSION "TestPassed;Al
 
 
 GENERATE_ROOT_TEST_SCRIPT(${R3BROOT_SOURCE_DIR}/macros/r3b/r3bsim_new.C)
-GENERATE_ROOT_TEST_SCRIPT(${R3BROOT_SOURCE_DIR}/macros/r3b/run_digi_new.C)
-configure_file(${R3BROOT_SOURCE_DIR}/macros/r3b/run_test_new.sh.in ${R3BROOT_BINARY_DIR}/macros/r3b/run_test_new.sh)
-add_test(r3bsim_new ${R3BROOT_BINARY_DIR}/macros/r3b/run_test_new.sh)
+add_test(r3bsim_new ${R3BROOT_BINARY_DIR}/macros/r3b/r3bsim_new.sh)
 SET_TESTS_PROPERTIES(r3bsim_new PROPERTIES TIMEOUT "100")
-SET_TESTS_PROPERTIES(r3bsim_new PROPERTIES PASS_REGULAR_EXPRESSION "Digitization successful")
+SET_TESTS_PROPERTIES(r3bsim_new PROPERTIES PASS_REGULAR_EXPRESSION "TestPassed;All ok")
+
+
+GENERATE_ROOT_TEST_SCRIPT(${R3BROOT_SOURCE_DIR}/macros/r3b/run_sim.C)
+GENERATE_ROOT_TEST_SCRIPT(${R3BROOT_SOURCE_DIR}/macros/r3b/run_digi.C)
+configure_file(${R3BROOT_SOURCE_DIR}/macros/r3b/run_digi_test.sh.in ${R3BROOT_BINARY_DIR}/macros/r3b/run_digi_test.sh)
+add_test(run_digi ${R3BROOT_BINARY_DIR}/macros/r3b/run_digi_test.sh)
+SET_TESTS_PROPERTIES(run_digi PROPERTIES TIMEOUT "100")
+SET_TESTS_PROPERTIES(run_digi PROPERTIES PASS_REGULAR_EXPRESSION "Digitization successful")
+
+
+GENERATE_ROOT_TEST_SCRIPT(${R3BROOT_SOURCE_DIR}/macros/r3b/run_aladin_sim.C)
+GENERATE_ROOT_TEST_SCRIPT(${R3BROOT_SOURCE_DIR}/macros/r3b/run_aladin_digi.C)
+configure_file(${R3BROOT_SOURCE_DIR}/macros/r3b/run_aladin_digi_test.sh.in ${R3BROOT_BINARY_DIR}/macros/r3b/run_aladin_digi_test.sh)
+add_test(run_aladin_digi ${R3BROOT_BINARY_DIR}/macros/r3b/run_aladin_digi_test.sh)
+SET_TESTS_PROPERTIES(run_aladin_digi PROPERTIES TIMEOUT "100")
+SET_TESTS_PROPERTIES(run_aladin_digi PROPERTIES PASS_REGULAR_EXPRESSION "Digitization successful")
 
 
 add_subdirectory(califa)

--- a/macros/r3b/run_aladin_digi.C
+++ b/macros/r3b/run_aladin_digi.C
@@ -1,12 +1,9 @@
-
-void RemoveGeoManager();
-
-void run_digi_new()
+void run_aladin_digi()
 {
     // ----- Files ---------------------------------------------------------------
-    TString inFile = "r3bsim_new.root";
-    TString parFile = "r3bpar_new.root";
-    TString outFile = "r3bhits_new.root";
+    TString inFile = "aladin_sim.root";
+    TString parFile = "aladin_par.root";
+    TString outFile = "aladin_digi.root";
     // ---------------------------------------------------------------------------
 
     // ----- Timer ---------------------------------------------------------------
@@ -21,24 +18,33 @@ void run_digi_new()
     // ---------------------------------------------------------------------------
 
     // ----- Connect the Digitization Task ---------------------------------------
-    R3BCalifaCrystalCal2Hit* califa_digitizer = new R3BCalifaCrystalCal2Hit();
-    run->AddTask(califa_digitizer);
-    
+    // TOF
+    R3BTof2pDigitizer* tof_digitizer = new R3BTof2pDigitizer();
+    run->AddTask(tof_digitizer);
+
     // mTOF
     R3BmTofDigitizer* mtof_digitizer = new R3BmTofDigitizer();
     run->AddTask(mtof_digitizer);
 
-    // STaRTrack
-    R3BSTaRTraHitFinder* tra_digitizer = new R3BSTaRTraHitFinder();
+    // DCH
+    R3BDch2pDigitizer* dch_2pdigitizer = new R3BDch2pDigitizer();
+    run->AddTask(dch_2pdigitizer);
+
+    // DCH
+    R3BDchDigitizer* dch_digitizer = new R3BDchDigitizer(1);
+    run->AddTask(dch_digitizer);
+
+    // Tracker
+    R3BTra2pDigitizer* tra_digitizer = new R3BTra2pDigitizer();
     run->AddTask(tra_digitizer);
-    
+
+    // GFI
+    R3BGfiDigitizer* gfi_digitizer = new R3BGfiDigitizer();
+    run->AddTask(gfi_digitizer);
+
     // MFI
     R3BMfiDigitizer* mfi_digitizer = new R3BMfiDigitizer();
     run->AddTask(mfi_digitizer);
-    
-    // PSP
-    R3BPspDigitizer* psp_digitizer = new R3BPspDigitizer();
-    run->AddTask(psp_digitizer);
     // ---------------------------------------------------------------------------
 
     // ----- Runtime DataBase info -----------------------------------------------
@@ -53,6 +59,7 @@ void run_digi_new()
     // ----- Intialise and run ---------------------------------------------------
     run->Init();
     run->Run();
+    delete run;
     // ---------------------------------------------------------------------------
 
     // ----- Finish --------------------------------------------------------------
@@ -69,25 +76,4 @@ void run_digi_new()
     cout << " All ok " << endl;
     cout << " Digitization successful." << endl;
     // ---------------------------------------------------------------------------
-
-    RemoveGeoManager();
-}
-
-/**
- * \ function RemoveGeoManager
- * There are some problems when deleting our geometries. In some cases
- * or combinations of geometries there is a double free of some memory
- * which results in a crash of ROOT. To avoid this we have patched one
- * ROOT class. With the newest ROOT6 version this isn't done any longer.
- * As a workaround to avoid the crash we delete two TObjArrays ourself
- * and then call the destructor of the TGeoManager at the end of the
- * macro. To simplify this one also can use this function.
- */
-void RemoveGeoManager()
-{
-  if (gROOT->GetVersionInt() >= 60602) {
-    gGeoManager->GetListOfVolumes()->Delete();
-    gGeoManager->GetListOfShapes()->Delete();
-    delete gGeoManager;
-  }
 }

--- a/macros/r3b/run_aladin_digi_test.sh.in
+++ b/macros/r3b/run_aladin_digi_test.sh.in
@@ -1,0 +1,6 @@
+#!/bin/bash -l
+
+. run_aladin_sim.sh
+
+. run_aladin_digi.sh
+

--- a/macros/r3b/run_digi_test.sh.in
+++ b/macros/r3b/run_digi_test.sh.in
@@ -1,6 +1,6 @@
 #!/bin/bash -l
 
-. r3bsim.sh
+. run_sim.sh
 
 . run_digi.sh
 

--- a/macros/r3b/run_test_new.sh.in
+++ b/macros/r3b/run_test_new.sh.in
@@ -1,6 +1,0 @@
-#!/bin/bash -l
-
-. r3bsim_new.sh
-
-. run_digi_new.sh
-


### PR DESCRIPTION
- Add run_sim.C and run_aladin_sim.C to the tests - together with digitizers.
- Add dTOF and Fibers(4,5,6,sfi) digitizers to the standard macro.