### PR TITLE
Use TString::Data() when passing argument to runtime_error

### DIFF
--- a/neuland/shared/TCAConnector.h
+++ b/neuland/shared/TCAConnector.h
@@ -34,13 +34,13 @@ class TCAInputConnector
         fTCA = (TClonesArray*)ioman->GetObject(fBranchName);
         if (fTCA == nullptr)
         {
-            throw std::runtime_error("TCAInputConnector: No TClonesArray called " + fBranchName +
-                                     " could be obtained from the FairRootManager");
+            throw std::runtime_error(("TCAInputConnector: No TClonesArray called " + fBranchName +
+                                     " could be obtained from the FairRootManager").Data());
         }
         if (!TString(fTCA->GetClass()->GetName()).EqualTo(fClassName))
         {
-            throw std::runtime_error("TCAInputConnector: TClonesArray " + fBranchName +
-                                     " does not contain elements of type " + fClassName);
+            throw std::runtime_error(("TCAInputConnector: TClonesArray " + fBranchName +
+                                     " does not contain elements of type " + fClassName).Data());
         }
     }
 
@@ -49,8 +49,8 @@ class TCAInputConnector
         std::vector<T*> fV;
         if (fTCA == nullptr)
         {
-            throw std::runtime_error("TCAInputConnector: TClonesArray " + fBranchName + " of " + fClassName +
-                                     "s not available");
+            throw std::runtime_error(("TCAInputConnector: TClonesArray " + fBranchName + " of " + fClassName +
+                                     "s not available").Data());
         }
 
         const Int_t n = fTCA->GetEntries();
@@ -67,8 +67,8 @@ class TCAInputConnector
         std::vector<T> fV;
         if (fTCA == nullptr)
         {
-            throw std::runtime_error("TCAInputConnector: TClonesArray " + fBranchName + " of " + fClassName +
-                                     "s not available");
+            throw std::runtime_error(("TCAInputConnector: TClonesArray " + fBranchName + " of " + fClassName +
+                                     "s not available").Data());
         }
 
         const Int_t n = fTCA->GetEntries();
@@ -107,8 +107,8 @@ class TCAOptionalInputConnector
         fTCA = (TClonesArray*)ioman->GetObject(fBranchName);
         if (fTCA != nullptr && !TString(fTCA->GetClass()->GetName()).EqualTo(fClassName))
         {
-            throw std::runtime_error("TCAInputConnector: TClonesArray " + fBranchName +
-                                     " does not contain elements of type " + fClassName);
+            throw std::runtime_error(("TCAInputConnector: TClonesArray " + fBranchName +
+                                     " does not contain elements of type " + fClassName).Data());
         }
     }
 
@@ -174,8 +174,8 @@ class TCAOutputConnector
 
         if (fTCA == nullptr)
         {
-            throw std::runtime_error("TCAOutputConnector: TClonesArray " + fBranchName + " of " + fClassName +
-                                     "s could not be provided by the FairRootManager");
+            throw std::runtime_error(("TCAOutputConnector: TClonesArray " + fBranchName + " of " + fClassName +
+                                     "s could not be provided by the FairRootManager").Data());
         }
     }
 
@@ -183,8 +183,8 @@ class TCAOutputConnector
     {
         if (fTCA == nullptr)
         {
-            throw std::runtime_error("TCAOutputConnector: TClonesArray " + fBranchName + " of " + fClassName +
-                                     "s not available");
+            throw std::runtime_error(("TCAOutputConnector: TClonesArray " + fBranchName + " of " + fClassName +
+                                     "s not available").Data());
         }
         fTCA->Clear("C");
     }
@@ -193,8 +193,8 @@ class TCAOutputConnector
     {
         if (fTCA == nullptr)
         {
-            throw std::runtime_error("TCAOutputConnector: TClonesArray " + fBranchName + " of " + fClassName +
-                                     "s not available");
+            throw std::runtime_error(("TCAOutputConnector: TClonesArray " + fBranchName + " of " + fClassName +
+                                     "s not available").Data());
         }
         return fTCA->GetEntries();
     }
@@ -203,8 +203,8 @@ class TCAOutputConnector
     {
         if (fTCA == nullptr)
         {
-            throw std::runtime_error("TCAOutputConnector: TClonesArray " + fBranchName + " of " + fClassName +
-                                     "s not available");
+            throw std::runtime_error(("TCAOutputConnector: TClonesArray " + fBranchName + " of " + fClassName +
+                                     "s not available").Data());
         }
         new ((*fTCA)[fTCA->GetEntries()]) T(std::move(t));
     }
@@ -213,8 +213,8 @@ class TCAOutputConnector
     {
         if (fTCA == nullptr)
         {
-            throw std::runtime_error("TCAOutputConnector: TClonesArray " + fBranchName + " of " + fClassName +
-                                     "s not available");
+            throw std::runtime_error(("TCAOutputConnector: TClonesArray " + fBranchName + " of " + fClassName +
+                                     "s not available").Data());
         }
         if (t != nullptr)
         {
@@ -226,8 +226,8 @@ class TCAOutputConnector
     {
         if (fTCA == nullptr)
         {
-            throw std::runtime_error("TCAOutputConnector: TClonesArray " + fBranchName + " of " + fClassName +
-                                     "s not available");
+            throw std::runtime_error(("TCAOutputConnector: TClonesArray " + fBranchName + " of " + fClassName +
+                                     "s not available").Data());
         }
         for (auto& o : v)
         {


### PR DESCRIPTION
Is needed because of compilation error on Debian 8 with gcc 4.9.2