### PR TITLE
sprintf bug fix

### DIFF
--- a/fiber/R3BBunchedFiberCal2Hit.cxx
+++ b/fiber/R3BBunchedFiberCal2Hit.cxx
@@ -106,8 +106,8 @@ InitStatus R3BBunchedFiberCal2Hit::Init()
 
   // ToT SAPMT:  
   for(Int_t i=0;i<4;i++){
-    char number[1];
-    sprintf(number, "%d", i);
+    char number[15];
+    snprintf(number, sizeof(number), "%d", i);
     chistName=fName+"_ToT_SAPMT"+number;
     chistTitle=fName+" ToT of single PMTs "+number;
     fh_ToT_s_Fib[i] = new TH2F(chistName.Data(), chistTitle.Data(), 2100, 0., 2100., 200, 0., 200.);   	   


### PR DESCRIPTION
travis compiler said: note: 'sprintf' output between 2 and 12 bytes into a destination of size 1. 
translation: random bad stuff *will* happen. 

Regarding sprintf, see http://natashenka.ca/wp-content/uploads/2014/01/sprintf8x11.png

The other 769 uses of sprintf may or may not be safe.