### PR TITLE
Remove constexpr declaration.

### DIFF
--- a/r3bgen/R3BCosmicGenerator.cxx
+++ b/r3bgen/R3BCosmicGenerator.cxx
@@ -19,7 +19,7 @@ constexpr Double_t Sqr(const Double_t val){
   return val*val;
 }
 
-constexpr Double_t Sin2(const Double_t val){
+Double_t Sin2(const Double_t val){
   return Sqr(sin(val));
 }
 


### PR DESCRIPTION
In c++ 11 sin() is declared as non-constexpr. Therefore make Sqr() and Sin2() functions non-constexpr.