### PR TITLE
Modification for the CALIFA cluster finder in S444

### DIFF
--- a/califa/R3BCalifaCrystalCal2Hit.cxx
+++ b/califa/R3BCalifaCrystalCal2Hit.cxx
@@ -31,7 +31,11 @@ R3BCalifaCrystalCal2Hit::R3BCalifaCrystalCal2Hit() : FairTask("R3B CALIFA Crysta
 {
   fGeometryVersion=17; //default version 8.11 BARREL
   fThreshold=0.;     //no threshold
+  fDRThreshold=15000; //in keV, for real data
   fCrystalResolution=0.; //perfect crystals
+  fComponentResolution=0.; //perfect crystals
+  fLaBrResolution=0;
+  fLaClResolution=0;
   fDeltaPolar=0.25;
   fDeltaAzimuthal=0.25;
   fDeltaAngleClust=0;
@@ -67,8 +71,8 @@ void R3BCalifaCrystalCal2Hit::SetParContainers()
   // if ( fVerbose && fCalifaHitFinderPar ) {
   //   LOG(INFO) << "R3BCalifaCrystalCal2Hit::SetParContainers() "<< FairLogger::endl;
   //   LOG(INFO) << "Container R3BCalifaCrystalCal2HitPar loaded " << FairLogger::endl;
-  // } 
-  
+  // }
+
 }
 
 
@@ -123,16 +127,16 @@ InitStatus R3BCalifaCrystalCal2Hit::ReInit()
 // -----   Public method Exec   --------------------------------------------
 void R3BCalifaCrystalCal2Hit::Exec(Option_t* opt)
 {
-
-  if(++nEvents % 10000 == 0)
-	LOG(INFO) << nEvents << FairLogger::endl;
-
+  
+  //if(++nEvents % 10000 == 0)
+  //LOG(INFO) << nEvents << FairLogger::endl;
+  
   // Reset entries in output arrays, local arrays
   Reset();
-
-
+  
+  
   //ALGORITHMS FOR HIT FINDING
-
+  
   ULong64_t hitTime=0;
   Double_t energy=0.;       // caloHits energy
   Double_t Nf=0.;           // caloHits Nf
@@ -142,69 +146,94 @@ void R3BCalifaCrystalCal2Hit::Exec(Option_t* opt)
   Double_t rhoAngle=0.;   // caloHits reconstructed rho
   Double_t angle1,angle2;
   Double_t eInc=0.;       // total incident energy (only for simulation)
-
+  
   bool* usedCrystalHits=NULL; //array to control the CrystalHits
   Int_t crystalsInHit=0;  //used crystals in each CalifaHitData
   Double_t testPolar=0 ;
   Double_t testAzimuthal=0 ;
   Double_t testRho =0 ;
   bool takeCrystalInCluster;
-
+  
   R3BCalifaCrystalCalData**    crystalHit = NULL;
-
+  
   Int_t crystalHits;        // Nb of CrystalHits in current event
   crystalHits = fCrystalHitCA->GetEntries();
-
+  
   if (crystalHits == 0)
-     return;
-
+    return;
+  
   crystalHit = new R3BCalifaCrystalCalData*[crystalHits];
   usedCrystalHits = new bool[crystalHits];
   for (Int_t i=0; i<crystalHits; i++) {
     crystalHit[i] = (R3BCalifaCrystalCalData*) fCrystalHitCA->At(i);
-    if(kSimulation)
-    {
-       // Apply resolution smearing for simulation
-       crystalHit[i]->SetEnergy(ExpResSmearing(crystalHit[i]->GetEnergy()));
-       crystalHit[i]->SetNf(CompSmearing(crystalHit[i]->GetNf()));
-       crystalHit[i]->SetNs(CompSmearing(crystalHit[i]->GetNs()));
+    if(kSimulation){
+      // Apply resolution smearing for simulation
+      crystalHit[i]->SetEnergy(ExpResSmearing(crystalHit[i]->GetEnergy()));
+      crystalHit[i]->SetNf(CompSmearing(crystalHit[i]->GetNf()));
+      crystalHit[i]->SetNs(CompSmearing(crystalHit[i]->GetNs()));
     }
     usedCrystalHits[i] = 0;
   }
-
+  
   //For the moment a simple analysis... more to come
   Int_t crystalWithHigherEnergy = 0;
   Int_t unusedCrystals = crystalHits;
-
+  
   //removing those crystals with energy below the threshold
-    for (Int_t i=0; i<crystalHits; i++) {
-      if (crystalHit[i]->GetEnergy()<fThreshold) {
-        usedCrystalHits[i] = 1;
-        unusedCrystals--;
+  for (Int_t i=0; i<crystalHits; i++) {
+    if (crystalHit[i]->GetEnergy()<fThreshold) {
+      usedCrystalHits[i] = 1;
+      unusedCrystals--;
+    }
+  }
+  
+  //S444 for crystals with double reading!!
+  //taking only the proton branch in the cluster
+  for (Int_t i=0; i<crystalHits; i++) {
+    for (Int_t j=i; j<crystalHits; j++) {
+      if (abs(crystalHit[i]->GetCrystalId()-crystalHit[j]->GetCrystalId()) == 5000) {
+        if(crystalHit[i]->GetCrystalId() > crystalHit[j]->GetCrystalId()){ //i is protonbranch
+          if(crystalHit[i]->GetEnergy()<fDRThreshold) { //take j, the gammabranch
+            usedCrystalHits[i] = 1;
+            unusedCrystals--;
+          } else{ //take i, the protonbranch
+            usedCrystalHits[j] = 1;
+            unusedCrystals--;
+          }
+	} else{//j is protonbranch
+	  if(crystalHit[i]->GetEnergy()<fDRThreshold) { //take i, the gammabranch
+            usedCrystalHits[j] = 1;
+            unusedCrystals--;
+          } else{ //take j, the protonbranch
+            usedCrystalHits[i] = 1;
+            unusedCrystals--;
+          }
+	}
       }
     }
-
-//  int n_clusters = 0;
-
+  }
+  
+  //  int n_clusters = 0;
+  
   while (unusedCrystals>0) {
     // First, finding the crystal with higher energy from the unused crystalHits
-      for (Int_t i=1; i<crystalHits; i++) {
-        if (!usedCrystalHits[i] && crystalHit[i]->GetEnergy() > 
-	    crystalHit[crystalWithHigherEnergy]->GetEnergy())
-          crystalWithHigherEnergy = i;
-      }
-
-    usedCrystalHits[crystalWithHigherEnergy] = 1; 
+    for (Int_t i=1; i<crystalHits; i++) {
+      if (!usedCrystalHits[i] && crystalHit[i]->GetEnergy() >
+	  crystalHit[crystalWithHigherEnergy]->GetEnergy())
+	crystalWithHigherEnergy = i;
+    }
+    
+    usedCrystalHits[crystalWithHigherEnergy] = 1;
     unusedCrystals--; crystalsInHit++;
-
+    
     // Second, energy and angles come from the crystal with the higher energy
-      hitTime = crystalHit[crystalWithHigherEnergy]->GetTime();
-      energy = crystalHit[crystalWithHigherEnergy]->GetEnergy();
-      Nf = crystalHit[crystalWithHigherEnergy]->GetNf();
-      Ns = crystalHit[crystalWithHigherEnergy]->GetNs();
-      GetAngles(crystalHit[crystalWithHigherEnergy]->GetCrystalId(),
-		&polarAngle,&azimuthalAngle,&rhoAngle);
-
+    hitTime = crystalHit[crystalWithHigherEnergy]->GetTime();
+    energy = crystalHit[crystalWithHigherEnergy]->GetEnergy();
+    Nf = crystalHit[crystalWithHigherEnergy]->GetNf();
+    Ns = crystalHit[crystalWithHigherEnergy]->GetNs();
+    GetAngles(crystalHit[crystalWithHigherEnergy]->GetCrystalId(),
+	      &polarAngle,&azimuthalAngle,&rhoAngle);
+    
     // Third, finding closest hits and adding their energy
     // Clusterization: you want to put a condition on the angle between the highest
     // energy crystal and the others. This is done by using the TVector3 classes and
@@ -215,7 +244,7 @@ void R3BCalifaCrystalCal2Hit::Exec(Option_t* opt)
     refAngle.SetPhi(azimuthalAngle);
     for (Int_t i=0; i<crystalHits; i++) {
       if (!usedCrystalHits[i] ) {
-          GetAngles(crystalHit[i]->GetCrystalId(), &testPolar, 
+          GetAngles(crystalHit[i]->GetCrystalId(), &testPolar,
 		    &testAzimuthal, &testRho);
 
         //if(kSimulation) eInc += crystalHitSim[i]->GetEinc();
@@ -228,13 +257,13 @@ void R3BCalifaCrystalCal2Hit::Exec(Option_t* opt)
         // Check if the angle between the two vectors is less than the reference angle.
         switch (fClusteringAlgorithmSelector) {
         case 1: {  //square window
-          //Dealing with the particular definition of azimuthal 
+          //Dealing with the particular definition of azimuthal
 	  //angles (discontinuity in pi and -pi)
           if (azimuthalAngle + fDeltaAzimuthal > TMath::Pi()) {
-            angle1 = azimuthalAngle-TMath::Pi(); 
+            angle1 = azimuthalAngle-TMath::Pi();
 	    angle2 = testAzimuthal-TMath::Pi();
           } else if (azimuthalAngle - fDeltaAzimuthal < -TMath::Pi()) {
-            angle1 = azimuthalAngle+TMath::Pi(); 
+            angle1 = azimuthalAngle+TMath::Pi();
 	    angle2 = testAzimuthal+TMath::Pi();
           } else {
             angle1 = azimuthalAngle; angle2 = testAzimuthal;
@@ -246,33 +275,33 @@ void R3BCalifaCrystalCal2Hit::Exec(Option_t* opt)
           break;
         }
         case 2:  //round window
-          // The angle is scaled to a reference distance (e.g. here is 
-	  // set to 35 cm) to take into account Califa's non-spherical 
-	  // geometry. The reference angle will then have to be defined 
-	  // in relation to this reference distance: for example, 10° at 
-	  // 35 cm corresponds to ~6cm, setting a fDeltaAngleClust=10 
-	  // means that the gamma rays will be allowed to travel 6 cm in 
+          // The angle is scaled to a reference distance (e.g. here is
+	  // set to 35 cm) to take into account Califa's non-spherical
+	  // geometry. The reference angle will then have to be defined
+	  // in relation to this reference distance: for example, 10° at
+	  // 35 cm corresponds to ~6cm, setting a fDeltaAngleClust=10
+	  // means that the gamma rays will be allowed to travel 6 cm in
 	  // the CsI, no matter the position of the crystal they hit.
-          if ( ((refAngle.Angle(testAngle))*((testRho+rhoAngle)/(35.*2.))) < 
+          if ( ((refAngle.Angle(testAngle))*((testRho+rhoAngle)/(35.*2.))) <
 	       fDeltaAngleClust )  {
                   takeCrystalInCluster = true;
           }
           break ;
         case 3: {  //round window scaled with energy
-          // The same as before but the angular window is scaled 
-	  // according to the energy of the hit in the higher energy 
+          // The same as before but the angular window is scaled
+	  // according to the energy of the hit in the higher energy
 	  // crystal. It needs a parameter that should be calibrated.
-            Double_t fDeltaAngleClustScaled = fDeltaAngleClust * 
+            Double_t fDeltaAngleClustScaled = fDeltaAngleClust *
 	      (crystalHit[crystalWithHigherEnergy]->GetEnergy()*fParCluster1);
-            if ( ((refAngle.Angle(testAngle))*((testRho+rhoAngle)/(35.*2.))) < 
+            if ( ((refAngle.Angle(testAngle))*((testRho+rhoAngle)/(35.*2.))) <
 		 fDeltaAngleClustScaled )  {
                   takeCrystalInCluster = true;
             }
           break;
         }
-        case 4: // round window scaled with the energy of the _two_ hits 
+        case 4: // round window scaled with the energy of the _two_ hits
 	  //(to be tested and implemented!!)
-          // More advanced: the condition on the distance between the 
+          // More advanced: the condition on the distance between the
 	  //two hits is function of the energy of both hits
           break;
         }
@@ -283,24 +312,24 @@ void R3BCalifaCrystalCal2Hit::Exec(Option_t* opt)
   	      Nf += crystalHit[i]->GetNf();
 	      Ns += crystalHit[i]->GetNs();
               usedCrystalHits[i] = 1; unusedCrystals--; crystalsInHit++;
-              
+
               if(kSimulation)
                   eInc += dynamic_cast<R3BCalifaCrystalCalDataSim*>(crystalHit[i])->GetEinc();
         }
       }
     }
-    
-    
+
+
     if(kSimulation) {
       AddHitSim(crystalsInHit, energy, Nf, Ns, polarAngle, azimuthalAngle, eInc);
     } else {
       AddHit(crystalsInHit, energy, Nf, Ns, polarAngle, azimuthalAngle, hitTime);
 //      n_clusters++;
     }
-    
+
     crystalsInHit = 0; //reset for next CalifaHitData
-    
-    //Finally, setting crystalWithHigherEnergy to the first unused 
+
+    //Finally, setting crystalWithHigherEnergy to the first unused
     //crystalHit (for the next iteration)
     for (Int_t i=0; i<crystalHits; i++) {
       if (!usedCrystalHits[i]) {
@@ -323,7 +352,7 @@ void R3BCalifaCrystalCal2Hit::Exec(Option_t* opt)
 void R3BCalifaCrystalCal2Hit::Reset()
 {
   // Clear the CA structure
-  
+
   if (fCalifaHitCA) fCalifaHitCA->Clear();
 }
 
@@ -347,7 +376,7 @@ void R3BCalifaCrystalCal2Hit::SelectGeometryVersion(Int_t version)
 void R3BCalifaCrystalCal2Hit::SetExperimentalResolution(Double_t crystalRes)
 {
   fCrystalResolution = crystalRes;
-  LOG(INFO) << "R3BCalifaCrystalCal2Hit::SetExperimentalResolution to " 
+  LOG(INFO) << "R3BCalifaCrystalCal2Hit::SetExperimentalResolution to "
 	    << fCrystalResolution << "% @ 1 MeV." << FairLogger::endl;
 }
 
@@ -356,7 +385,7 @@ void R3BCalifaCrystalCal2Hit::SetExperimentalResolution(Double_t crystalRes)
 void R3BCalifaCrystalCal2Hit::SetComponentResolution(Double_t componentRes)
 {
   fComponentResolution = componentRes;
-  LOG(INFO) << "R3BCalifaCrystalCal2Hit::SetComponentResolution to " 
+  LOG(INFO) << "R3BCalifaCrystalCal2Hit::SetComponentResolution to "
 	    << fComponentResolution << " MeV." << FairLogger::endl;
 }
 
@@ -365,7 +394,7 @@ void R3BCalifaCrystalCal2Hit::SetPhoswichResolution(Double_t LaBr, Double_t LaCl
 {
   fLaBrResolution = LaBr;
   fLaClResolution = LaCl;
-  LOG(INFO) << "R3BCalifaCrystalCal2Hit::SetPhoswichResolution to " 
+  LOG(INFO) << "R3BCalifaCrystalCal2Hit::SetPhoswichResolution to "
 	    << fLaBrResolution << "% @ 1 MeV (LaBr) and to " << fLaClResolution << "% @ 1 MeV (LaCl)" << FairLogger::endl;
 }
 
@@ -373,10 +402,23 @@ void R3BCalifaCrystalCal2Hit::SetPhoswichResolution(Double_t LaBr, Double_t LaCl
 void R3BCalifaCrystalCal2Hit::SetDetectionThreshold(Double_t thresholdEne)
 {
   fThreshold = thresholdEne;
-  LOG(INFO) << "R3BCalifaCrystalCal2Hit::SetDetectionThreshold to " 
-	    << fThreshold << " GeV." << FairLogger::endl;
+  if(kSimulation) {
+    LOG(INFO) << "R3BCalifaCrystalCal2Hit::SetDetectionThreshold to "
+	     << fThreshold << " GeV." << FairLogger::endl;
+  }
+  else{
+    LOG(INFO) << "R3BCalifaCrystalCal2Hit::SetDetectionThreshold to "
+         << fThreshold << " keV." << FairLogger::endl;
+  }
 }
 
+// -----  Public method SetDRThreshold  ----------------------------------
+void R3BCalifaCrystalCal2Hit::SetDRThreshold(Double_t DRthresholdEne)
+{
+  fDRThreshold = DRthresholdEne;
+  LOG(INFO) << "R3BCalifaCrystalCal2Hit::SetDRThreshold to "
+	    << fDRThreshold << " keV." << FairLogger::endl;
+}
 
 
 // ---- Public method GetAngles   --------------------------------------------------
@@ -389,7 +431,7 @@ void R3BCalifaCrystalCal2Hit::GetAngles(Int_t iD, Double_t* polar, Double_t* azi
 
 
 // ---- Public method GetAngles   --------------------------------------------------
-void R3BCalifaCrystalCal2Hit::GetAngles(Int_t iD, Double_t* polar, 
+void R3BCalifaCrystalCal2Hit::GetAngles(Int_t iD, Double_t* polar,
 				 Double_t* azimuthal, Double_t* rho)
 {
 
@@ -400,1401 +442,13 @@ void R3BCalifaCrystalCal2Hit::GetAngles(Int_t iD, Double_t* polar,
   Int_t alveolusCopy =0;
   Int_t crystalInAlveolus=0;
 
-  //  TGeoVolume *pAWorld  =  gGeoManager->GetTopVolume();
-  if (fGeometryVersion==0) {
-    //The present scheme here done works nicely with 5.0
-    // crystalType = crystal type (from 1 to 30)
-    // crystalCopy = crystal copy (from 1 to 512 for crystal types from 1 to 6 
-    //          (BARREL), from 1 to 64 for crystal types from 7 to 30 (ENDCAP))
-    // crystalId = (crystal type-1) *512 + crystal copy  (from 1 to 3072) 
-    //          for the BARREL
-    // crystalId = 3072 + (crystal type-7) *64 + crystal copy  (from 3073 to 
-    //          4608) for the ENDCAP
- 
-    if (iD<3073)
-      crystalType = (Int_t)((iD-1)/512) + 1;  //crystal type (from 1 to 30)
-    else
-      crystalType = (Int_t)((iD-3073)/64) + 7; //crystal type (from 1 to 30)
-
-    if (iD<3073)
-      crystalCopy = ((iD-1)%512) + 1;     //CrystalCopy (from 1 to 512)
-    else
-      crystalCopy = ((iD-3073)%64) + 1;     //CrystalCopy (from 1 to 160)
-
-
-    Char_t nameVolume[200];
-    //in the crystalLog creation description in califa/R3BCalifa.cxx for v5.0, 
-    //the crystalCopy begins in 0!!!
-    sprintf(nameVolume, "/cave_1/CalifaWorld_0/crystalLog%i_%i",
-	    crystalType,crystalCopy-1);
-
-    gGeoManager->cd(nameVolume);
-    TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-    currentNode->LocalToMaster(local, master);
-
-    sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-
-  } else if (fGeometryVersion==1) {
-    //The present scheme here done works nicely with 7.05
-    // crystalType = alveolus type (from 1 to 24)   [Basically the alveolus number]
-    // crystalCopy = (alveolus copy - 1) * 4 + crystals copy (from 1 to 160)  
-    //           [Not exactly azimuthal]
-    // crystalId = (alveolus type-1)*160 + (alvelous copy-1)*4 + (crystal copy)  
-    //           (from 1 to 3840) crystalID is asingle identifier per crystal!
-    //That is:
-    // crystalId = (crystalType-1)*160 + cpAlv * 4 + cpCry;
-    //
-    crystalType = (Int_t)((iD-1)/160) + 1;  //Alv type (from 1 to 24)
-    crystalCopy = ((iD-1)%160) + 1;     //CrystalCopy (from 1 to 160)
-    alveolusCopy =(Int_t)(((iD-1)%160)/4) +1; //Alveolus copy (from 1 to 40)
-    crystalInAlveolus = (iD-1)%4 + 1;   //Crystal number in alveolus (from 1 to 4)
-
-    Int_t alveoliType[24]={1,1,2,2,2,2,2,3,3,3,3,4,4,4,4,4,4,4,4,5,5,6,6,6};
-    Char_t nameVolume[200];
-    if (crystalInAlveolus<3)
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i/Crystal_%iA_1",
-              crystalType, alveolusCopy-1, alveoliType[crystalType-1], 
-	      crystalInAlveolus, alveoliType[crystalType-1]);
-    else
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iB_%i/Crystal_%iB_1",
-              crystalType, alveolusCopy-1, alveoliType[crystalType-1], 
-	      crystalInAlveolus, alveoliType[crystalType-1]);
-
-    gGeoManager->cd(nameVolume);
-    TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-    currentNode->LocalToMaster(local, master);
-    if (crystalInAlveolus<3)
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i",
-              crystalType, alveolusCopy-1, 
-	      alveoliType[crystalType-1], crystalInAlveolus);
-    else
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iB_%i",
-              crystalType, alveolusCopy-1, 
-	      alveoliType[crystalType-1], crystalInAlveolus);
-
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-
-    sprintf(nameVolume, "/cave_1/CalifaWorld_0/Alveolus_%i_%i",
-	    crystalType, alveolusCopy-1);
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-
-    sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-  } else if (fGeometryVersion==2) {
-    //The present scheme here done works nicely with 7.07
-    // crystalType = alveolus type (from 1 to 20)   [Alveolus number]
-    // crystalCopy = (alveolus copy - 1) * 4 + crystals copy (from 1 to 128)  
-    //            [Not exactly azimuthal]
-    // crystalId = (alveolus type-1)*128 + (alvelous copy-1)*4 + (crystal copy)  
-    //            (from 1 to 2560)
-    //That is:
-    // crystalId = (crystalType-1)*128 + cpAlv * 4 + cpCry;
-    //
-    crystalType = (Int_t)((iD-1)/128) + 1;  //Alv type (from 1 to 20)
-    crystalCopy = ((iD-1)%128) + 1; //CrystalCopy (from 1 to 128)
-    alveolusCopy =(Int_t)(((iD-1)%128)/4) +1; //Alveolus copy (from 1 to 32)
-    crystalInAlveolus = (iD-1)%4 + 1; //Crystal number in alveolus (from 1 to 4)
-
-    Int_t alveoliType[20]={1,1,2,2,2,3,3,4,4,4,5,5,6,6,6,7,7,7,8,8};
-
-    Char_t nameVolume[200];
-    if (crystalInAlveolus<3)
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i/Crystal_%iA_1",
-              crystalType, alveolusCopy-1, alveoliType[crystalType-1], 
-	      crystalInAlveolus, alveoliType[crystalType-1]);
-    else
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iB_%i/Crystal_%iB_1",
-              crystalType, alveolusCopy-1, alveoliType[crystalType-1], 
-	      crystalInAlveolus, alveoliType[crystalType-1]);
-
-    gGeoManager->cd(nameVolume);
-    TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-    currentNode->LocalToMaster(local, master);
-    if (crystalInAlveolus<3)
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i",
-              crystalType, alveolusCopy-1, 
-	      alveoliType[crystalType-1], crystalInAlveolus);
-    else
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iB_%i",
-              crystalType, alveolusCopy-1, 
-	      alveoliType[crystalType-1], crystalInAlveolus);
-
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-
-    sprintf(nameVolume, "/cave_1/CalifaWorld_0/Alveolus_%i_%i",
-	    crystalType, alveolusCopy-1);
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-
-    sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-  } else if (fGeometryVersion==3) {
-    //The present scheme here done works with 7.09
-    
-    Char_t nameVolume[200];
-    if (iD<2049) {
-      Int_t alveoliType[19]={1,1,2,2,3,3,3,3,3,3,4,4,4,5,5,5,6,6,6};
-
-      crystalType = (Int_t)((iD-1)/128) + 1;  //Alv type (from 1 to 19)
-      crystalCopy = ((iD-1)%128) + 1;     //CrystalCopy (from 1 to 128)
-      alveolusCopy =(Int_t)(((iD-1)%128)/4) +1; //Alveolus copy (from 1 to 32)
-      crystalInAlveolus = (iD-1)%4 + 1; //Crystal number in alveolus (from 1 to 4)
-
-      if (crystalInAlveolus<3)
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i/Crystal_%iA_1",
-                crystalType, alveolusCopy-1, alveoliType[crystalType-1], 
-		crystalInAlveolus, alveoliType[crystalType-1]);
-      else
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iB_%i/Crystal_%iB_1",
-                crystalType, alveolusCopy-1, alveoliType[crystalType-1], 
-		crystalInAlveolus, alveoliType[crystalType-1]);
-
-      gGeoManager->cd(nameVolume);
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-      if (crystalInAlveolus<3)
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i",
-                crystalType, alveolusCopy-1, 
-		alveoliType[crystalType-1], crystalInAlveolus);
-      else
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iB_%i",
-                crystalType, alveolusCopy-1, 
-		alveoliType[crystalType-1], crystalInAlveolus);
-
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0/Alveolus_%i_%i",
-	      crystalType, alveolusCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-
-    }
-    // for the last three (type 6) alveoli, which hold a single large crystal.
-    else if (iD>2048 && iD<2145) {
-      Int_t alveoliType[19]={1,1,2,2,3,3,3,3,3,3,4,4,4,5,5,5,6,6,6};
-      crystalType = (Int_t)((iD-2049)/32) + 17; //Alv type (from 17 to 19)
-      crystalCopy = ((iD-2049)%32) + 1;     //CrystalCopy (from 1 to 32)
-      alveolusCopy =(Int_t)((iD-1)%32) + 1; //Alveolus copy (from 1 to 32)
-      crystalInAlveolus = 1;         //Crystal number in alveolus (just one)
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i/Crystal_%iA_1",
-              crystalType, alveolusCopy-1, alveoliType[crystalType-1], 
-	      crystalInAlveolus, alveoliType[crystalType-1]);
-
-      gGeoManager->cd(nameVolume);
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i",
-              crystalType, alveolusCopy-1, 
-	      alveoliType[crystalType-1], crystalInAlveolus);
-
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0/Alveolus_%i_%i",
-	      crystalType, alveolusCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-
-    }
-  } else if (fGeometryVersion==4) {
-    //The present scheme here done works nicely with 7.17
-    // crystalType = crystals type (from 1 to 23)
-    // crystalCopy = alveolus copy (from 1 to 32)
-    // crystalId = 3000 + (alvelous copy-1)*23 + (crystal copy-1)  
-    // (from 3000 to 3736)
-
-    crystalType = ((iD-3000)%23) + 1;
-    crystalCopy = (iD-3000)/23 + 1;
-    
-    //here the alveoliType array meaning is opposite to the other BARREL cases
-    //the array shows the alveoli number where each crystal of the EndCap belong
-    Int_t alveoliType[23]={1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,3,3,3,3,3,3,3};
-    
-    Char_t nameVolume[200];
-    sprintf(nameVolume, 
-	    "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1/Crystal_%i_1",
-	    alveoliType[crystalType-1], crystalCopy-1, crystalType, crystalType);
-    
-    // The definition of the crystals is different in this particular EndCap design
-    // the origin for each crystal is the alveoli corner
-    if (crystalType==1) {
-      local[0]=-1.24654194026499; local[1]=0.648218850702041; local[2]=9.75;
-    } else if (crystalType==2) {
-      local[0]=-4.57345805973491; local[1]=0.64821885070204; local[2]=9.75;
-    } else if (crystalType==3) {
-      local[0]=-1.33137201955507; local[1]=2.59875; local[2]=9.75;
-    } else if (crystalType==4) {
-      local[0]=-4.48862798044483; local[1]=2.59875; local[2]=9.75;
-    } else if (crystalType==5) {
-      local[0]=-1.40646166097653; local[1]=4.33125; local[2]=9.75;
-    } else if (crystalType==6) {
-      local[0]=-4.41353833902337; local[1]=4.33125; local[2]=9.75;
-    } else if (crystalType==7) {
-      local[0]=-1.49184443219704; local[1]=6.29334272612279; local[2]=9.75;
-    } else if (crystalType==8) {
-      local[0]=-4.32815556780286; local[1]=6.29334272612279; local[2]=9.75;
-    } else if (crystalType==9) {
-      local[0]=-1.01201040487607; local[1]=0.739366638062432; local[2]=9.75;
-    } else if (crystalType==10) {
-      local[0]=-3.64595915673333; local[1]=0.739366638062431; local[2]=9.75;
-    } else if (crystalType==11) {
-      local[0]=-1.10703474322362; local[1]=2.8015; local[2]=9.75;
-    } else if (crystalType==12) {
-      local[0]=-3.55093481838578; local[1]=2.8015; local[2]=9.75;
-    } else if (crystalType==13) {
-      local[0]=-1.19303835409747; local[1]=4.669; local[2]=9.75;
-    } else if (crystalType==14) {
-      local[0]=-3.46496164590243; local[1]=4.669; local[2]=9.75;
-    } else if (crystalType==15) {
-      local[0]=-1.28957028029965; local[1]=6.76354164083689; local[2]=9.75;
-    } else if (crystalType==16) {
-      local[0]=-3.36842971970024; local[1]=6.76354164083688; local[2]=9.75;
-    } else if (crystalType==17) {
-      local[0]=-0.70032959626342; local[1]=0.836296001993993; local[2]=9.75;
-    } else if (crystalType==18) {
-      local[0]=-2.53967040373648; local[1]=0.836296001993992; local[2]=9.75;
-    } else if (crystalType==19) {
-      local[0]=-0.797829723064974; local[1]=2.95125; local[2]=9.75;
-    } else if (crystalType==20) {
-      local[0]=-2.44217027693492; local[1]=2.95125; local[2]=9.75;
-    } else if (crystalType==21) {
-      local[0]=-0.888582051402232; local[1]=4.91875; local[2]=9.75;
-    } else if (crystalType==22) {
-      local[0]=-2.35141794859767; local[1]=4.91875; local[2]=9.75;
-    } else if (crystalType==23) {
-      local[0]=-1.61999999999997; local[1]=7.22933631874703; local[2]=9.75;
-    }
-    
-    gGeoManager->cd(nameVolume);
-    TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-    currentNode->LocalToMaster(local, master);
-    
-    sprintf(nameVolume, 
-	    "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1",
-	    alveoliType[crystalType-1], crystalCopy-1, crystalType);
-    
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-    
-    sprintf(nameVolume, 
-	    "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i",
-	    alveoliType[crystalType-1], crystalCopy-1);
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-    
-    sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-     
-  } else if (fGeometryVersion==5) {
-    //The present scheme here done works nicely with 7.07+7.17
-    //see the explanation for geometries 2 and 4
-    Char_t nameVolume[200];
-    if (iD<3000) {
-      crystalType = (Int_t)((iD-1)/128) + 1;  //Alv type (from 1 to 20)
-      crystalCopy = ((iD-1)%128) + 1;     //CrystalCopy (from 1 to 128)
-      alveolusCopy =(Int_t)(((iD-1)%128)/4) +1; //Alveolus copy (from 1 to 32)
-      crystalInAlveolus = (iD-1)%4 + 1;//Crystal number in alveolus (from 1 to 4)
-
-      Int_t alveoliType[20]={1,1,2,2,2,3,3,4,4,4,5,5,6,6,6,7,7,7,8,8};
-
-      if (crystalInAlveolus<3)
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i/Crystal_%iA_1",
-                crystalType, alveolusCopy-1, alveoliType[crystalType-1], 
-		crystalInAlveolus, alveoliType[crystalType-1]);
-      else
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iB_%i/Crystal_%iB_1",
-                crystalType, alveolusCopy-1, alveoliType[crystalType-1], 
-		crystalInAlveolus, alveoliType[crystalType-1]);
-
-      gGeoManager->cd(nameVolume);
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-      if (crystalInAlveolus<3)
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i",
-                crystalType, alveolusCopy-1, 
-		alveoliType[crystalType-1], crystalInAlveolus);
-      else
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iB_%i",
-                crystalType, alveolusCopy-1, 
-		alveoliType[crystalType-1], crystalInAlveolus);
-
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i",
-	      crystalType, alveolusCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-    } else {
-      crystalType = ((iD-3000)%23) + 1;
-      crystalCopy = (iD-3000)/23 + 1;
-      
-      //here the alveoliType array meaning is opposite to the other BARREL cases
-      //the array shows the alveoli number where each crystal of the EndCap belong
-      Int_t alveoliType[23]={1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,3,3,3,3,3,3,3};
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1/Crystal_%i_1",
-	      alveoliType[crystalType-1], crystalCopy-1, crystalType, crystalType);
-      
-      // The definition of the crystals is different in this particular EndCap design
-      // the origin for each crystal is the alveoli corner
-      if (crystalType==1) {
-	local[0]=-1.24654194026499; local[1]=0.648218850702041; local[2]=9.75;
-      } else if (crystalType==2) {
-	local[0]=-4.57345805973491; local[1]=0.64821885070204; local[2]=9.75;
-      } else if (crystalType==3) {
-	local[0]=-1.33137201955507; local[1]=2.59875; local[2]=9.75;
-      } else if (crystalType==4) {
-	local[0]=-4.48862798044483; local[1]=2.59875; local[2]=9.75;
-      } else if (crystalType==5) {
-	local[0]=-1.40646166097653; local[1]=4.33125; local[2]=9.75;
-      } else if (crystalType==6) {
-	local[0]=-4.41353833902337; local[1]=4.33125; local[2]=9.75;
-      } else if (crystalType==7) {
-	local[0]=-1.49184443219704; local[1]=6.29334272612279; local[2]=9.75;
-      } else if (crystalType==8) {
-	local[0]=-4.32815556780286; local[1]=6.29334272612279; local[2]=9.75;
-      } else if (crystalType==9) {
-	local[0]=-1.01201040487607; local[1]=0.739366638062432; local[2]=9.75;
-      } else if (crystalType==10) {
-	local[0]=-3.64595915673333; local[1]=0.739366638062431; local[2]=9.75;
-      } else if (crystalType==11) {
-	local[0]=-1.10703474322362; local[1]=2.8015; local[2]=9.75;
-      } else if (crystalType==12) {
-	local[0]=-3.55093481838578; local[1]=2.8015; local[2]=9.75;
-      } else if (crystalType==13) {
-	local[0]=-1.19303835409747; local[1]=4.669; local[2]=9.75;
-      } else if (crystalType==14) {
-	local[0]=-3.46496164590243; local[1]=4.669; local[2]=9.75;
-      } else if (crystalType==15) {
-	local[0]=-1.28957028029965; local[1]=6.76354164083689; local[2]=9.75;
-      } else if (crystalType==16) {
-	local[0]=-3.36842971970024; local[1]=6.76354164083688; local[2]=9.75;
-      } else if (crystalType==17) {
-	local[0]=-0.70032959626342; local[1]=0.836296001993993; local[2]=9.75;
-      } else if (crystalType==18) {
-	local[0]=-2.53967040373648; local[1]=0.836296001993992; local[2]=9.75;
-      } else if (crystalType==19) {
-	local[0]=-0.797829723064974; local[1]=2.95125; local[2]=9.75;
-      } else if (crystalType==20) {
-	local[0]=-2.44217027693492; local[1]=2.95125; local[2]=9.75;
-      } else if (crystalType==21) {
-	local[0]=-0.888582051402232; local[1]=4.91875; local[2]=9.75;
-      } else if (crystalType==22) {
-	local[0]=-2.35141794859767; local[1]=4.91875; local[2]=9.75;
-      } else if (crystalType==23) {
-	local[0]=-1.61999999999997; local[1]=7.22933631874703; local[2]=9.75;
-      }
-      
-      gGeoManager->cd(nameVolume);
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1",
-	      alveoliType[crystalType-1], crystalCopy-1, crystalType);
-      
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i",
-	      alveoliType[crystalType-1], crystalCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-    } 
-  } else if (fGeometryVersion==6) {
-    //The present scheme here done works with 7.09+7.17
-    //see the explanation for geometries 3 and 4
-    
-    Char_t nameVolume[200];
-    if (iD<2049) {
-      Int_t alveoliType[19]={1,1,2,2,3,3,3,3,3,3,4,4,4,5,5,5,6,6,6};
-      crystalType = (Int_t)((iD-1)/128) + 1;  //Alv type (from 1 to 20)
-      crystalCopy = ((iD-1)%128) + 1;     //CrystalCopy (from 1 to 128)
-      alveolusCopy =(Int_t)(((iD-1)%128)/4) +1; //Alveolus copy (from 1 to 32)
-      crystalInAlveolus = (iD-1)%4 + 1;//Crystal number in alveolus (from 1 to 4)
-
-      if (crystalInAlveolus<3)
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i/Crystal_%iA_1",
-                crystalType, alveolusCopy-1, alveoliType[crystalType-1], 
-		crystalInAlveolus, alveoliType[crystalType-1]);
-      else
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iB_%i/Crystal_%iB_1",
-                crystalType, alveolusCopy-1, alveoliType[crystalType-1], 
-		crystalInAlveolus, alveoliType[crystalType-1]);
-
-      gGeoManager->cd(nameVolume);
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-      if (crystalInAlveolus<3)
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i",
-                crystalType, alveolusCopy-1, 
-		alveoliType[crystalType-1], crystalInAlveolus);
-      else
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iB_%i",
-                crystalType, alveolusCopy-1, 
-		alveoliType[crystalType-1], crystalInAlveolus);
-
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i",
-	      crystalType, alveolusCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-    }
-    // For alveoli type 6, which has only 1 crystal in each of the 
-    // last three alveoli that are type 6.
-    else if (iD>2048&&iD<3000) {
-      Int_t alveoliType[19]={1,1,2,2,3,3,3,3,3,3,4,4,4,5,5,5,6,6,6};
-      crystalType = (Int_t)((iD-2049)/32) + 17; //Alv type (from 1 to 20)
-      crystalCopy = ((iD-2049)%32) + 1;     //CrystalCopy (from 1 to 32)
-      alveolusCopy =(Int_t)((iD-1)%32) + 1; //Alveolus copy (from 1 to 32)
-      crystalInAlveolus = 1;    //Crystal number in alveolus (from 1 to 4)
-
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i/Crystal_%iA_1",
-              crystalType, alveolusCopy-1, alveoliType[crystalType-1], 
-	      crystalInAlveolus, alveoliType[crystalType-1]);
-
-      gGeoManager->cd(nameVolume);
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i",
-              crystalType, alveolusCopy-1, 
-	      alveoliType[crystalType-1], crystalInAlveolus);
-
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i",
-	      crystalType, alveolusCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-    } else {
-      crystalType = ((iD-3000)%23) + 1;
-      crystalCopy = (iD-3000)/23 + 1;
-      
-      //here the alveoliType array meaning is opposite to the other BARREL cases
-      //the array shows the alveoli number where each crystal of the EndCap belong
-      Int_t alveoliType[23]={1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2,3,3,3,3,3,3,3};
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1/Crystal_%i_1",
-	      alveoliType[crystalType-1], crystalCopy-1, crystalType, crystalType);
-      
-      // The definition of the crystals is different in this particular EndCap design
-      // the origin for each crystal is the alveoli corner
-      if (crystalType==1) {
-	local[0]=-1.24654194026499; local[1]=0.648218850702041; local[2]=9.75;
-      } else if (crystalType==2) {
-	local[0]=-4.57345805973491; local[1]=0.64821885070204; local[2]=9.75;
-      } else if (crystalType==3) {
-	local[0]=-1.33137201955507; local[1]=2.59875; local[2]=9.75;
-      } else if (crystalType==4) {
-	local[0]=-4.48862798044483; local[1]=2.59875; local[2]=9.75;
-      } else if (crystalType==5) {
-	local[0]=-1.40646166097653; local[1]=4.33125; local[2]=9.75;
-      } else if (crystalType==6) {
-	local[0]=-4.41353833902337; local[1]=4.33125; local[2]=9.75;
-      } else if (crystalType==7) {
-	local[0]=-1.49184443219704; local[1]=6.29334272612279; local[2]=9.75;
-      } else if (crystalType==8) {
-	local[0]=-4.32815556780286; local[1]=6.29334272612279; local[2]=9.75;
-      } else if (crystalType==9) {
-	local[0]=-1.01201040487607; local[1]=0.739366638062432; local[2]=9.75;
-      } else if (crystalType==10) {
-	local[0]=-3.64595915673333; local[1]=0.739366638062431; local[2]=9.75;
-      } else if (crystalType==11) {
-	local[0]=-1.10703474322362; local[1]=2.8015; local[2]=9.75;
-      } else if (crystalType==12) {
-	local[0]=-3.55093481838578; local[1]=2.8015; local[2]=9.75;
-      } else if (crystalType==13) {
-	local[0]=-1.19303835409747; local[1]=4.669; local[2]=9.75;
-      } else if (crystalType==14) {
-	local[0]=-3.46496164590243; local[1]=4.669; local[2]=9.75;
-      } else if (crystalType==15) {
-	local[0]=-1.28957028029965; local[1]=6.76354164083689; local[2]=9.75;
-      } else if (crystalType==16) {
-	local[0]=-3.36842971970024; local[1]=6.76354164083688; local[2]=9.75;
-      } else if (crystalType==17) {
-	local[0]=-0.70032959626342; local[1]=0.836296001993993; local[2]=9.75;
-      } else if (crystalType==18) {
-	local[0]=-2.53967040373648; local[1]=0.836296001993992; local[2]=9.75;
-      } else if (crystalType==19) {
-	local[0]=-0.797829723064974; local[1]=2.95125; local[2]=9.75;
-      } else if (crystalType==20) {
-	local[0]=-2.44217027693492; local[1]=2.95125; local[2]=9.75;
-      } else if (crystalType==21) {
-	local[0]=-0.888582051402232; local[1]=4.91875; local[2]=9.75;
-      } else if (crystalType==22) {
-	local[0]=-2.35141794859767; local[1]=4.91875; local[2]=9.75;
-      } else if (crystalType==23) {
-	local[0]=-1.61999999999997; local[1]=7.22933631874703; local[2]=9.75;
-      }
-      
-      gGeoManager->cd(nameVolume);
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1",
-	      alveoliType[crystalType-1], crystalCopy-1, crystalType);
-      
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i",
-	      alveoliType[crystalType-1], crystalCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-    } 
-  }  else if (fGeometryVersion==7) {
-    //RESERVED FOR CALIFA 717PHOSWICH, only phoswich ENDCAP 
-    Char_t nameVolume[200];
-    crystalType = ((iD-3000)%30) + 1;
-    crystalCopy = (iD-3000)/30 + 1;
-    Int_t alveoliType[30]={1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,
-			   10,10,11,11,12,12,13,13,14,14,15,15};
-    sprintf(nameVolume, 
-	    "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1/Crystal_%i_1",
-	    alveoliType[crystalType-1], crystalCopy-1, 
-	    crystalType, crystalType);	
-    gGeoManager->cd(nameVolume);
-    TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-    currentNode->LocalToMaster(local, master);
-    
-    sprintf(nameVolume, 
-	    "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1",
-	    alveoliType[crystalType-1], crystalCopy-1, crystalType);	
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-    
-    sprintf(nameVolume, 
-	    "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i",
-	    alveoliType[crystalType-1], crystalCopy-1);
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-    
-    sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-  } else if (fGeometryVersion==8) {
-    //RESERVED FOR CALIFA 7.07 BARREL + 717PHOSWICH 
-    
-    Char_t nameVolume[200];
-    if (iD<3000) {
-      crystalType = (Int_t)((iD-1)/128) + 1;  //Alv type (from 1 to 20)
-      crystalCopy = ((iD-1)%128) + 1;     //CrystalCopy (from 1 to 128)
-      alveolusCopy =(Int_t)(((iD-1)%128)/4) +1; //Alveolus copy (from 1 to 32)
-      crystalInAlveolus = (iD-1)%4 + 1;//Crystal number in alveolus (from 1 to 4)
-      
-      Int_t alveoliType[20]={1,1,2,2,2,3,3,4,4,4,5,5,6,6,6,7,7,7,8,8};
-      
-      if (crystalInAlveolus<3)
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i/Crystal_%iA_1",
-                crystalType, alveolusCopy-1, 
-		alveoliType[crystalType-1], crystalInAlveolus, 
-		alveoliType[crystalType-1]);
-      else
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iB_%i/Crystal_%iB_1",
-                crystalType, alveolusCopy-1, 
-		alveoliType[crystalType-1], crystalInAlveolus, 
-		alveoliType[crystalType-1]);
-      
-      gGeoManager->cd(nameVolume);
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-      if (crystalInAlveolus<3)
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i",
-                crystalType, alveolusCopy-1, 
-		alveoliType[crystalType-1], crystalInAlveolus);
-      else
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iB_%i",
-                crystalType, alveolusCopy-1, 
-		alveoliType[crystalType-1], crystalInAlveolus);
-      
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i",
-	      crystalType, alveolusCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-    } else {
-      crystalType = ((iD-3000)%30) + 1;
-      crystalCopy = (iD-3000)/30 + 1; 
-      Int_t alveoliType[30]={1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,
-			     10,10,11,11,12,12,13,13,14,14,15,15};
-    
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1/Crystal_%i_1",
-              alveoliType[crystalType-1], crystalCopy-1, 
-	      crystalType, crystalType);
-      
-      gGeoManager->cd(nameVolume);
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1",
-              alveoliType[crystalType-1], crystalCopy-1, crystalType);
-      
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i",
-	      alveoliType[crystalType-1], crystalCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-    }
-  } else if (fGeometryVersion==9) {
-    //RESERVED FOR CALIFA 7.09 BARREL + 717PHOSWICH
-    
-    Char_t nameVolume[200];
-    if (iD<2049) {
-      Int_t alveoliType[19]={1,1,2,2,3,3,3,3,3,3,4,4,4,5,5,5,6,6,6};
-      crystalType = (Int_t)((iD-1)/128) + 1;  //Alv type (from 1 to 20)
-      crystalCopy = ((iD-1)%128) + 1;     //CrystalCopy (from 1 to 128)
-      alveolusCopy =(Int_t)(((iD-1)%128)/4) +1; //Alveolus copy (from 1 to 32)
-      crystalInAlveolus = (iD-1)%4 + 1;//Crystal number in alveolus (from 1 to 4)
-      
-      if (crystalInAlveolus<3)
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i/Crystal_%iA_1",
-                crystalType, alveolusCopy-1, 
-		alveoliType[crystalType-1], crystalInAlveolus, 
-		alveoliType[crystalType-1]);
-      else
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iB_%i/Crystal_%iB_1",
-                crystalType, alveolusCopy-1, 
-		alveoliType[crystalType-1], crystalInAlveolus, 
-		alveoliType[crystalType-1]);
-      
-      gGeoManager->cd(nameVolume);
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-      if (crystalInAlveolus<3)
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i",
-                crystalType, alveolusCopy-1, 
-		alveoliType[crystalType-1], crystalInAlveolus);
-      else
-        sprintf(nameVolume, 
-		"/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iB_%i",
-                crystalType, alveolusCopy-1, 
-		alveoliType[crystalType-1], crystalInAlveolus);
-      
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i",
-	      crystalType, alveolusCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-    }
-    // For alveoli type 6, which has only 1 crystal in each of the 
-    // last three alveoli that are type 6.
-    else if (iD>2048&&iD<3000) {
-      Int_t alveoliType[19]={1,1,2,2,3,3,3,3,3,3,4,4,4,5,5,5,6,6,6};
-      crystalType = (Int_t)((iD-2049)/32) + 17; //Alv type (from 1 to 20)
-      crystalCopy = ((iD-2049)%32) + 1;     //CrystalCopy (from 1 to 32)
-      alveolusCopy =(Int_t)((iD-1)%32) + 1; //Alveolus copy (from 1 to 32)
-      crystalInAlveolus = 1;    //Crystal number in alveolus (from 1 to 4)
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i/Crystal_%iA_1",
-              crystalType, alveolusCopy-1, 
-	      alveoliType[crystalType-1], crystalInAlveolus, 
-	      alveoliType[crystalType-1]);
-      
-      gGeoManager->cd(nameVolume);
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/CrystalWithWrapping_%iA_%i",
-              crystalType, alveolusCopy-1, 
-	      alveoliType[crystalType-1], crystalInAlveolus);
-      
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i",
-	      crystalType, alveolusCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-    }
-    else {
-      crystalType = ((iD-3000)%30) + 1;
-      crystalCopy = (iD-3000)/30 + 1;
-      
-      Int_t alveoliType[30]={1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,
-			     10,10,11,11,12,12,13,13,14,14,15,15};
-
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1/Crystal_%i_1",
-              alveoliType[crystalType-1], crystalCopy-1, 
-	      crystalType, crystalType);
-      
-      gGeoManager->cd(nameVolume);
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1",
-              alveoliType[crystalType-1], crystalCopy-1, crystalType);
-      
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i",
-	      alveoliType[crystalType-1], crystalCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-    }
-  } else if (fGeometryVersion==10) {
-    //The present scheme here done works with 8.11
-    // crystalType = alveolus type (from 1 to 17) [Alveolus number]
-    // crystalCopy = alveolus copy * 4 + crystals copy +1 (from 1 to 128)
-    // crystalId = 1 to 32 for the first 32 crystals 
-    //                     (single crystal in each alveoli)
-    // or 32 + (alveolus type-2)*128 + (alvelous copy)*4 + (crystal copy) + 1
-    //                     (from 1 to 1952)
-    //
-    if(iD<33) crystalType = 1;  //Alv type 1
-    else crystalType = (Int_t)((iD-33)/128) + 2;  //Alv type (2 to 16)
-    if(iD<33) crystalCopy = iD;     //for Alv type 1 
-    else crystalCopy = ((iD-33)%128) + 1;         //CrystalCopy (1 to 128)
-    if(iD<33) alveolusCopy = iD;    //Alv type 1 
-    else alveolusCopy =(Int_t)(((iD-33)%128)/4) +1; //Alveolus copy (1 to 32)
-    if(iD<33) crystalInAlveolus =1;          //Alv type 1
-    else crystalInAlveolus = (iD-33)%4 + 1;//Crystal number in alveolus (1 to 4)
-    
-    Int_t alveoliType[16]={1,2,2,2,2,3,3,4,4,4,5,5,5,6,6,6};
-    
-    Char_t nameVolume[200];
-    sprintf(nameVolume, 
-	    "/cave_1/CalifaWorld_0/Alveolus_%i_%i/AlveolusInner_%i_1/CrystalWithWrapping_%i_%i_%i/Crystal_%i_%i_1",
-	    crystalType, alveolusCopy-1, 
-	    crystalType, alveoliType[crystalType-1], 
-	    crystalInAlveolus, crystalInAlveolus-1, 
-	    alveoliType[crystalType-1], crystalInAlveolus);
-    
-    // The definition of the crystals is different in this particular EndCap design:
-    // the origin for each crystal is the alveoli corner
-    if (crystalType==1) {
-      local[0]=27.108/8; local[1]=-28.0483/8; local[2]=0;
-    } else if (crystalType==2 || crystalType==3 || 
-	       crystalType==4 || crystalType==5) {
-      if(crystalInAlveolus==1){
-	local[0]=37.4639/8; local[1]=-8.57573/8; local[2]=0;
-      } else if(crystalInAlveolus==2) {
-	local[0]=37.4639/8; local[1]=-31.1043/8; local[2]=0;
-      } else if(crystalInAlveolus==3) {
-	local[0]=9.52012/8; local[1]=-8.57573/8; local[2]=0;
-      } else if(crystalInAlveolus==4){
-	local[0]=9.52012/8; local[1]=-31.1043/8; local[2]=0;
-      }
-    } else if (crystalType==6 || crystalType==7) {
-      if(crystalInAlveolus==1){
-	local[0]=38.3282/8; local[1]=-5.49819/8; local[2]=0;
-      } else if(crystalInAlveolus==2) {
-	local[0]=38.3282/8; local[1]=-23.0538/8; local[2]=0;
-      } else if(crystalInAlveolus==3) {
-	local[0]=8.66384/8; local[1]=-5.49819/8; local[2]=0;
-      } else if(crystalInAlveolus==4){
-	local[0]=8.66384/8; local[1]=-23.0538/8; local[2]=0;
-      }
-    } else if (crystalType==8 || crystalType==9 || crystalType==10) {
-      if(crystalInAlveolus==1){
-	local[0]=38.3683/8; local[1]=-4.71618/8; local[2]=0;
-      } else if(crystalInAlveolus==2) {
-	local[0]=38.3683/8; local[1]=-19.8438/8; local[2]=0;
-      } else if(crystalInAlveolus==3) {
-	local[0]=8.43569/8; local[1]=-4.71618/8; local[2]=0;
-      } else if(crystalInAlveolus==4){
-	local[0]=8.43569/8; local[1]=-19.8438/8; local[2]=0;
-      }
-    } else if (crystalType==11 || crystalType==12 || crystalType==13) {
-      if(crystalInAlveolus==1){
-	local[0]=38.3495/8; local[1]=-4.70373/8; local[2]=0;
-      } else if(crystalInAlveolus==2) {
-	local[0]=38.3495/8; local[1]=-19.8403/8; local[2]=0;
-      } else if(crystalInAlveolus==3) {
-	local[0]=8.66654/8; local[1]=-4.70373/8; local[2]=0;
-      } else if(crystalInAlveolus==4){
-	local[0]=8.66654/8; local[1]=-19.8403/8; local[2]=0;
-      }
-    } else if (crystalType==14 || crystalType==15 || crystalType==16) {
-      if(crystalInAlveolus==1){
-	local[0]=37.9075/8; local[1]=-4.66458/8; local[2]=0;
-      } else if(crystalInAlveolus==2) {
-	local[0]=37.9075/8; local[1]=-19.8474/8; local[2]=0;
-      } else if(crystalInAlveolus==3) {
-	local[0]=9.07247/8; local[1]=-19.8474/8; local[2]=0;
-      } else if(crystalInAlveolus==4){
-	local[0]=9.07247/8; local[1]=-4.66458/8; local[2]=0;
-      }
-    }		
-
-    gGeoManager->CdTop();
-
-    if(gGeoManager->CheckPath(nameVolume)) gGeoManager->cd(nameVolume);
-    else { 
-      LOG(ERROR) << "R3BCalifaCrystalCal2Hit: Invalid crystal path: " << nameVolume
-		 << FairLogger::endl;
-      return; 
-    }
-    TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-    currentNode->LocalToMaster(local, master);
-    
-    sprintf(nameVolume, 
-	    "/cave_1/CalifaWorld_0/Alveolus_%i_%i/AlveolusInner_%i_1/CrystalWithWrapping_%i_%i_%i",
-	    crystalType, alveolusCopy-1, 
-	    crystalType, alveoliType[crystalType-1], 
-	    crystalInAlveolus, crystalInAlveolus-1);
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-    
-    sprintf(nameVolume, 
-	    "/cave_1/CalifaWorld_0/Alveolus_%i_%i/AlveolusInner_%i_1",
-	    crystalType, alveolusCopy-1, crystalType);
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-    
-    sprintf(nameVolume, 
-	    "/cave_1/CalifaWorld_0/Alveolus_%i_%i",
-	    crystalType, alveolusCopy-1);
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-    
-    sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-    gGeoManager->cd(nameVolume);
-    currentNode = gGeoManager->GetCurrentNode();
-    local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-    currentNode->LocalToMaster(local, master);
-    
-  } else if (fGeometryVersion==11) {
-    Char_t nameVolume[200];
-    if (iD<3000) { 
-      if(iD<33) crystalType = 1;  //Alv type 1
-      else crystalType = (Int_t)((iD-33)/128) + 2;  //Alv type (2 to 16)
-      if(iD<33) crystalCopy = iD;     //for Alv type 1 
-      else crystalCopy = ((iD-33)%128) + 1;         //CrystalCopy (1 to 128)
-      if(iD<33) alveolusCopy = iD;    //Alv type 1 
-      else alveolusCopy =(Int_t)(((iD-33)%128)/4) +1; //Alveolus copy (1 to 32)
-      if(iD<33) crystalInAlveolus =1;          //Alv type 1
-      else crystalInAlveolus = (iD-33)%4 + 1;//Crystal number in alveolus (1 to 4)
-      
-      Int_t alveoliType[16]={1,2,2,2,2,3,3,4,4,4,5,5,5,6,6,6};
-    
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/AlveolusInner_%i_1/CrystalWithWrapping_%i_%i_%i/Crystal_%i_%i_1",
-	      crystalType, alveolusCopy-1, crystalType, 
-	      alveoliType[crystalType-1], crystalInAlveolus, crystalInAlveolus-1, 
-	      alveoliType[crystalType-1], crystalInAlveolus);
-      
-      // The definition of the crystals is different in this particular EndCap design:
-      // the origin for each crystal is the alveoli corner
-      if (crystalType==1) {
-	local[0]=27.108/8; local[1]=-28.0483/8; local[2]=0;
-      } else if (crystalType==2 || crystalType==3 || 
-		 crystalType==4 || crystalType==5) {
-	if(crystalInAlveolus==1){
-	  local[0]=37.4639/8; local[1]=-8.57573/8; local[2]=0;
-	} else if(crystalInAlveolus==2) {
-	  local[0]=37.4639/8; local[1]=-31.1043/8; local[2]=0;
-	} else if(crystalInAlveolus==3) {
-	  local[0]=9.52012/8; local[1]=-8.57573/8; local[2]=0;
-	} else if(crystalInAlveolus==4){
-	  local[0]=9.52012/8; local[1]=-31.1043/8; local[2]=0;
-	}
-      } else if (crystalType==6 || crystalType==7) {
-	if(crystalInAlveolus==1){
-	  local[0]=38.3282/8; local[1]=-5.49819/8; local[2]=0;
-	} else if(crystalInAlveolus==2) {
-	  local[0]=38.3282/8; local[1]=-23.0538/8; local[2]=0;
-	} else if(crystalInAlveolus==3) {
-	  local[0]=8.66384/8; local[1]=-5.49819/8; local[2]=0;
-	} else if(crystalInAlveolus==4){
-	  local[0]=8.66384/8; local[1]=-23.0538/8; local[2]=0;
-	}
-      } else if (crystalType==8 || crystalType==9 || crystalType==10) {
-	if(crystalInAlveolus==1){
-	  local[0]=38.3683/8; local[1]=-4.71618/8; local[2]=0;
-	} else if(crystalInAlveolus==2) {
-	  local[0]=38.3683/8; local[1]=-19.8438/8; local[2]=0;
-	} else if(crystalInAlveolus==3) {
-	  local[0]=8.43569/8; local[1]=-4.71618/8; local[2]=0;
-	} else if(crystalInAlveolus==4){
-	  local[0]=8.43569/8; local[1]=-19.8438/8; local[2]=0;
-	}
-      } else if (crystalType==11 || crystalType==12 || crystalType==13) {
-	if(crystalInAlveolus==1){
-	  local[0]=38.3495/8; local[1]=-4.70373/8; local[2]=0;
-	} else if(crystalInAlveolus==2) {
-	  local[0]=38.3495/8; local[1]=-19.8403/8; local[2]=0;
-	} else if(crystalInAlveolus==3) {
-	  local[0]=8.66654/8; local[1]=-4.70373/8; local[2]=0;
-	} else if(crystalInAlveolus==4){
-	  local[0]=8.66654/8; local[1]=-19.8403/8; local[2]=0;
-	}
-      } else if (crystalType==14 || crystalType==15 || crystalType==16) {
-	if(crystalInAlveolus==1){
-	  local[0]=37.9075/8; local[1]=-4.66458/8; local[2]=0;
-	} else if(crystalInAlveolus==2) {
-	  local[0]=37.9075/8; local[1]=-19.8474/8; local[2]=0;
-	} else if(crystalInAlveolus==3) {
-	  local[0]=9.07247/8; local[1]=-19.8474/8; local[2]=0;
-	} else if(crystalInAlveolus==4){
-	  local[0]=9.07247/8; local[1]=-4.66458/8; local[2]=0;
-	}
-      }		
-      
-      gGeoManager->cd(nameVolume);
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/AlveolusInner_%i_1/CrystalWithWrapping_%i_%i_%i",
-	      crystalType, alveolusCopy-1, 
-	      crystalType, alveoliType[crystalType-1], 
-	      crystalInAlveolus, crystalInAlveolus-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/AlveolusInner_%i_1",
-	      crystalType, alveolusCopy-1, crystalType);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i",
-	      crystalType, alveolusCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);  
-    }
-    else{//For IEM LaBr - LaCl phoswich endcap 
-      crystalType = ((iD-3000)%30) + 1;
-      crystalCopy = (iD-3000)/30 + 1;
-      Int_t alveoliType[30]={1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,
-			     10,10,11,11,12,12,13,13,14,14,15,15};
-
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1/Crystal_%i_1",
-              alveoliType[crystalType-1], crystalCopy-1, 
-	      crystalType, crystalType);
-      
-      gGeoManager->cd(nameVolume);
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1",
-              alveoliType[crystalType-1], crystalCopy-1, crystalType);
-      
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i",
-	      alveoliType[crystalType-1], crystalCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-      
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-    } 
-    
-  } else if (fGeometryVersion==15) {
-    //The present scheme here done works with 8.11
-    // crystalType = alveolus type (from 1 to 17) [Alveolus number]
-    // crystalCopy = alveolus copy * 4 + crystals copy +1 (from 1 to 128)
-    // crystalId = 1 to 32 for the first 32 crystals 
-    //                     (single crystal in each alveoli)
-    // or 32 + (alveolus type-2)*128 + (alvelous copy)*4 + (crystal copy) + 1
-    //                     (from 1 to 1952)
-    //
-    Char_t nameVolume[200];
-    if (iD<3000) {
-      if(iD<33) crystalType = 1;  //Alv type 1
-      else crystalType = (Int_t)((iD-33)/128) + 2;  //Alv type (2 to 16)
-      if(iD<33) crystalCopy = iD;     //for Alv type 1 
-      else crystalCopy = ((iD-33)%128) + 1;         //CrystalCopy (1 to 128)
-      if(iD<33) alveolusCopy = iD;    //Alv type 1 
-      else alveolusCopy =(Int_t)(((iD-33)%128)/4) +1; //Alveolus copy (1 to 32)
-      if(iD<33) crystalInAlveolus =1;          //Alv type 1
-      else crystalInAlveolus = (iD-33)%4 + 1;//Crystal number in alveolus (1 to 4)
-    
-      Int_t alveoliType[16]={1,2,2,2,2,3,3,4,4,4,5,5,5,6,6,6};
-    
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/AlveolusInner_%i_1/CrystalWithWrapping_%i_%i_%i/Crystal_%i_%i_1",
-	      crystalType, alveolusCopy-1, 
-	      crystalType, alveoliType[crystalType-1], 
-	      crystalInAlveolus, crystalInAlveolus-1, 
-	      alveoliType[crystalType-1], crystalInAlveolus);
-    
-      // The definition of the crystals is different in this particular EndCap design:
-      // the origin for each crystal is the alveoli corner
-      if (crystalType==1) {
-	local[0]=27.108/8; local[1]=-28.0483/8; local[2]=0;
-      } else if (crystalType==2 || crystalType==3 || 
-		 crystalType==4 || crystalType==5) {
-	if(crystalInAlveolus==1){
-	  local[0]=37.4639/8; local[1]=-8.57573/8; local[2]=0;
-	} else if(crystalInAlveolus==2) {
-	  local[0]=37.4639/8; local[1]=-31.1043/8; local[2]=0;
-	} else if(crystalInAlveolus==3) {
-	  local[0]=9.52012/8; local[1]=-8.57573/8; local[2]=0;
-	} else if(crystalInAlveolus==4){
-	  local[0]=9.52012/8; local[1]=-31.1043/8; local[2]=0;
-	}
-      } else if (crystalType==6 || crystalType==7) {
-	if(crystalInAlveolus==1){
-	  local[0]=38.3282/8; local[1]=-5.49819/8; local[2]=0;
-	} else if(crystalInAlveolus==2) {
-	  local[0]=38.3282/8; local[1]=-23.0538/8; local[2]=0;
-	} else if(crystalInAlveolus==3) {
-	  local[0]=8.66384/8; local[1]=-5.49819/8; local[2]=0;
-	} else if(crystalInAlveolus==4){
-	  local[0]=8.66384/8; local[1]=-23.0538/8; local[2]=0;
-	}
-      } else if (crystalType==8 || crystalType==9 || crystalType==10) {
-	if(crystalInAlveolus==1){
-	  local[0]=38.3683/8; local[1]=-4.71618/8; local[2]=0;
-	} else if(crystalInAlveolus==2) {
-	  local[0]=38.3683/8; local[1]=-19.8438/8; local[2]=0;
-	} else if(crystalInAlveolus==3) {
-	  local[0]=8.43569/8; local[1]=-4.71618/8; local[2]=0;
-	} else if(crystalInAlveolus==4){
-	  local[0]=8.43569/8; local[1]=-19.8438/8; local[2]=0;
-	}
-      } else if (crystalType==11 || crystalType==12 || crystalType==13) {
-	if(crystalInAlveolus==1){
-	  local[0]=38.3495/8; local[1]=-4.70373/8; local[2]=0;
-	} else if(crystalInAlveolus==2) {
-	  local[0]=38.3495/8; local[1]=-19.8403/8; local[2]=0;
-	} else if(crystalInAlveolus==3) {
-	  local[0]=8.66654/8; local[1]=-4.70373/8; local[2]=0;
-	} else if(crystalInAlveolus==4){
-	  local[0]=8.66654/8; local[1]=-19.8403/8; local[2]=0;
-	}
-      } else if (crystalType==14 || crystalType==15 || crystalType==16) {
-	if(crystalInAlveolus==1){
-	  local[0]=37.9075/8; local[1]=-4.66458/8; local[2]=0;
-	} else if(crystalInAlveolus==2) {
-	  local[0]=37.9075/8; local[1]=-19.8474/8; local[2]=0;
-	} else if(crystalInAlveolus==3) {
-	  local[0]=9.07247/8; local[1]=-19.8474/8; local[2]=0;
-	} else if(crystalInAlveolus==4){
-	  local[0]=9.07247/8; local[1]=-4.66458/8; local[2]=0;
-	}
-      }		
-
-      gGeoManager->CdTop();
-
-      if(gGeoManager->CheckPath(nameVolume)) gGeoManager->cd(nameVolume);
-      else { 
-	LOG(ERROR) << "R3BCalifaCrystalCal2Hit: Invalid crystal path: " << nameVolume
-		   << FairLogger::endl;
-	return; 
-      }
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-    
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/AlveolusInner_%i_1/CrystalWithWrapping_%i_%i_%i",
-	      crystalType, alveolusCopy-1, 
-	      crystalType, alveoliType[crystalType-1], 
-	      crystalInAlveolus, crystalInAlveolus-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-    
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/AlveolusInner_%i_1",
-	      crystalType, alveolusCopy-1, crystalType);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-    
-      sprintf(nameVolume, 
-	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i",
-	      crystalType, alveolusCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-    
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-    } else{
-      //For TUM iPhos endcap 
-      crystalType = ((iD-3000)%15) + 1;
-      crystalCopy = (iD-3000 - crystalType + 1)/15 + 1;
-      Int_t alveoliType[15]={1,2,3,4,5,6,7,8,9,10,11,12,13,14,15};
-      //Char_t nameVolume[200];
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1/Crystal_%i_1",
-              alveoliType[crystalType-1], crystalCopy-1, crystalType, crystalType);
-
-      gGeoManager->cd(nameVolume);
-      TGeoNode* currentNode = gGeoManager->GetCurrentNode();
-      currentNode->LocalToMaster(local, master);
-
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i/CrystalWithWrapping_%i_1",
-              alveoliType[crystalType-1], crystalCopy-1, crystalType);
-
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0/Alveolus_EC_%i_%i",alveoliType[crystalType-1], crystalCopy-1);
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);
-
-      sprintf(nameVolume, "/cave_1/CalifaWorld_0");
-      gGeoManager->cd(nameVolume);
-      currentNode = gGeoManager->GetCurrentNode();
-      local[0]=master[0]; local[1]=master[1]; local[2]=master[2];
-      currentNode->LocalToMaster(local, master);   
-    }
-  } else if (fGeometryVersion>=16) {
+if (fGeometryVersion>=16) {
     // Use new R3BCalifaGeometry class to get geometrical information
     R3BCalifaGeometry::Instance(fGeometryVersion)->GetAngles(iD, polar, azimuthal, rho);
     return;
   } else LOG(ERROR) << "R3BCalifaCrystalCal2Hit: Geometry version not available in R3BCalifa::ProcessHits(). " << FairLogger::endl;
-  
-  
+
+
   TVector3 masterV(master[0],master[1],master[2]);
   //masterV.Print();
   *polar=masterV.Theta();

--- a/califa/R3BCalifaCrystalCal2Hit.h
+++ b/califa/R3BCalifaCrystalCal2Hit.h
@@ -71,12 +71,20 @@ class R3BCalifaCrystalCal2Hit : public FairTask
      *@param Lacl  Double parameter used to set the experimental resolution in % for LaCl
      **/
     void SetPhoswichResolution(Double_t LaBr, Double_t LaCl);
+
     /** Public method SetDetectionThreshold
      **
      ** Defines the minimum energy requested in a crystal to be considered in a calorimeter Hit
      *@param thresholdEne  Double parameter used to set the threshold
      **/
     void SetDetectionThreshold(Double_t thresholdEne);
+
+    /** Public method SetDRThreshold
+     **
+     ** Defines the minimum energy requested in a crystal to be considered in a calorimeter Hit
+     *@param thresholdEne  Double parameter used to set the threshold
+     **/
+    void SetDRThreshold(Double_t DRthresholdEne);
 
     /** Public method SetAngularWindow
      **
@@ -125,6 +133,8 @@ class R3BCalifaCrystalCal2Hit : public FairTask
     Int_t fGeometryVersion;
     // Minimum energy requested in a crystal to be considered in a calorimeter Hit
     Double_t fThreshold;
+    // Threshold for selecting gamma or proton branch in double reading channels
+    Double_t fDRThreshold;
     // Experimental resolution @ 1 MeV
     Double_t fCrystalResolution;
     // Experimental resolution for Nf and Ns

--- a/califa/R3BCalifaGeometry.cxx
+++ b/califa/R3BCalifaGeometry.cxx
@@ -54,6 +54,11 @@ R3BCalifaGeometry::R3BCalifaGeometry(int version)  : fGeometryVersion(version), 
     geoPath += "califa_demo.geo.root";
     break;
 
+  case 444:
+    // s444 geometry
+    geoPath += "califa_s444.geo.root";
+    break;
+
   default:
     LOG(ERROR) << "R3BCalifaGeometry: Unsupported geometry version: " << version << FairLogger::endl;
     return;
@@ -82,9 +87,10 @@ R3BCalifaGeometry::R3BCalifaGeometry(int version)  : fGeometryVersion(version), 
   gGeoManager->SetTopVolume(v);
 
   fNavigator = new TGeoNavigator(gGeoManager);
+  f->Close();
 }
 
-void R3BCalifaGeometry::GetAngles(Int_t iD, Double_t* polar, 
+void R3BCalifaGeometry::GetAngles(Int_t iD, Double_t* polar,
 				 Double_t* azimuthal, Double_t* rho)
 {
 
@@ -95,11 +101,14 @@ void R3BCalifaGeometry::GetAngles(Int_t iD, Double_t* polar,
   Int_t alveolusCopy =0;
   Int_t crystalInAlveolus=0;
 
+  //SOLUTION FOR S444 - REDO AFTER EXPERIMENTS
+  if(iD>5000 && iD<6952) iD = iD - 5000; //for double reading crystals
+
  if (fGeometryVersion==16) {
     //The present scheme here done works with 8.11
     // crystalType = alveolus type (from 1 to 16) [Alveolus number]
     // crystalCopy = alveolus copy * 4 + crystals copy +1 (from 1 to 128)
-    // crystalId = 1 to 32 for the first 32 crystals 
+    // crystalId = 1 to 32 for the first 32 crystals
     //                     (single crystal in each alveoli)
     // or 32 + (alveolus type-2)*128 + (alvelous copy)*4 + (crystal copy) + 1
     //                     (from 1 to 1952)
@@ -108,27 +117,27 @@ void R3BCalifaGeometry::GetAngles(Int_t iD, Double_t* polar,
     if (iD<3000) {
       if(iD<33) crystalType = 1;  //Alv type 1
       else crystalType = (Int_t)((iD-33)/128) + 2;  //Alv type (2 to 16)
-      if(iD<33) crystalCopy = iD;     //for Alv type 1 
+      if(iD<33) crystalCopy = iD;     //for Alv type 1
       else crystalCopy = ((iD-33)%128) + 1;         //CrystalCopy (1 to 128)
-      if(iD<33) alveolusCopy = iD;    //Alv type 1 
+      if(iD<33) alveolusCopy = iD;    //Alv type 1
       else alveolusCopy =(Int_t)(((iD-33)%128)/4) +1; //Alveolus copy (1 to 32)
       if(iD<33) crystalInAlveolus =1;          //Alv type 1
       else crystalInAlveolus = (iD-33)%4 + 1;//Crystal number in alveolus (1 to 4)
-    
+
       Int_t alveoliType[16]={1,2,2,2,2,3,3,4,4,4,5,5,5,6,6,6};
-    
-      sprintf(nameVolume, 
+
+      sprintf(nameVolume,
 	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/AlveolusInner_%i_1/CrystalWithWrapping_%i_%i_%i/Crystal_%i_%i_1",
-	      crystalType, alveolusCopy-1, 
-	      crystalType, alveoliType[crystalType-1], 
-	      crystalInAlveolus, crystalInAlveolus-1, 
+	      crystalType, alveolusCopy-1,
+	      crystalType, alveoliType[crystalType-1],
+	      crystalInAlveolus, crystalInAlveolus-1,
 	      alveoliType[crystalType-1], crystalInAlveolus);
-    
+
       // The definition of the crystals is different in this particular EndCap design:
       // the origin for each crystal is the alveoli corner
       if (crystalType==1) {
 	local[0]=27.108/8; local[1]=-28.0483/8; local[2]=0;
-      } else if (crystalType==2 || crystalType==3 || 
+      } else if (crystalType==2 || crystalType==3 ||
 		 crystalType==4 || crystalType==5) {
 	if(crystalInAlveolus==1){
 	  local[0]=37.4639/8; local[1]=-8.57573/8; local[2]=0;
@@ -179,15 +188,15 @@ void R3BCalifaGeometry::GetAngles(Int_t iD, Double_t* polar,
 	} else if(crystalInAlveolus==4){
 	  local[0]=9.07247/8; local[1]=-4.66458/8; local[2]=0;
 	}
-      }		
+      }
 
       gGeoManager->CdTop();
 
       if(gGeoManager->CheckPath(nameVolume)) gGeoManager->cd(nameVolume);
-      else { 
+      else {
 	LOG(ERROR) << "R3BCalifaCrysta2Hit: Invalid crystal path: " << nameVolume
 		   << FairLogger::endl;
-	return; 
+	return;
       }
       gGeoManager->LocalToMaster(local, master);
 
@@ -206,7 +215,9 @@ void R3BCalifaGeometry::GetAngles(Int_t iD, Double_t* polar,
       gGeoManager->LocalToMaster(local, master);
     }
   }
-  else if(fGeometryVersion == 17 || fGeometryVersion == 0x438b)
+  else if(fGeometryVersion == 17 ||
+          fGeometryVersion == 0x438b ||
+          fGeometryVersion == 444)
   {
     const char *nameVolume = GetCrystalVolumePath(iD);
     if(!nameVolume)
@@ -229,8 +240,8 @@ void R3BCalifaGeometry::GetAngles(Int_t iD, Double_t* polar,
    LOG(ERROR) << "R3BCalifaGeometry: Geometry version not available in R3BCalifaGeometry::GetAngles(). " << FairLogger::endl;
    return;
  }
-  
-  
+
+
   TVector3 masterV(master[0],master[1],master[2]);
   //masterV.Print();
   *polar=masterV.Theta();
@@ -255,6 +266,7 @@ const char * R3BCalifaGeometry::GetCrystalVolumePath(int iD)
     case 16:
     case 17:
     case 0x438b:
+    case 444:
     if (iD >= 1 && iD <= 1952)
     {
       // Barrel
@@ -262,8 +274,8 @@ const char * R3BCalifaGeometry::GetCrystalVolumePath(int iD)
       {
         // First ring (single crystals)
         crystalType = 1;  //Alv type 1
-        crystalCopy = iD;     //for Alv type 1 
-        alveolusCopy = iD;    //Alv type 1 
+        crystalCopy = iD;     //for Alv type 1
+        alveolusCopy = iD;    //Alv type 1
         crystalInAlveolus =1;          //Alv type 1
       }
       else
@@ -275,12 +287,12 @@ const char * R3BCalifaGeometry::GetCrystalVolumePath(int iD)
         crystalInAlveolus = (iD-33)%4 + 1;//Crystal number in alveolus (1 to 4)
       }
       Int_t alveoliType[16]={1,2,2,2,2,3,3,4,4,4,5,5,5,6,6,6};
-    
-      nameVolume = TString::Format( 
+
+      nameVolume = TString::Format(
 	      "/cave_1/CalifaWorld_0/Alveolus_%i_%i/AlveolusInner_%i_1/CrystalWithWrapping_%i_%i_%i/Crystal_%i_%i_1",
-	      crystalType, alveolusCopy-1, 
-	      crystalType, alveoliType[crystalType-1], 
-	      crystalInAlveolus, crystalInAlveolus-1, 
+	      crystalType, alveolusCopy-1,
+	      crystalType, alveoliType[crystalType-1],
+	      crystalInAlveolus, crystalInAlveolus-1,
 	      alveoliType[crystalType-1], crystalInAlveolus);
     }
     else if(iD >= 3000)
@@ -378,7 +390,7 @@ int R3BCalifaGeometry::GetCrystalId(const char *volumePath)
 
   if (fGeometryVersion==16 || fGeometryVersion==17 || fGeometryVersion==0x438b) {
     //RESERVED FOR CALIFA 8.11 BARREL + CC 0.2
-    
+
     if(volumeNames.size() < 4)
     {
       LOG(ERROR) << "R3BCalifaGeometry::GetCrystalId(): Invalid path: " << volumePath << FairLogger::endl;
@@ -410,12 +422,12 @@ int R3BCalifaGeometry::GetCrystalId(const char *volumePath)
 	  crystalType -= 1;
       }
       crystalId = 3000 + cpAlv*24 + (crystalType-1);
-      
+
       if (crystalType>24 || crystalType<1 ||
-	  crystalCopy>32 || crystalCopy<1 || 
+	  crystalCopy>32 || crystalCopy<1 ||
           crystalId<3000 || crystalId>4800)
       {
-	LOG(ERROR) << "R3BCalifaGeometry: Wrong crystal number in geometryVersion 16+ (CC). " 
+	LOG(ERROR) << "R3BCalifaGeometry: Wrong crystal number in geometryVersion 16+ (CC). "
 		   << FairLogger::endl;
         return -1;
       }
@@ -425,32 +437,32 @@ int R3BCalifaGeometry::GetCrystalId(const char *volumePath)
       crystalType = atoi(volumeName+9);//converting to int the alveolus index
       if (crystalType==1) {
 	//only one crystal per alveoli in this ring, running from 1 to 32
-        crystalCopy = cpSupAlv+1; 
-        crystalId = cpSupAlv+1;                    
+        crystalCopy = cpSupAlv+1;
+        crystalId = cpSupAlv+1;
       } else if (crystalType>1 && crystalType<17) {
 	//running from 0*4+0+1=1 to 31*4+3+1=128
         crystalCopy = cpSupAlv*4+cpCry+1;
 	//running from 32+0*128+0*4+0+1=1 to 32+14*128+31*4+3+1=1952
-        crystalId = 32+(crystalType-2)*128+cpSupAlv*4+cpCry+1; 
+        crystalId = 32+(crystalType-2)*128+cpSupAlv*4+cpCry+1;
       }
-      if (crystalType>16 || crystalType<1 || crystalCopy>128 || 
-	  crystalCopy<1 || crystalId>1952 || crystalId<1) 
+      if (crystalType>16 || crystalType<1 || crystalCopy>128 ||
+	  crystalCopy<1 || crystalId>1952 || crystalId<1)
       {
-        LOG(ERROR) << "R3BCalifaGeometry: Wrong crystal number in geometryVersion 16+ (BARREL)." 
+        LOG(ERROR) << "R3BCalifaGeometry: Wrong crystal number in geometryVersion 16+ (BARREL)."
 		   << FairLogger::endl;
         return -1;
       }
     }
     else
     {
-      LOG(ERROR) << "R3BCalifaGeometry: Impossible crystalType for geometryVersion 16+." 
+      LOG(ERROR) << "R3BCalifaGeometry: Impossible crystalType for geometryVersion 16+."
 		      << FairLogger::endl;
       return -1;
     }
   }
   else
   {
-    LOG(ERROR) << "R3BCalifaGeometry: Geometry version not available in R3BCalifaGeometry::GetCrystalId(). " 
+    LOG(ERROR) << "R3BCalifaGeometry: Geometry version not available in R3BCalifaGeometry::GetCrystalId(). "
 		    << FairLogger::endl;
     return -1;
   }


### PR DESCRIPTION
Select channel from double reading crystals based on a threshold

For double reading channels (S444 and beyond) the clusterfinder takes the
information from the gammaBranch if both are present and energy is below
a given fDRThreshold, user configurable. If energy is above the fDRThreshold,
it takes the protonBranch.