### PR TITLE
Added -Werror, (minus some). Fixed warnings. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,15 @@ find_package(HEPMC)
 # Check the compiler and set the compile and link flags
 check_compiler()
 
-#set(CMAKE_CXX_FLAGS -std=c++14)
+if(DEFINED $ENV{WERROR} AND $ENV{WERROR})
+  message(STATUS "Will compile with -Werror. ")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-error=sign-compare -Wno-error=reorder -Wno-error=unused-variable -Wno-error=unused-but-set-variable")
+else()
+  if (NOT APPLE)
+    message(STATUS "Set env WERROR to 1 to enable -Werror. If origin/dev compiles on your platform with that option, it is definitly a good idea to do that.")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-sign-compare -Wno-reorder -Wno-unused-variable -Wno-unused-but-set-variable")
+  endif()
+endif()
 
 set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/lib")
 set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin")
@@ -217,6 +225,9 @@ find_package(ucesb)
 if(ucesb_FOUND)
     set(WITH_UCESB true)
     set(LD_LIBRARY_PATH ${ucesb_LIBRARY_DIR} ${LD_LIBRARY_PATH})
+else()
+  message(WARNING "${BMagenta}No UCESB configured. You will not be able to unpack lmd files. Set UCESB_DIR"
+    " to a ucesb installation to fix this.${CR}")
 endif(ucesb_FOUND)
 
 find_package(EPICS)

--- a/califa/unpack/R3BCalifaMapped2CrystalCalPar.cxx
+++ b/califa/unpack/R3BCalifaMapped2CrystalCalPar.cxx
@@ -291,7 +291,7 @@ void R3BCalifaMapped2CrystalCalPar::SearchPeaks()
                     fleft = fMapHistos_leftp;
                 }
 
-                TF1* f1;
+                TF1* f1 = nullptr;
                 if (fNumParam)
                 {
 

--- a/dch/R3BDch2pDigitizer.cxx
+++ b/dch/R3BDch2pDigitizer.cxx
@@ -313,8 +313,9 @@ void R3BDch2pDigitizer::Exec(Option_t* opt)
             }
 
             if (DetID == 1 && l == 1)
-            { //Check tilt direction, positive or negative angle?! Make it consistent with rotations in R3BDch.cxx !!!\
-     //using this manual calculation (based on the manual offsets above), a consistency with the s318 tracker is achieved. F. Wamers.
+            { // Check tilt direction, positive or negative angle?! Make it consistent with rotations in R3BDch.cxx !!!
+                // using this manual calculation (based on the manual offsets above), a consistency with the s318
+                // tracker is achieved. F. Wamers.
                 // fX_Local	= (fX_Global-PDC2_X0)*cos(PDC2_Atilt*TMath::Pi()/180.)/cos(PDC2_Aparm*TMath::Pi()/180.) -
                 // (fY_Global-PDC2_Y0)*sin(PDC2_Atilt*TMath::Pi()/180.); fY_Local	=
                 // (fX_Global-PDC2_X0)*sin(PDC2_Atilt*TMath::Pi()/180.)/cos(PDC2_Aparm*TMath::Pi()/180.) +

--- a/dch/R3BDchDigitizer.cxx
+++ b/dch/R3BDchDigitizer.cxx
@@ -348,8 +348,10 @@ void R3BDchDigitizer::Exec(Option_t* opt)
 
             if (DetID == 1)
             {
-                //Check tilt direction, positive or negative angle?! Make it consistent with rotations in R3BDch.cxx !!!\
-     //using this manual calculation (based on the manual offsets above), a consistency with the s318 tracker is achieved. F. Wamers.
+                // Check tilt direction, positive or negative angle?! Make it consistent with rotations in R3BDch.cxx
+                // !!!
+                // using this manual calculation (based on the manual offsets above), a consistency with the s318
+                // tracker is achieved. F. Wamers.
                 // fX_Local	= (fX_Global-PDC2_X0)*cos(PDC2_Atilt*TMath::Pi()/180.)/cos(PDC2_Aparm*TMath::Pi()/180.) -
                 // (fY_Global-PDC2_Y0)*sin(PDC2_Atilt*TMath::Pi()/180.); fY_Local	=
                 // (fX_Global-PDC2_X0)*sin(PDC2_Atilt*TMath::Pi()/180.)/cos(PDC2_Aparm*TMath::Pi()/180.) +

--- a/evtvis/R3BCalifaEventDisplay.cxx
+++ b/evtvis/R3BCalifaEventDisplay.cxx
@@ -55,6 +55,8 @@
 #include "TH2F.h"
 #include "TStyle.h"
 
+#include <assert.h>
+
 using std::cout;
 using std::endl;
 
@@ -156,12 +158,12 @@ void R3BCalifaEventDisplay::Exec(Option_t* opt)
 
         Reset();
 
-        R3BCalifaCrystalCalData* crystalHit;
+        R3BCalifaCrystalCalData* crystalHit = nullptr;
 
         Int_t crystalHits; // Nb of CrystalHits in current event
         crystalHits = fCrystalHitCA->GetEntriesFast();
 
-        Int_t binx, biny;
+        Int_t binx = -1, biny = -1;
         Double_t theta = 0., phi = 0., rho = 0., eta = 0.;
 
         // Loop in Crystal Hits
@@ -190,6 +192,12 @@ void R3BCalifaEventDisplay::Exec(Option_t* opt)
                 break;
             }
         }
+
+        assert(binx != -1 && biny != -1);
+
+        // crystalHit seems to point to whatever came last when looping over the TCA.
+        // Not sure why we want that, but at least make sure it exists.
+        assert(crystalHit);
 
         // Filling histograms
 

--- a/evtvis/R3BCalifaHitEventDisplay.cxx
+++ b/evtvis/R3BCalifaHitEventDisplay.cxx
@@ -50,6 +50,8 @@
 #include "TH2F.h"
 #include "TStyle.h"
 
+#include <assert.h>
+
 using std::cout;
 using std::endl;
 
@@ -151,7 +153,6 @@ void R3BCalifaHitEventDisplay::Exec(Option_t* opt)
         Int_t caloHits = 0; // Nb of CaloHits in current event
         caloHits = fCaloHitCA->GetEntriesFast();
 
-        Int_t binx, biny;
         Double_t theta, phi, eta;
 
         //    TAxis *ax = hcalohit->GetXaxis();
@@ -163,6 +164,7 @@ void R3BCalifaHitEventDisplay::Exec(Option_t* opt)
         for (Int_t i = 0; i < caloHits; i++)
         {
 
+            Int_t binx = -1, biny = -1;
             caloHit = (R3BCalifaHitData*)fCaloHitCA->At(i);
             theta = caloHit->GetTheta();
             phi = caloHit->GetPhi();
@@ -186,6 +188,8 @@ void R3BCalifaHitEventDisplay::Exec(Option_t* opt)
                     break;
                 }
             }
+
+            assert(binx != -1 && biny != -1);
 
             // Filling histograms
 

--- a/gfi/R3BGfiDigitizer.cxx
+++ b/gfi/R3BGfiDigitizer.cxx
@@ -106,8 +106,8 @@ void R3BGfiDigitizer::Exec(Option_t* opt)
 
     Int_t gf1mul;
     Int_t gf2mul;
-    Double_t gf1_01x;
-    Double_t gf2_01x;
+    Double_t gf1_01x = nan("");
+    Double_t gf2_01x = nan("");
 
     //******************** GFI **************************//
     gf1mul = 0;

--- a/land/R3BLandDigitizerQA.cxx
+++ b/land/R3BLandDigitizerQA.cxx
@@ -120,7 +120,7 @@ void R3BLandDigitizerQA::Exec(Option_t* option)
     Int_t nDigis = fDigis->GetEntriesFast();
     R3BLandDigi* digi;
     Double_t qdc;
-    Double_t tdc;
+    Double_t tdc = nan("");
     Double_t x, y, z;
     Double_t beta;
     Double_t tdc_first = 1e10;

--- a/land/R3BNeutronTracker2D.cxx
+++ b/land/R3BNeutronTracker2D.cxx
@@ -41,6 +41,8 @@
 #include "R3BNeutHit.h"
 #include "R3BNeutronTracker2D.h"
 
+#include <assert.h>
+
 using std::cout;
 using std::endl;
 using std::ifstream;
@@ -920,7 +922,7 @@ void R3BNeutronTracker2D::CalculateMassInv()
         R3BLandPoint* point;
         TVector3 posPoint;
         Double_t d;
-        Int_t index;
+        Int_t index = -1;
         Double_t dmin = 1e6;
         for (Int_t ip = 0; ip < fLandPoints->GetEntriesFast(); ip++)
         {
@@ -934,6 +936,7 @@ void R3BNeutronTracker2D::CalculateMassInv()
                 index = ip;
             }
         }
+        assert(index != -1);
         point = (R3BLandPoint*)fLandPoints->At(index);
         Int_t trackID = point->GetTrackID();
         R3BMCTrack* track = (R3BMCTrack*)fLandMCTrack->At(trackID);

--- a/mfi/R3BMfiDigitizer.cxx
+++ b/mfi/R3BMfiDigitizer.cxx
@@ -153,7 +153,7 @@ void R3BMfiDigitizer::Exec(Option_t* opt)
     Int_t fiber;
 
     // mfi fiber determing variables
-    Double_t fib;
+    Double_t fib = nan("");
     Double_t fib_coverage = 0.8828;
     Bool_t fib_hit = false;
     Double_t _rndm;

--- a/mtof/R3BmTofDigitizer.cxx
+++ b/mtof/R3BmTofDigitizer.cxx
@@ -118,7 +118,7 @@ void R3BmTofDigitizer::Exec(Option_t* opt)
     Double_t ntfx;
     Double_t ntfy;
     Double_t ntft;
-    Double_t ntfpath;
+    Double_t ntfpath = nan("");
     Double_t ntfpx;
     Double_t ntfpy;
     Double_t ntfpz;

--- a/neuland/calibration/R3BNeulandTacquilaMapped2Cal.cxx
+++ b/neuland/calibration/R3BNeulandTacquilaMapped2Cal.cxx
@@ -196,7 +196,7 @@ void R3BNeulandTacquilaMapped2Cal::Exec(Option_t* option)
     if (fPulserMode)
     {
         R3BNeulandCalData* pmt1;
-        Double_t time1;
+        Double_t time1 = nan("");
         for (Int_t i = 0; i < fNPmt; i++)
         {
             pmt1 = (R3BNeulandCalData*)fPmt->At(i);

--- a/r3bbase/R3BGlobalAnalysis.cxx
+++ b/r3bbase/R3BGlobalAnalysis.cxx
@@ -685,9 +685,9 @@ void R3BGlobalAnalysis::Exec(Option_t* option)
             Double_t totMax_MA = 0.;
             Int_t iFibMax_MA = 0;
 
-            Double_t spmtMax;
-            Double_t mapmtMax;
-            Double_t tofMax;
+            Double_t spmtMax = nan("");
+            Double_t mapmtMax = nan("");
+            Double_t tofMax = nan("");
             Double_t y;
             Double_t tof[14] = { 0., 0., 0., 0., 60., 60., 0., 0., 0., 140., 140., 0., 140., 140. };
             Double_t z[14] = { -51., -49., 0., 0., 45., 50., 0., 0., 0., 700., 670., 0., 630., 600. };

--- a/r3bbase/R3BGlobalAnalysisS454.cxx
+++ b/r3bbase/R3BGlobalAnalysisS454.cxx
@@ -588,7 +588,7 @@ void R3BGlobalAnalysisS454::Exec(Option_t* option)
         if (fTpat_bit >= 0)
         {
             itpat = header->GetTpat();
-            tpatvalue = (itpat && (1 << fTpat_bit)) >> fTpat_bit;
+            tpatvalue = (itpat & (1 << fTpat_bit)) >> fTpat_bit;
             if (tpatvalue == 0)
                 return;
         }

--- a/r3bbase/R3BOnlineSpectraDec2019.cxx
+++ b/r3bbase/R3BOnlineSpectraDec2019.cxx
@@ -65,6 +65,8 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
+
+#include <assert.h>
 #define IS_NAN(x) TMath::IsNaN(x)
 using namespace std;
 
@@ -1428,7 +1430,7 @@ void R3BOnlineSpectraDec2019::Exec(Option_t* option)
     if (fTpat_bit >= 0)
     {
         itpat = header->GetTpat();
-        tpatvalue = (itpat && (1 << fTpat_bit)) >> fTpat_bit;
+        tpatvalue = (itpat & (1 << fTpat_bit)) >> fTpat_bit;
         if (tpatvalue == 0)
             return;
     }
@@ -2144,7 +2146,7 @@ void R3BOnlineSpectraDec2019::Exec(Option_t* option)
     Double_t totsumS8[10] = { 0.0 };
     Double_t totS8[10][8] = { 0.0 / 0.0 };
 
-    Int_t MultipS8;
+    Int_t MultipS8 = -1;
 
     if (fMappedItems.at(DET_SCI8))
     {
@@ -2166,6 +2168,7 @@ void R3BOnlineSpectraDec2019::Exec(Option_t* option)
             fh_sci8_channels->Fill(iCha);
         }
     }
+    assert(MultipS8 != -1);
 
     Int_t nPartS8;
 
@@ -3032,7 +3035,7 @@ void R3BOnlineSpectraDec2019::FinishTask()
     {
         fh_TimePreviousEvent->Write();
 
-        for (Int_t i; i < 4; i++)
+        for (Int_t i = 0; i < 4; i++)
         {
             fh_tofd_TotPm[i]->Write();
         }

--- a/r3bbase/R3BOnlineSpectraS454.cxx
+++ b/r3bbase/R3BOnlineSpectraS454.cxx
@@ -1144,7 +1144,7 @@ void R3BOnlineSpectra::Exec(Option_t* option)
     if (fTpat_bit >= 0)
     {
         itpat = header->GetTpat();
-        tpatvalue = (itpat && (1 << fTpat_bit)) >> fTpat_bit;
+        tpatvalue = (itpat & (1 << fTpat_bit)) >> fTpat_bit;
         if ((tpatvalue == 0))
             return;
     }

--- a/r3bgen/R3BPhaseSpaceGenerator.cxx
+++ b/r3bgen/R3BPhaseSpaceGenerator.cxx
@@ -79,8 +79,8 @@ Bool_t R3BPhaseSpaceGenerator::ReadEvent(FairPrimaryGenerator* primGen)
     const auto TotE_GeV = erel_GeV + fTotMass;
     const auto gamma = 1 + beamEnergy_GeV / 0.931494028;
     const auto beta = std::sqrt(1 - 1 / (gamma * gamma));
-    TLorentzVector Init(0.0, 0.0, 0.0, TotE_GeV);
-    fPhaseSpace.SetDecay(Init, fMasses.size(), fMasses.data());
+    TLorentzVector InitVec(0.0, 0.0, 0.0, TotE_GeV);
+    fPhaseSpace.SetDecay(InitVec, fMasses.size(), fMasses.data());
     fPhaseSpace.Generate();
 
     const size_t nParticles = fPDGCodes.size();

--- a/r3bsource/R3BStartrackReader.cxx
+++ b/r3bsource/R3BStartrackReader.cxx
@@ -89,13 +89,13 @@ Bool_t R3BStartrackReader::Read()
     //    UInt_t WRvhb=0;
     //    UInt_t WRhb=0;
     //    UInt_t WRlb=0;
-    uint64_t TS;
-    uint64_t TSExt;
+    uint64_t TS = -1;
+    uint64_t TSExt = -1;
     //    UInt_t ts_vhb=0.; // replaced by fts_vhb
     //    UInt_t ts_hb=0.;  // replaced by fts_hb
     UInt_t ts_lb = 0;
-    UInt_t tsExt_vhb = 0.;
-    UInt_t tsExt_hb = 0.;
+    UInt_t tsExt_vhb = 0;
+    UInt_t tsExt_hb = 0;
     UInt_t tsExt_lb = 0;
 
     uint32_t starN = data->sit_n; // not necessarly number of hits! (b/c multi hit)  = block size
@@ -147,6 +147,9 @@ Bool_t R3BStartrackReader::Read()
                     TSExt = ((uint64_t)tsExt_hb << 28) |
                             tsExt_lb; // Reconstructed timestamp from MSB (most significant bits) and sLSB (slightly
                                       // lower significant bits) for a startrack signal
+                // so, if either tsExt_vhb, tsExt_hb or tsExt_lb happen to be zero, TSExt will not be intialized.
+                // Otherwise, tsExt_vhb is ignored for the TS.
+                // if this is working as intended, I do not want to know anything more about it.
 
                 // Case of wordtype=3:
             }

--- a/startrack/unpack/B4Ucesb/R3BStartrackOrderTS.cxx
+++ b/startrack/unpack/B4Ucesb/R3BStartrackOrderTS.cxx
@@ -228,7 +228,7 @@ void R3BStartrackOrderTS::Exec(Option_t* option)
     R3BStartrackRawHit* item;
     R3BStartrackRawHit* item2;
 
-    int difflb, diff45, diff78;
+    int difflb = 0, diff45, diff78;
 
     Int_t nItems = fRawData->GetEntriesFast(); // returns the number of hits in the block
 

--- a/tof/R3BTofdCal2Histo.h
+++ b/tof/R3BTofdCal2Histo.h
@@ -19,8 +19,9 @@ class TClonesArray;
 class R3BEventHeader;
 class TH1F;
 class TH2F;
-
+#ifdef __CINT__
 #pragma link C++ class R3BTofdHitModulePar + ;
+#endif
 class R3BTofdCal2Histo : public FairTask
 {
 

--- a/tof/R3BTofdCal2HistoPar.h
+++ b/tof/R3BTofdCal2HistoPar.h
@@ -18,7 +18,9 @@ class R3BEventHeader;
 class TH1F;
 class TH2F;
 
+#ifdef __CINT__
 #pragma link C++ class R3BTofdHitModulePar + ;
+#endif
 class R3BTofdCal2HistoPar : public FairTask
 {
   public:

--- a/tof/R3BTofdCal2HitPar.cxx
+++ b/tof/R3BTofdCal2HitPar.cxx
@@ -195,7 +195,8 @@ void R3BTofdCal2HitPar::Exec(Option_t* option)
         return;
 
     Double_t timeLos = 0;
-    Double_t time_r_V, time_t_V, time_l_V, time_b_V, time_rt_V, time_lt_V, time_lb_V, time_rb_V;
+    Double_t time_r_V = nan(""), time_t_V = nan(""), time_l_V = nan(""), time_b_V = nan(""), time_rt_V = nan(""),
+             time_lt_V = nan(""), time_lb_V = nan(""), time_rb_V = nan("");
 
     // Los detector
     if (fCalItemsLos)

--- a/tof/R3BTofdCal2HitPar.h
+++ b/tof/R3BTofdCal2HitPar.h
@@ -37,7 +37,11 @@ class TH2F;
  * This class fills time differences of the 2 PMTs of every paddle
  * and calculates the calibration parameters.
  * M.Heil in May 2016
- */ #pragma link C++ class R3BTofdHitModulePar + ;
+ */
+#ifdef __CINT__
+// strange place for cint stuff, but whatever
+#pragma link C++ class R3BTofdHitModulePar + ;
+#endif 
 class R3BTofdCal2HitPar : public FairTask
 {
 

--- a/tof/R3BTofdChangePar.h
+++ b/tof/R3BTofdChangePar.h
@@ -19,7 +19,9 @@ class R3BEventHeader;
 class TH1F;
 class TH2F;
 
+#ifdef __CINT__
 #pragma link C++ class R3BTofdHitModulePar + ;
+#endif
 class R3BTofdChangePar : public FairTask
 {
 

--- a/tof/calibration/R3BPtofCal2Hit.cxx
+++ b/tof/calibration/R3BPtofCal2Hit.cxx
@@ -144,7 +144,7 @@ void R3BPtofCal2Hit::Exec(Option_t* option)
         R3BPaddleCalData* caldata = (R3BPaddleCalData*)fCalItems->At(i);
         Int_t iPlane = caldata->GetPlane() - 1;
         Int_t iBar = caldata->GetBar() - 1;
-
+        assert(iBar >= 0 && iBar < PtofPaddlesPerPlane);
         Int_t id = iPlane * PtofPaddlesPerPlane + iBar;
 
         Double_t t1 = caldata->fTime1L_ns + fTOffset1[id];
@@ -167,7 +167,7 @@ void R3BPtofCal2Hit::Exec(Option_t* option)
             zz[iPlane][iBar] = 10.;
         }
 
-        if (iBar + 1 == 40)
+        if (PtofPaddlesPerPlane >= 40 && iBar + 1 == 40)
         {
             LOG(ERROR) << "cal2hit: Plane: " << iPlane + 1 << "  Bar: " << iBar + 1 << "  t1= " << t1 << "  t2= " << t2;
             LOG(ERROR) << "cal2hit: xx: " << xx[iPlane][iBar] << "  charge: " << charge[iPlane][iBar];
@@ -177,7 +177,7 @@ void R3BPtofCal2Hit::Exec(Option_t* option)
     }
     for (Int_t iBar = 0; iBar < PtofPaddlesPerPlane; iBar++)
     {
-        if (iBar + 1 == 40)
+        if (PtofPaddlesPerPlane >= 40 && iBar + 1 == 40)
         {
             LOG(ERROR) << "Planne 1  Bar: " << iBar + 1 << "  charge: " << charge[0][iBar] << "  x: " << xx[0][iBar];
             LOG(ERROR) << "Planne 2  Bar: " << iBar + 1 << "  charge: " << charge[1][iBar] << "  x: " << xx[1][iBar];

--- a/tracker/R3BTarget2pDigitizer.cxx
+++ b/tracker/R3BTarget2pDigitizer.cxx
@@ -121,9 +121,9 @@ void R3BTarget2pDigitizer::Exec(Option_t* opt)
     Int_t TrackIdTra = 0;
     //     Int_t TrackId=0;
 
-    Double_t x0;
-    Double_t y0;
-    Double_t t0;
+    Double_t x0 = nan("");
+    Double_t y0 = nan("");
+    Double_t t0 = nan("");
 
     Int_t ss03_smul;
     Int_t ss03_kmul;
@@ -142,17 +142,17 @@ void R3BTarget2pDigitizer::Exec(Option_t* opt)
     Double_t Pyp2 = 0;
     Double_t Pzp2 = 0;
 
-    Double_t Pf_tot;
-    Double_t Pp1_tot;
-    Double_t Pp2_tot;
+    Double_t Pf_tot = nan("");
+    Double_t Pp1_tot = nan("");
+    Double_t Pp2_tot = nan("");
 
-    Double_t f_beta;
-    Double_t p1_beta;
-    Double_t p2_beta;
+    Double_t f_beta = nan("");
+    Double_t p1_beta = nan("");
+    Double_t p2_beta = nan("");
 
-    Double_t p2;
-    Double_t E2;
-    Double_t estar;
+    Double_t p2 = nan("");
+    Double_t E2 = nan("");
+    Double_t estar = nan("");
 
     // Todo: do those properly, maybe 15O+2p mass
     Double_t in_beta = 0.7579865;

--- a/tracker/R3BTargetDigitizer.cxx
+++ b/tracker/R3BTargetDigitizer.cxx
@@ -118,9 +118,9 @@ void R3BTargetDigitizer::Exec(Option_t* opt)
     Int_t TrackIdTra = 0;
     //     Int_t TrackId=0;
 
-    Double_t x0;
-    Double_t y0;
-    Double_t t0;
+    Double_t x0 = nan("");
+    Double_t y0 = nan("");
+    Double_t t0 = nan("");
 
     Int_t ss03_smul;
     Int_t ss03_kmul;
@@ -135,15 +135,15 @@ void R3BTargetDigitizer::Exec(Option_t* opt)
     Double_t Pyp1 = 0;
     Double_t Pzp1 = 0;
 
-    Double_t Pf_tot;
-    Double_t Pp1_tot;
+    Double_t Pf_tot = nan("");
+    Double_t Pp1_tot = nan("");
 
-    Double_t f_beta;
-    Double_t p1_beta;
+    Double_t f_beta = nan("");
+    Double_t p1_beta = nan("");
 
-    Double_t p2;
-    Double_t E2;
-    Double_t estar;
+    Double_t p2 = nan("");
+    Double_t E2 = nan("");
+    Double_t estar = nan("");
 
     //******************** Target **************************//
 

--- a/tracker/R3BTra2pDigitizer.cxx
+++ b/tracker/R3BTra2pDigitizer.cxx
@@ -106,53 +106,53 @@ void R3BTra2pDigitizer::Exec(Option_t* opt)
     Int_t TrackIdTra = 0;
     //     Int_t TrackId=0;
 
-    Double_t ss03_se_p1;
-    Double_t ss03_spos_p1;
-    Double_t ss03_sbw_p1;
-    Double_t ss03_sarea_p1;
-    Double_t ss03_seta_p1;
+    Double_t ss03_se_p1 = nan("");
+    Double_t ss03_spos_p1 = nan("");
+    Double_t ss03_sbw_p1 = nan("");
+    Double_t ss03_sarea_p1 = nan("");
+    Double_t ss03_seta_p1 = nan("");
 
-    Double_t ss03_ke_p1;
-    Double_t ss03_kpos_p1;
-    Double_t ss03_kbw_p1;
-    Double_t ss03_karea_p1;
-    Double_t ss03_keta_p1;
+    Double_t ss03_ke_p1 = nan("");
+    Double_t ss03_kpos_p1 = nan("");
+    Double_t ss03_kbw_p1 = nan("");
+    Double_t ss03_karea_p1 = nan("");
+    Double_t ss03_keta_p1 = nan("");
 
-    Double_t ss06_se_p1;
-    Double_t ss06_spos_p1;
-    Double_t ss06_sbw_p1;
-    Double_t ss06_sarea_p1;
-    Double_t ss06_seta_p1;
+    Double_t ss06_se_p1 = nan("");
+    Double_t ss06_spos_p1 = nan("");
+    Double_t ss06_sbw_p1 = nan("");
+    Double_t ss06_sarea_p1 = nan("");
+    Double_t ss06_seta_p1 = nan("");
 
-    Double_t ss06_ke_p1;
-    Double_t ss06_kpos_p1;
-    Double_t ss06_kbw_p1;
-    Double_t ss06_karea_p1;
-    Double_t ss06_keta_p1;
+    Double_t ss06_ke_p1 = nan("");
+    Double_t ss06_kpos_p1 = nan("");
+    Double_t ss06_kbw_p1 = nan("");
+    Double_t ss06_karea_p1 = nan("");
+    Double_t ss06_keta_p1 = nan("");
 
-    Double_t ss03_se_p2;
-    Double_t ss03_spos_p2;
-    Double_t ss03_sbw_p2;
-    Double_t ss03_sarea_p2;
-    Double_t ss03_seta_p2;
+    Double_t ss03_se_p2 = nan("");
+    Double_t ss03_spos_p2 = nan("");
+    Double_t ss03_sbw_p2 = nan("");
+    Double_t ss03_sarea_p2 = nan("");
+    Double_t ss03_seta_p2 = nan("");
 
-    Double_t ss03_ke_p2;
-    Double_t ss03_kpos_p2;
-    Double_t ss03_kbw_p2;
-    Double_t ss03_karea_p2;
-    Double_t ss03_keta_p2;
+    Double_t ss03_ke_p2 = nan("");
+    Double_t ss03_kpos_p2 = nan("");
+    Double_t ss03_kbw_p2 = nan("");
+    Double_t ss03_karea_p2 = nan("");
+    Double_t ss03_keta_p2 = nan("");
 
-    Double_t ss06_se_p2;
-    Double_t ss06_spos_p2;
-    Double_t ss06_sbw_p2;
-    Double_t ss06_sarea_p2;
-    Double_t ss06_seta_p2;
+    Double_t ss06_se_p2 = nan("");
+    Double_t ss06_spos_p2 = nan("");
+    Double_t ss06_sbw_p2 = nan("");
+    Double_t ss06_sarea_p2 = nan("");
+    Double_t ss06_seta_p2 = nan("");
 
-    Double_t ss06_ke_p2;
-    Double_t ss06_kpos_p2;
-    Double_t ss06_kbw_p2;
-    Double_t ss06_karea_p2;
-    Double_t ss06_keta_p2;
+    Double_t ss06_ke_p2 = nan("");
+    Double_t ss06_kpos_p2 = nan("");
+    Double_t ss06_kbw_p2 = nan("");
+    Double_t ss06_karea_p2 = nan("");
+    Double_t ss06_keta_p2 = nan("");
 
     //******************** SSTs **************************//
 

--- a/tracker/R3BTraDigitizer.cxx
+++ b/tracker/R3BTraDigitizer.cxx
@@ -105,53 +105,53 @@ void R3BTraDigitizer::Exec(Option_t* opt)
     Int_t TrackIdTra = 0;
     //     Int_t TrackId=0;
 
-    Double_t ss03_se_f;
-    Double_t ss03_spos_f;
-    Double_t ss03_sbw_f;
-    Double_t ss03_sarea_f;
-    Double_t ss03_seta_f;
+    Double_t ss03_se_f = nan("");
+    Double_t ss03_spos_f = nan("");
+    Double_t ss03_sbw_f = nan("");
+    Double_t ss03_sarea_f = nan("");
+    Double_t ss03_seta_f = nan("");
 
-    Double_t ss03_ke_f;
-    Double_t ss03_kpos_f;
-    Double_t ss03_kbw_f;
-    Double_t ss03_karea_f;
-    Double_t ss03_keta_f;
+    Double_t ss03_ke_f = nan("");
+    Double_t ss03_kpos_f = nan("");
+    Double_t ss03_kbw_f = nan("");
+    Double_t ss03_karea_f = nan("");
+    Double_t ss03_keta_f = nan("");
 
-    Double_t ss06_se_f;
-    Double_t ss06_spos_f;
-    Double_t ss06_sbw_f;
-    Double_t ss06_sarea_f;
-    Double_t ss06_seta_f;
+    Double_t ss06_se_f = nan("");
+    Double_t ss06_spos_f = nan("");
+    Double_t ss06_sbw_f = nan("");
+    Double_t ss06_sarea_f = nan("");
+    Double_t ss06_seta_f = nan("");
 
-    Double_t ss06_ke_f;
-    Double_t ss06_kpos_f;
-    Double_t ss06_kbw_f;
-    Double_t ss06_karea_f;
-    Double_t ss06_keta_f;
+    Double_t ss06_ke_f = nan("");
+    Double_t ss06_kpos_f = nan("");
+    Double_t ss06_kbw_f = nan("");
+    Double_t ss06_karea_f = nan("");
+    Double_t ss06_keta_f = nan("");
 
-    Double_t ss03_se_p1;
-    Double_t ss03_spos_p1;
-    Double_t ss03_sbw_p1;
-    Double_t ss03_sarea_p1;
-    Double_t ss03_seta_p1;
+    Double_t ss03_se_p1 = nan("");
+    Double_t ss03_spos_p1 = nan("");
+    Double_t ss03_sbw_p1 = nan("");
+    Double_t ss03_sarea_p1 = nan("");
+    Double_t ss03_seta_p1 = nan("");
 
-    Double_t ss03_ke_p1;
-    Double_t ss03_kpos_p1;
-    Double_t ss03_kbw_p1;
-    Double_t ss03_karea_p1;
-    Double_t ss03_keta_p1;
+    Double_t ss03_ke_p1 = nan("");
+    Double_t ss03_kpos_p1 = nan("");
+    Double_t ss03_kbw_p1 = nan("");
+    Double_t ss03_karea_p1 = nan("");
+    Double_t ss03_keta_p1 = nan("");
 
-    Double_t ss06_se_p1;
-    Double_t ss06_spos_p1;
-    Double_t ss06_sbw_p1;
-    Double_t ss06_sarea_p1;
-    Double_t ss06_seta_p1;
+    Double_t ss06_se_p1 = nan("");
+    Double_t ss06_spos_p1 = nan("");
+    Double_t ss06_sbw_p1 = nan("");
+    Double_t ss06_sarea_p1 = nan("");
+    Double_t ss06_seta_p1 = nan("");
 
-    Double_t ss06_ke_p1;
-    Double_t ss06_kpos_p1;
-    Double_t ss06_kbw_p1;
-    Double_t ss06_karea_p1;
-    Double_t ss06_keta_p1;
+    Double_t ss06_ke_p1 = nan("");
+    Double_t ss06_kpos_p1 = nan("");
+    Double_t ss06_kbw_p1 = nan("");
+    Double_t ss06_karea_p1 = nan("");
+    Double_t ss06_keta_p1 = nan("");
 
     //******************** SSTs **************************//
 

--- a/tracker/R3BTraFraDigitizer.cxx
+++ b/tracker/R3BTraFraDigitizer.cxx
@@ -107,25 +107,25 @@ void R3BTraFraDigitizer::Exec(Option_t* opt)
     // Int_t TrackId=0;
 
     Double_t ss03_se_f;
-    Double_t ss03_spos_f;
+    Double_t ss03_spos_f = nan("");
     Double_t ss03_sbw_f;
     Double_t ss03_sarea_f;
     Double_t ss03_seta_f;
 
     Double_t ss03_ke_f;
-    Double_t ss03_kpos_f;
+    Double_t ss03_kpos_f = nan("");
     Double_t ss03_kbw_f;
     Double_t ss03_karea_f;
     Double_t ss03_keta_f;
 
     Double_t ss06_se_f;
-    Double_t ss06_spos_f;
+    Double_t ss06_spos_f = nan("");
     Double_t ss06_sbw_f;
     Double_t ss06_sarea_f;
     Double_t ss06_seta_f;
 
     Double_t ss06_ke_f;
-    Double_t ss06_kpos_f;
+    Double_t ss06_kpos_f = nan("");
     Double_t ss06_kbw_f;
     Double_t ss06_karea_f;
     Double_t ss06_keta_f;

--- a/tracker/R3BTraHitFinder.cxx
+++ b/tracker/R3BTraHitFinder.cxx
@@ -85,7 +85,7 @@ void R3BTraHitFinder::Exec(Option_t* opt)
     Int_t strip = 0;
     Int_t StripA_Id = 0;
     Int_t StripB_Id = 0;
-    Double_t SlopA, SlopB, OffsetA, OffsetB;
+    Double_t SlopA, SlopB, OffsetA = nan(""), OffsetB = nan("");
 
     // Middle layer
     Double_t Length2 = 30.06;                      // cm
@@ -1011,22 +1011,7 @@ Double_t R3BTraHitFinder::GetThetaScatZero(Double_t X, Double_t Y, Double_t Z)
 }
 
 // -----   Private method GetPhiScatZero  --------------------------------------------
-Double_t R3BTraHitFinder::GetPhiScatZero(Double_t X, Double_t Y, Double_t Z)
-{
-
-    Double_t Phi;
-
-    if (X > 0 && Y > 0)
-        Phi = atan(Y / X);
-    if (X < 0 && Y >= 0)
-        Phi = TMath::Pi() + atan(Y / X);
-    if (X < 0 && Y < 0)
-        Phi = -TMath::Pi() + atan(Y / X);
-    if (X > 0 && Y <= 0)
-        Phi = atan(Y / X);
-
-    return Phi;
-}
+Double_t R3BTraHitFinder::GetPhiScatZero(Double_t X, Double_t Y, Double_t Z) { return atan2(Y, X); }
 
 // -----   Private method AddHit  --------------------------------------------
 R3BTrackerHit* R3BTraHitFinder::AddHit(Double_t ene,

--- a/tracking/R3BTrackingSetup.h
+++ b/tracking/R3BTrackingSetup.h
@@ -23,7 +23,7 @@ class R3BTrackingSetup
 {
   public:
     R3BTrackingSetup();
-    ~R3BTrackingSetup();
+    virtual ~R3BTrackingSetup();
 
     void AddDetector(const std::string& name,
                      EDetectorType type,

--- a/travis-clang-format-check.sh
+++ b/travis-clang-format-check.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+test "$1" == "--autofix" && AUTOFIX=1 && shift
 
 CLANG_FORMAT=${1:-clang-format}
 
@@ -21,11 +22,17 @@ fi
 
 filesToCheck="$(git diff --name-only ${base_commit} | grep -e '.(\.C\|\.cpp\|\.cxx\|\.h)$' || true)"
 for f in $filesToCheck; do
-    echo "  Checking: ${f}"
-    d=$(diff -u "$f" <($CLANG_FORMAT -style=file "$f") || true)
-    if ! [ -z "$d" ]; then
-        echo "$d"
-        fail=1
+    if test -n "$AUTOFIX"
+    then
+	echo "fixing $f, if needed." 
+	$CLANG_FORMAT -i -style=file "$f"
+    else
+	echo "  Checking: ${f}"
+	d=$(diff -u "$f" <($CLANG_FORMAT -style=file "$f") || true)
+	if ! [ -z "$d" ]; then
+            echo "$d"
+            fail=1
+	fi
     fi
 done
 

--- a/travis-generate-dockerfile-buildonly.sh
+++ b/travis-generate-dockerfile-buildonly.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export WERROR=1
+export BUILDONLY=1
+exec $(dirname $0)/travis-generate-dockerfile.sh

--- a/travis-generate-dockerfile.sh
+++ b/travis-generate-dockerfile.sh
@@ -1,8 +1,13 @@
+#!/bin/bash
+# WERROR and BUILDONLY are enabled by the wrapper script travis-...-buildonly.sh
+# by default, they are "", which disables them.
 echo "FROM fairroot:${FAIRROOT_VERSION}_${FAIRSOFT_VERSION}_ubuntu
 MAINTAINER Dmytro Kresan <d.kresan@gsi.de>
 ENTRYPOINT cd /root/R3BRoot && git clone https://github.com/R3BRootGroup/macros.git && \\
 cd macros && git checkout dev && cd /root && \\
 echo 'export LINUX_FLAVOUR=Ubuntu-16.04\n\\
+export WERROR=${WERROR:-NO}\n\\
+export BUILDONLY=${BUILDONLY:-NO}\n\\
 export FAIRSOFT_VERSION=${FAIRSOFT_VERSION}\n\\
 export FAIRROOT_VERSION=v${FAIRROOT_VERSION}\n\\
 export SIMPATH=/root/FairSoft/\${FAIRSOFT_VERSION}/build\n\\


### PR DESCRIPTION
While I welcome enforcing formatting rules, I believe we can do even better. 

To that end, I added the gcc -Werror flag (minus sign-compare, reorder, unused*) to the default flags.

It can be disabled by setting export NO_WERROR=1 in the shell, so it should not break icc and the like. 

Also I took care of the warnings. 
Some of them clearly indicated bugs (e.g. for (Int_t i; i<4; i++), some are mostly harmless (a #pragma link C++ where gcc can see it). 

Potential use of undefined variable was a very common theme. 

Typically:

double d;
for (...)
   if (...)
      d=...;
For doubles, I generally initialized them nan. For non-negative integers, I initialized them to -1 and mostly assert()ed after the loop that they were assigned. 

Cheers,
   Philipp
