### PR TITLE
Ascii Generator starts over if EoF is reached.

### DIFF
--- a/r3bgen/R3BAsciiGenerator.h
+++ b/r3bgen/R3BAsciiGenerator.h
@@ -1,105 +1,62 @@
-// -------------------------------------------------------------------------
-// -----                R3BAsciiGenerator header file                 -----
-// -----                Created 27.11.09 <D.Bertini@gsi.de>           -----
-// -------------------------------------------------------------------------
-
-/** R3BAsciiGenerator
-**/
-
-
 #ifndef R3BASCIIGENERATOR_H
 #define R3BASCIIGENERATOR_H 1
 
-
 #include "FairGenerator.h"
-
+#include "TString.h"
 #include <fstream>
 #include <map>
-
-using namespace std;
-
-using std::ifstream;
+#include <string>
 
 class TDatabasePDG;
 class FairPrimaryGenerator;
 class FairIon;
 
-class R3BAsciiGenerator : public FairGenerator  
+class R3BAsciiGenerator : public FairGenerator
 {
+  public:
+    /** Default constructor without arguments should not be used. **/
+    R3BAsciiGenerator();
 
- public: 
+    /** Standard constructor.
+     ** @param fileName The input file name
+     **/
+    explicit R3BAsciiGenerator(std::string fileName);
+    explicit R3BAsciiGenerator(const TString& fileName);
+    explicit R3BAsciiGenerator(const char* fileName); // for old macros
 
-  /** Default constructor without arguments should not be used. **/
-  R3BAsciiGenerator();
+    /** Destructor. **/
+    ~R3BAsciiGenerator() override;
 
+    /** Reads on event from the input file and pushes the tracks onto
+     ** the stack. Abstract method in base class.
+     ** @param primGen  pointer to the R3BPrimaryGenerator
+     **/
+    bool ReadEvent(FairPrimaryGenerator* primGen) override;
 
-  /** Standard constructor. 
-   ** @param fileName The input file name
-   **/
-  R3BAsciiGenerator(const char* fileName);
+    void SetXYZ(Double32_t x = 0, Double32_t y = 0, Double32_t z = 0);
 
+    void SetDxDyDz(Double32_t sx = 0, Double32_t sy = 0, Double32_t sz = 0);
 
-  R3BAsciiGenerator(const R3BAsciiGenerator&);
+  private:
+    std::ifstream fInputFile;    //! Input file stream
+    const std::string fFileName; //! Input file Name
+    TDatabasePDG* fPDG;          //!  PDG database (non-owning)
 
+    /** Private method RegisterIons. Goes through the input file and registers
+     ** any ion needed. **/
+    int RegisterIons();
 
-  R3BAsciiGenerator& operator=(const R3BAsciiGenerator&) { return *this; }
+    void CheckAndOpen();
 
+    /** STL map from ion name to FairIon **/
+    std::map<TString, FairIon*> fIonMap; //!
 
-  /** Destructor. **/
-  virtual ~R3BAsciiGenerator();
+    Double32_t fX, fY, fZ;    // Point vertex coordinates [cm]
+    bool fPointVtxIsSet;      // True if point vertex is set
+    Double32_t fDX, fDY, fDZ; // Point vertex coordinates [cm]
+    bool fBoxVtxIsSet;        // True if point vertex is set
 
-	
-  /** Reads on event from the input file and pushes the tracks onto
-   ** the stack. Abstract method in base class.
-   ** @param primGen  pointer to the R3BPrimaryGenerator
-   **/
-  virtual Bool_t ReadEvent(FairPrimaryGenerator* primGen);
-
- void SetXYZ   (Double32_t x=0, Double32_t y=0, Double32_t z=0) {
-      fX=x;
-      fY=y;
-      fZ=z;
-      fPointVtxIsSet=kTRUE;
-   }
-
- void SetDxDyDz(Double32_t sx=0, Double32_t sy=0, Double32_t sz=0) {
-      fDX=sx;
-      fDY=sy;
-      fDZ=sz;
-      fBoxVtxIsSet=kTRUE;
-
- } 
-
- private:
-
-  ifstream*      fInputFile;          //! Input file stream
-  const Char_t*  fFileName;           //! Input file Name
-  TDatabasePDG*  fPDG;                //!  PDG database
-
-	
-  /** Private method CloseInput. Just for convenience. Closes the 
-   ** input file properly. Called from destructor and from ReadEvent. **/
-  void CloseInput();
-
-
-  /** Private method RegisterIons. Goes through the input file and registers
-   ** any ion needed. **/
-  Int_t RegisterIons();
-
-
-
-  /** STL map from ion name to FairIon **/
-  std::map<TString, FairIon*> fIonMap;       //!
-	
-  Double32_t fX, fY, fZ;           // Point vertex coordinates [cm]	
-  Bool_t     fPointVtxIsSet;       // True if point vertex is set
-  Double32_t fDX, fDY, fDZ;           // Point vertex coordinates [cm]	
-  Bool_t     fBoxVtxIsSet;       // True if point vertex is set
-
-
-
-  ClassDef(R3BAsciiGenerator,1);
-
+    ClassDefOverride(R3BAsciiGenerator, 1);
 };
 
 #endif


### PR DESCRIPTION
When more events are requested then are stored in an input file, the R3BAsciiGenerator will now simply start reading the file again. (The Monte-Carlo transport codes use a different, independent seed for each event, thus repetition of primary particles should not be an issue if the file is only repeated a few times.)

Also, some cleanup:
- No unnecessary pointers
- Using `FairLogger` instead of `std::cout`
- clang-format