### PR TITLE
fixed memory leak, together with Philipp Klenze

### DIFF
--- a/tracker/unpackams/R3BAmsStripCal2Hit.cxx
+++ b/tracker/unpackams/R3BAmsStripCal2Hit.cxx
@@ -169,6 +169,7 @@ void R3BAmsStripCal2Hit::Exec(Option_t* option)
 
   for(Int_t i = 0; i < fMaxNumDet*2; i++)hams[i]->Reset();
   if(calData) delete calData;
+  delete ss;
   return;
 }
 


### PR DESCRIPTION
Fixed a memory leak regarding an unbalanced new TSpectrum() in R3BAmsStripCal2Hit, with help from Philipp. 