### PR TITLE
R3BPspxCal2Hit.h: added inclusion of math.h (same as cmath) to suppor…

### DIFF
--- a/psp/R3BPspxCal2Hit.cxx
+++ b/psp/R3BPspxCal2Hit.cxx
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <limits>
+#include <cmath>
 
 #include "FairLogger.h"
 #include "FairRootManager.h"


### PR DESCRIPTION
Hi,
I got an inclusion miss during the last build. Apparently, math.h was included implicitly somewhere and now it isn't any more. Just added it --it's needed for isnan() checks.