### PR TITLE
Add Phase Space Generator.

### DIFF
--- a/macros/r3b/CMakeLists.txt
+++ b/macros/r3b/CMakeLists.txt
@@ -23,6 +23,12 @@ SET_TESTS_PROPERTIES(r3bsim_new PROPERTIES TIMEOUT "100")
 SET_TESTS_PROPERTIES(r3bsim_new PROPERTIES PASS_REGULAR_EXPRESSION "TestPassed;All ok")
 
 
+GENERATE_ROOT_TEST_SCRIPT(${R3BROOT_SOURCE_DIR}/macros/r3b/test/testR3BPhaseSpaceGeneratorIntegration.C)
+add_test(testR3BPhaseSpaceGeneratorIntegration ${R3BROOT_BINARY_DIR}/macros/r3b/test/testR3BPhaseSpaceGeneratorIntegration.sh)
+SET_TESTS_PROPERTIES(testR3BPhaseSpaceGeneratorIntegration PROPERTIES TIMEOUT "100")
+SET_TESTS_PROPERTIES(testR3BPhaseSpaceGeneratorIntegration PROPERTIES PASS_REGULAR_EXPRESSION "TestPassed;All ok")
+
+
 GENERATE_ROOT_TEST_SCRIPT(${R3BROOT_SOURCE_DIR}/macros/r3b/run_sim.C)
 GENERATE_ROOT_TEST_SCRIPT(${R3BROOT_SOURCE_DIR}/macros/r3b/run_digi.C)
 configure_file(${R3BROOT_SOURCE_DIR}/macros/r3b/run_digi_test.sh.in ${R3BROOT_BINARY_DIR}/macros/r3b/run_digi_test.sh)

--- a/macros/r3b/test/testR3BPhaseSpaceGeneratorIntegration.C
+++ b/macros/r3b/test/testR3BPhaseSpaceGeneratorIntegration.C
@@ -1,0 +1,88 @@
+void testR3BPhaseSpaceGeneratorIntegration()
+{
+    // System paths
+    const TString workDirectory = getenv("VMCWORKDIR");
+    gSystem->Setenv("GEOMPATH", workDirectory + "/geometry");
+    gSystem->Setenv("CONFIG_DIR", workDirectory + "/gconfig");
+
+    // Simulation Base
+    FairRunSim run;
+    run.SetName("TGeant4");
+    run.SetOutputFile("testR3BPhaseSpaceGeneratorIntegration.root");
+    run.SetMaterials("media_r3b.geo");
+
+    // World
+    auto cave = new R3BCave("Cave");
+    cave->SetGeometryFileName("r3b_cave_vacuum.geo");
+    run.AddModule(cave);
+
+    // Magnet
+    run.AddModule(new R3BGladMagnet("glad_v17_flange.geo.root"));
+    auto magField = new R3BGladFieldMap("R3BGladMap");
+    magField->SetScale(-0.6);
+    run.SetField(magField);
+
+    // Primaries
+    auto primGen = new FairPrimaryGenerator();
+    auto gen = new R3BPhaseSpaceGenerator();
+    gen->SetBeamEnergyAMeV(600);
+    gen->SetErelkeV(500);
+    gen->AddHeavyIon({ "B-17", 5, 17, 5 });
+    gen->AddParticle(2112);
+    gen->AddParticle(2112);
+    primGen->AddGenerator(gen);
+    run.SetGenerator(primGen);
+
+    // Logging
+    run.SetStoreTraj(false);
+    FairLogger::GetLogger()->SetLogVerbosityLevel("LOW");
+    FairLogger::GetLogger()->SetLogScreenLevel("INFO");
+
+    // Init & Special MC Settings
+    run.Init();
+
+    // Database
+    auto rtdb = run.GetRuntimeDb();
+    auto fieldPar = (R3BFieldPar*)rtdb->getContainer("R3BFieldPar");
+    fieldPar->SetParameters(magField);
+    fieldPar->setChanged();
+    auto parOut = new FairParRootFileIo(true);
+    parOut->open("testR3BPhaseSpaceGeneratorIntegration.para.root");
+    rtdb->setOutput(parOut);
+    rtdb->saveOutput();
+    rtdb->print();
+
+    // Go
+    run.Run(1);
+
+    // Test Output
+    auto file = run.GetOutputFile();
+    auto tree = (TTree*)file->Get("evt");
+    auto mctc = new TClonesArray("R3BMCTrack");
+    tree->SetBranchAddress("MCTrack", &mctc);
+
+    tree->GetEvent(0);
+    if (mctc->GetEntries() < 3)
+    {
+        cout << "Not enough particles produced" << endl;
+        return;
+    }
+
+    auto track = (R3BMCTrack*)mctc->At(1);
+    if (track->GetPdgCode() != 2112 || track->GetMotherId() != -1)
+    {
+        cout << "Not the correct primary particle" << endl;
+        return;
+    }
+
+    const Double_t ekin = track->GetEnergy() - track->GetMass();
+    cout << "Ekin of primary neutron 1" << ekin << endl;
+    if ((ekin - 0.6) > 0.02)
+    {
+        cout << "Primary neutron doesn't have the correct energy!" << endl;
+        return;
+    }
+
+    cout << " Test passed" << endl;
+    cout << " All ok " << endl;
+}

--- a/r3bgen/CMakeLists.txt
+++ b/r3bgen/CMakeLists.txt
@@ -49,7 +49,7 @@ R3BLandGenerator.cxx
 R3BCALIFATestGenerator.cxx
 R3BIonGenerator.cxx
 R3BGammaGenerator.cxx
-
+R3BPhaseSpaceGenerator.cxx
 )
 
 # fill list of header files from list of source files
@@ -63,3 +63,12 @@ set(DEPENDENCIES
 
 GENERATE_LIBRARY()
 
+# Testing
+enable_testing()
+Set(GTEST_ROOT ${SIMPATH})
+find_package(GTest REQUIRED)
+include_directories(${GTEST_INCLUDE_DIRS})
+
+add_executable(testR3BPhaseSpaceGenerator testR3BPhaseSpaceGenerator.cxx)
+target_link_libraries(testR3BPhaseSpaceGenerator ${GTEST_BOTH_LIBRARIES} ${ROOT_LIBRARIES} R3BGen)
+add_test(R3BPhaseSpaceGeneratorUnitTest ${EXECUTABLE_OUTPUT_PATH}/testR3BPhaseSpaceGenerator)

--- a/r3bgen/R3BGenLinkDef.h
+++ b/r3bgen/R3BGenLinkDef.h
@@ -19,5 +19,6 @@
 #pragma link C++ class  R3Bp2pGenerator+;
 #pragma link C++ class  R3BIonGenerator+;
 #pragma link C++ class  R3BGammaGenerator+;
+#pragma link C++ class  R3BPhaseSpaceGenerator+;
 
 #endif

--- a/r3bgen/R3BPhaseSpaceGenerator.cxx
+++ b/r3bgen/R3BPhaseSpaceGenerator.cxx
@@ -1,0 +1,71 @@
+#include "R3BPhaseSpaceGenerator.h"
+#include "FairLogger.h"
+#include "FairPrimaryGenerator.h"
+#include "FairRunSim.h"
+#include "TDatabasePDG.h"
+#include <numeric>
+
+Bool_t R3BPhaseSpaceGenerator::Init()
+{
+    const Double_t TotE_GeV = fErel_keV / (1000. * 1000.) + std::accumulate(fMasses.begin(), fMasses.end(), 0.);
+    TLorentzVector Init(0.0, 0.0, 0.0, TotE_GeV);
+    fPhaseSpace.SetDecay(Init, fMasses.size(), fMasses.data());
+    return true;
+}
+
+Bool_t R3BPhaseSpaceGenerator::ReadEvent(FairPrimaryGenerator* primGen)
+{
+    fPhaseSpace.Generate();
+
+    const size_t nParticles = fPDGCodes.size();
+    for (size_t i = 0; i < nParticles; i++)
+    {
+        const TLorentzVector* p = fPhaseSpace.GetDecay(i);
+
+        // Apply boost
+        const Double_t pz = fBeta * fGamma * p->E() + fGamma * p->Pz();
+
+        primGen->AddTrack(fPDGCodes.at(i), p->Px(), p->Py(), pz, 0., 0., 0.);
+    }
+    return true;
+}
+
+void R3BPhaseSpaceGenerator::SetBeamEnergyAMeV(const Double_t EBeam_AMeV)
+{
+    fGamma = 1 + (EBeam_AMeV / 1000.) / 0.931494028; // MeV/A -> GeV/A
+    fBeta = std::sqrt(1 - 1 / std::pow(fGamma, 2));
+}
+
+void R3BPhaseSpaceGenerator::AddParticle(const Int_t PDGCode)
+{
+    auto particle = TDatabasePDG::Instance()->GetParticle(PDGCode);
+    if (particle == nullptr)
+    {
+        LOG(FATAL) << "R3BPhaseSpaceGenerator::AddParticle: No such particle: " << PDGCode << FairLogger::endl;
+        return;
+    }
+    fMasses.push_back(particle->Mass());
+    fPDGCodes.push_back(particle->PdgCode());
+}
+
+void R3BPhaseSpaceGenerator::AddHeavyIon(const FairIon& ion)
+{
+    auto run = FairRunSim::Instance();
+    if (run == nullptr)
+    {
+        LOG(WARNING) << "R3BPhaseSpaceGenerator::AddIon: No FairRunSim" << FairLogger::endl;
+    }
+    else
+    {
+        run->AddNewIon((FairIon*)ion.Clone());
+    }
+    fMasses.push_back(ion.GetMass());
+    fPDGCodes.push_back(1000000000 + 10 * 1000 * ion.GetZ() + 10 * ion.GetA());
+}
+
+R3BPhaseSpaceGenerator::R3BPhaseSpaceGenerator()
+    : fGamma(1.)
+    , fBeta(0.)
+    , fErel_keV(0.)
+{
+}

--- a/r3bgen/R3BPhaseSpaceGenerator.h
+++ b/r3bgen/R3BPhaseSpaceGenerator.h
@@ -1,0 +1,38 @@
+#ifndef R3BROOT_R3BPHASESPACEGENERATOR_H
+#define R3BROOT_R3BPHASESPACEGENERATOR_H
+
+// Wrapper for TGenPhaseSpace
+
+#include "FairGenerator.h"
+#include "FairIon.h"
+#include "TGenPhaseSpace.h"
+#include <string>
+#include <vector>
+
+class R3BPhaseSpaceGenerator : public FairGenerator
+{
+  public:
+    R3BPhaseSpaceGenerator();
+
+    void AddParticle(const Int_t PDGCode);
+    void AddHeavyIon(const FairIon& ion);
+
+    void SetBeamEnergyAMeV(const Double_t EBeam_AMeV);
+    void SetErelkeV(const Double_t Erel_keV) { fErel_keV = Erel_keV; }
+
+    Bool_t Init() override;
+    Bool_t ReadEvent(FairPrimaryGenerator* primGen) override;
+    // FairGenerator* CloneGenerator() const override;
+
+  private:
+    Double_t fGamma;
+    Double_t fBeta;
+    Double_t fErel_keV;
+    TGenPhaseSpace fPhaseSpace;
+    std::vector<Int_t> fPDGCodes;
+    std::vector<Double_t> fMasses;
+
+    ClassDefOverride(R3BPhaseSpaceGenerator, 1);
+};
+
+#endif // R3BROOT_R3BPHASESPACEGENERATOR_H

--- a/r3bgen/testR3BPhaseSpaceGenerator.cxx
+++ b/r3bgen/testR3BPhaseSpaceGenerator.cxx
@@ -1,0 +1,74 @@
+#include "FairPrimaryGenerator.h"
+#include "R3BPhaseSpaceGenerator.h"
+#include "TVector3.h"
+#include "gtest/gtest.h"
+#include <stdexcept>
+#include <vector>
+
+namespace
+{
+    class MockFairPrimaryGenerator : public FairPrimaryGenerator
+    {
+      public:
+        Int_t nTracks;
+        std::vector<Int_t> PDGs;
+        std::vector<TVector3> ps;
+
+        void AddTrack(Int_t pdgid,
+                      Double_t px,
+                      Double_t py,
+                      Double_t pz,
+                      Double_t vx,
+                      Double_t vy,
+                      Double_t vz,
+                      Int_t parent = -1,
+                      Bool_t wanttracking = true,
+                      Double_t e = -9e9,
+                      Double_t tof = 0.,
+                      Double_t weight = 0.) override
+        {
+            nTracks++;
+            PDGs.push_back(pdgid);
+            ps.emplace_back(TVector3(px, py, pz));
+        }
+    };
+
+    TEST(testR3BPhaseSpaceGenerator, can_add_tracks)
+    {
+        auto fpg = new MockFairPrimaryGenerator();
+
+        R3BPhaseSpaceGenerator gen;
+        gen.AddHeavyIon({ "U-238", 92, 238, 92 });
+        gen.AddParticle(2112);
+        gen.Init();
+        gen.ReadEvent(fpg);
+
+        EXPECT_EQ(fpg->nTracks, 2);
+        EXPECT_EQ(fpg->PDGs.at(0), 1000922380);
+        EXPECT_EQ(fpg->PDGs.at(1), 2112);
+    }
+
+    TEST(testR3BPhaseSpaceGenerator, does_some_physics)
+    {
+        auto fpg = new MockFairPrimaryGenerator();
+        R3BPhaseSpaceGenerator gen;
+
+        gen.SetBeamEnergyAMeV(600);
+        gen.SetErelkeV(500);
+        gen.AddParticle(2112);
+        gen.AddParticle(2112);
+
+        gen.Init();
+        gen.ReadEvent(fpg);
+
+        const Double_t mass = 0.93956536;
+        EXPECT_NEAR(std::sqrt(fpg->ps.at(0).Mag2() + std::pow(mass, 2)) - std::pow(mass, 2), 0.6, 0.1);
+    }
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
For a lot of simulations it was necessary to generate input files for primary particle with TGenPhaseSpace first, one for each different set of parameters. With enough entries for high statistics, the file size was 50MB or more. This eliminates this intermediate file by directly integrating TGenPhaseSpace as a generator.