### PR TITLE
Removed temporary Travis config and fixed FairPrimaryGenerator Problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os: linux
 compiler: gcc
 dist: trusty
 sudo: required
-group: deprecated-2017Q3
 
 before_install:
     - sudo apt-get update -q;

--- a/macros/r3b/test/testR3BPhaseSpaceGeneratorIntegration.C
+++ b/macros/r3b/test/testR3BPhaseSpaceGeneratorIntegration.C
@@ -56,7 +56,7 @@ void testR3BPhaseSpaceGeneratorIntegration()
     run.Run(1);
 
     // Test Output
-    auto file = run.GetOutputFile();
+    auto file = TFile::Open("testR3BPhaseSpaceGeneratorIntegration.root");
     auto tree = (TTree*)file->Get("evt");
     auto mctc = new TClonesArray("R3BMCTrack");
     tree->SetBranchAddress("MCTrack", &mctc);

--- a/r3bgen/CMakeLists.txt
+++ b/r3bgen/CMakeLists.txt
@@ -12,6 +12,21 @@
 #  "-ffriend-injection")
 #ENDIF(${req_gcc_major_vers} MATCHES "4" AND NOT ${req_gcc_minor_vers} MATCHES "0")
 
+
+#########################################################
+# temporary workaround for testR3BPhaseSpaceGenerator.cxx
+# while FairVersion.h is not working
+execute_process(COMMAND ${FAIRROOTPATH}/bin/fairroot-config --major_version
+    OUTPUT_VARIABLE fairroot_major_version)
+execute_process(COMMAND ${FAIRROOTPATH}/bin/fairroot-config --minor_version
+    OUTPUT_VARIABLE fairroot_minor_version) 
+
+if((${fairroot_major_version} EQUAL 17 AND ${fairroot_minor_version} EQUAL 10) OR ${fairroot_major_version} GREATER 17)
+message("using new FairPrimaryGenerator interface")
+add_definitions(-DFairPrimaryGeneratorAddTrackNewInterface)
+endif((${fairroot_major_version} EQUAL 17 AND ${fairroot_minor_version} EQUAL 10) OR ${fairroot_major_version} GREATER 17)
+#########################################################
+
 Set(SYSTEM_INCLUDE_DIRECTORIES 
 ${SYSTEM_INCLUDE_DIRECTORIES}
 ${BASE_INCLUDE_DIRECTORIES}

--- a/r3bgen/testR3BPhaseSpaceGenerator.cxx
+++ b/r3bgen/testR3BPhaseSpaceGenerator.cxx
@@ -1,5 +1,6 @@
 #include "FairPrimaryGenerator.h"
 #include "R3BPhaseSpaceGenerator.h"
+#include "TMCProcess.h"
 #include "TVector3.h"
 #include "gtest/gtest.h"
 #include <stdexcept>
@@ -25,7 +26,12 @@ namespace
                       Bool_t wanttracking = true,
                       Double_t e = -9e9,
                       Double_t tof = 0.,
-                      Double_t weight = 0.) override
+                      Double_t weight = 0.
+#ifdef FairPrimaryGeneratorAddTrackNewInterface
+                      ,TMCProcess proc = kPPrimary
+#endif
+                     ) override
+
         {
             nTracks++;
             PDGs.push_back(pdgid);


### PR DESCRIPTION
Travis CI has increased the size of the virtual machines. Using deprecated image is not necessary anymore.

Fixed FairPrimaryGenerator problem with a temporary workaround.