### PR TITLE
Support for SOFIA simulations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,9 @@ add_subdirectory (tracking)
   ENDIF(GARFIELD_FOUND)
 
 IF(EXISTS "${R3BROOT_SOURCE_DIR}/sofia/")
+  Message("Building SOFIA framework...")
+  Set(WITH_SOFIA true)
+  add_definitions(-DSOFIA)
   add_subdirectory(sofia)
 ENDIF(EXISTS "${R3BROOT_SOURCE_DIR}/sofia/")
 

--- a/r3bdata/R3BDetectorList.h
+++ b/r3bdata/R3BDetectorList.h
@@ -31,6 +31,10 @@ enum DetectorId
     kFI6,
     kFI5,
     kSFI,
+#ifdef SOFIA
+    kSOFSCI,
+    kSOFAT,
+#endif
     kLAST
 };
 
@@ -58,6 +62,10 @@ enum fDetectorType
     kFI6Point,
     kFI5Point,
     kSFIPoint
+#ifdef SOFIA
+    ,kSOFSCIPoint
+    ,kSOFATPoint
+#endif
 };
 
 enum SensorSide

--- a/r3bdata/R3BMCTrack.cxx
+++ b/r3bdata/R3BMCTrack.cxx
@@ -191,6 +191,12 @@ Int_t R3BMCTrack::GetNPoints(DetectorId detId) const
         return ((fNPoints & 0xC000000000) >> 38);
     else if (detId == kSFI)
         return ((fNPoints & 0x30000000000) >> 40);
+#ifdef SOFIA
+    else if (detId == kSOFSCI)
+        return ((fNPoints & 0xC0000000000) >> 42);
+    else if (detId == kSOFAT)
+        return ((fNPoints & 0x300000000000) >> 44);
+#endif
     else
     {
         cout << "-E- R3BMCTrack::GetNPoints: Unknown detector ID " << detId << endl;
@@ -292,6 +298,16 @@ void R3BMCTrack::SetNPoints(Int_t iDet, Int_t nP)
     {
         fNPoints = (fNPoints & (~0x30000000000)) | (nPoints << 40);
     }
+#ifdef SOFIA
+    else if (iDet == kSOFSCI)
+    {
+        fNPoints = (fNPoints & (~0xC0000000000)) | (nPoints << 42);
+    }
+    else if (iDet == kSOFAT)
+    {
+        fNPoints = (fNPoints & (~0x300000000000)) | (nPoints << 44);
+    }
+#endif
     else
     {
         cout << "-E- R3BMCTrack::SetNPoints: Unknown detector ID " << iDet << endl;


### PR DESCRIPTION
Include ID's of SOFIA detectors (currently 1 example) into R3BDetectorList.h and R3BMCTrack.cxx