### PR TITLE
Added CALIFA online for the experiments of 2020

### DIFF
--- a/califa/CMakeLists.txt
+++ b/califa/CMakeLists.txt
@@ -57,12 +57,13 @@ R3BCalifaHitPar.cxx
 R3BCalifaMappingPar.cxx
 R3BCalifaContFact.cxx
 R3BCalifaDigitizer.cxx
+R3BCalifaOnlineSpectra.cxx
 unpack/R3BCalifaMapped2CrystalCal.cxx
 unpack/R3BCalifaCrystalCalDataAnalysis.cxx
 unpack/R3BCalifaMapped2CrystalCalPar.cxx
 unpack/R3BCalifaCrystalCal2CrystalCalPID.cxx
 unpack/R3BCalifaCrystalCalPar.cxx
-unpack/R3BCalifaOnlineSpectra.cxx
+unpack/R3BCalifaDemoOnlineSpectra.cxx
 #unpack/R3BCalifaDUCalPar.cxx
 )
 

--- a/califa/CalifaLinkDef.h
+++ b/califa/CalifaLinkDef.h
@@ -29,6 +29,7 @@
 #pragma link C++ class R3BCalifaCrystalCal2CrystalCalPID+;
 #pragma link C++ class R3BCalifaCrystalCalPar+;
 #pragma link C++ class R3BCalifaOnlineSpectra+;
+#pragma link C++ class R3BCalifaDemoOnlineSpectra+;
 #pragma link C++ class R3BCalifaDigitizer+;
 //#pragma link C++ class R3BCalifaDUCalPar+;
 

--- a/califa/R3BCalifaCrystalCal2Hit.cxx
+++ b/califa/R3BCalifaCrystalCal2Hit.cxx
@@ -42,18 +42,19 @@ R3BCalifaCrystalCal2Hit::R3BCalifaCrystalCal2Hit()
     : FairTask("R3B CALIFA CrystalCal to Hit Finder")
     , fCrystalHitCA(NULL)
     , fCalifaHitCA(NULL)
+    , fGeometryVersion(2020) // BARREL+iPhos
+    , fThreshold(0.)         // no threshold
+    , fDRThreshold(15000)    // in keV, for real data (15000 = 15MeV)
+    , fDeltaPolar(0.25)
+    , fDeltaAzimuthal(0.25)
+    , fDeltaAngleClust(0)
+    , fClusterAlgorithmSelector(RECT)
+    , fParCluster1(0)
+    , fCalifaGeo(NULL)
+    , fNbCrystalsGammaRange(2432) // during 2019 it was 5000
     , fOnline(kFALSE)
 {
-    fGeometryVersion = 2020; // BARREL+iPhos
-    fThreshold = 0.;         // no threshold
-    fDRThreshold = 15000;    // in keV, for real data (15000 = 15MeV)
-    fDeltaPolar = 0.25;
-    fDeltaAzimuthal = 0.25;
-    fDeltaAngleClust = 0;
-    fClusterAlgorithmSelector = RECT;
-    fParCluster1 = 0;
-    fCalifaGeo = NULL;
-    SetSquareWindowAlg(0.25, 0.25);
+    SetSquareWindowAlg(fDeltaPolar, fDeltaAzimuthal);
 }
 
 R3BCalifaCrystalCal2Hit::~R3BCalifaCrystalCal2Hit()
@@ -209,16 +210,16 @@ void R3BCalifaCrystalCal2Hit::Exec(Option_t* opt)
         LOG(DEBUG) << "R3BCalifaCrystalCal2Hit::Exec():  crystalId2Pos.size()=" << crystalId2Pos.size();
 
         for (auto& k1 : crystalId2Pos) // k1: lower id, gamma branch?
-            if (crystalId2Pos.count(k1.first + 5000))
+            if (crystalId2Pos.count(k1.first + fNbCrystalsGammaRange))
             {
-                auto proton = *crystalId2Pos.find(k1.first + 5000);
+                auto proton = *crystalId2Pos.find(k1.first + fNbCrystalsGammaRange);
                 // k2: higher id, proton branch
                 if (proton.second->GetEnergy() < fDRThreshold)
                     addHit(k1.second); // gamma
                 else
                     addHit(proton.second);
             }
-            else if (!crystalId2Pos.count(k1.first - 5000))
+            else if (!crystalId2Pos.count(k1.first - fNbCrystalsGammaRange))
                 // not a hit where two ranges were hit
                 addHit(k1.second);
     }

--- a/califa/R3BCalifaCrystalCal2Hit.h
+++ b/califa/R3BCalifaCrystalCal2Hit.h
@@ -161,14 +161,15 @@ class R3BCalifaCrystalCal2Hit : public FairTask
     TClonesArray* fCrystalHitCA;
     TClonesArray* fCalifaHitCA;
 
-    Bool_t fOnline;            // Selector for online data storage
-    Int_t fGeometryVersion;    // Selecting the geometry of the CALIFA calorimeter
-    Double_t fDeltaPolar;      // Angular window (polar angle)
-    Double_t fDeltaAzimuthal;  // Angular window (azimuthal angle)
-    Double_t fDeltaAngleClust; // Angular opening used for the cluster condition
-    Double_t fParCluster1;     // Clustering parameter 1
-    Double_t fThreshold;       // Minimum energy requested in a crystal to be included in a Cal
-    Double_t fDRThreshold;     // Threshold for selecting gamma or proton branch in double reading channels
+    Bool_t fOnline;              // Selector for online data storage
+    Int_t fGeometryVersion;      // Selecting the geometry of the CALIFA calorimeter
+    Int_t fNbCrystalsGammaRange; // Define max. number of crystals with gamma range
+    Double_t fDeltaPolar;        // Angular window (polar angle)
+    Double_t fDeltaAzimuthal;    // Angular window (azimuthal angle)
+    Double_t fDeltaAngleClust;   // Angular opening used for the cluster condition
+    Double_t fParCluster1;       // Clustering parameter 1
+    Double_t fThreshold;         // Minimum energy requested in a crystal to be included in a Cal
+    Double_t fDRThreshold;       // Threshold for selecting gamma or proton branch in double reading channels
     Double_t energyFactor;
 
     // Clustering algorithm selector

--- a/califa/R3BCalifaGeometry.h
+++ b/califa/R3BCalifaGeometry.h
@@ -31,7 +31,7 @@ class R3BCalifaGeometry : public TObject
     /** Standard constructor.
      *@param version geonetry version
      */
-    R3BCalifaGeometry(int version);
+    R3BCalifaGeometry(Int_t version);
 
     /** Destructor **/
     ~R3BCalifaGeometry();
@@ -62,7 +62,7 @@ class R3BCalifaGeometry : public TObject
      * @param iD crystal ID (depending on geometry version)
      * @return Volume path
      */
-    const char* GetCrystalVolumePath(int iD);
+    const char* GetCrystalVolumePath(Int_t iD);
 
     /**
      * Gets crystal ID for given volume path.
@@ -95,8 +95,8 @@ class R3BCalifaGeometry : public TObject
     double GetDistanceThroughCrystals(TVector3& startVertex,
                                       TVector3& direction,
                                       TVector3* hitPos = NULL,
-                                      int* numCrystals = NULL,
-                                      int* crystalIds = NULL);
+                                      Int_t* numCrystals = NULL,
+                                      Int_t* crystalIds = NULL);
 
     /**
      * Returns singleton instance of R3BCalifaGeometry for given geometry version.
@@ -105,10 +105,11 @@ class R3BCalifaGeometry : public TObject
      * @param version Geometry version to use. If in doubt, use 2020.
      * @return Instance of R3BCalifaGeometry
      */
-    static R3BCalifaGeometry* Instance(int version);
+    static R3BCalifaGeometry* Instance(Int_t version);
 
   private:
-    int fGeometryVersion;
+    Int_t fGeometryVersion;
+    Int_t fNumCrystals;
     static R3BCalifaGeometry* inst;
 
     ClassDef(R3BCalifaGeometry, 5);

--- a/califa/R3BCalifaOnlineSpectra.cxx
+++ b/califa/R3BCalifaOnlineSpectra.cxx
@@ -1,0 +1,910 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "R3BCalifaOnlineSpectra.h"
+#include "R3BCalifaCrystalCalData.h"
+#include "R3BCalifaHitData.h"
+#include "R3BCalifaMappedData.h"
+#include "R3BCalifaMappingPar.h"
+#include "R3BEventHeader.h"
+#include "THttpServer.h"
+
+#include "FairLogger.h"
+#include "FairRootManager.h"
+#include "FairRunAna.h"
+#include "FairRunOnline.h"
+#include "FairRuntimeDb.h"
+#include "TCanvas.h"
+#include "TFolder.h"
+#include "TH1F.h"
+#include "TH2F.h"
+
+#include "TClonesArray.h"
+#include "TMath.h"
+#include "TRandom.h"
+#include <array>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+using namespace std;
+
+R3BCalifaOnlineSpectra::R3BCalifaOnlineSpectra()
+    : FairTask("CALIFAOnlineSpectra", 1)
+    , fMappedItemsCalifa(NULL)
+    , fCalItemsCalifa(NULL)
+    , fHitItemsCalifa(NULL)
+    , fMap_Par(NULL)
+    , fNEvents(0)
+    , fNbCalifaCrystals(4864)
+    , fNumSides(Nb_Sides)
+    , fNumRings(Nb_Rings)
+    , fNumPreamps(Nb_Preamps)
+    , fNumCrystalPreamp(Nb_PreampCh)
+    , fMapHistos_bins(500)
+    , fMapHistos_max(4000)
+    , fBinsChannelFebex(5000)
+    , fMaxBinChannelFebex(65535)
+    , fMaxEnergyBarrel(10)
+    , fMaxEnergyIphos(30)
+    , fRaw2Cal(kFALSE)
+    , fLogScale(kTRUE)
+    , fFebex2Preamp(kTRUE)
+    , fCalON(kTRUE)
+{
+}
+
+R3BCalifaOnlineSpectra::R3BCalifaOnlineSpectra(const TString& name, Int_t iVerbose)
+    : FairTask(name, iVerbose)
+    , fMappedItemsCalifa(NULL)
+    , fCalItemsCalifa(NULL)
+    , fHitItemsCalifa(NULL)
+    , fMap_Par(NULL)
+    , fNEvents(0)
+    , fNbCalifaCrystals(4864)
+    , fNumSides(Nb_Sides)
+    , fNumRings(Nb_Rings)
+    , fNumPreamps(Nb_Preamps)
+    , fNumCrystalPreamp(Nb_PreampCh)
+    , fMapHistos_bins(500)
+    , fMapHistos_max(4000)
+    , fBinsChannelFebex(5000)
+    , fMaxBinChannelFebex(65535)
+    , fMaxEnergyBarrel(10)
+    , fMaxEnergyIphos(30)
+    , fRaw2Cal(kFALSE)
+    , fLogScale(kTRUE)
+    , fFebex2Preamp(kTRUE)
+    , fCalON(kTRUE)
+{
+}
+
+R3BCalifaOnlineSpectra::~R3BCalifaOnlineSpectra()
+{
+    LOG(INFO) << "R3BCalifaOnlineSpectra: Delete instance";
+    if (fMappedItemsCalifa)
+        delete fMappedItemsCalifa;
+    if (fCalItemsCalifa)
+        delete fCalItemsCalifa;
+    if (fHitItemsCalifa)
+        delete fHitItemsCalifa;
+}
+
+void R3BCalifaOnlineSpectra::SetParContainers()
+{
+    // Parameter Container
+    // Reading amsStripCalPar from FairRuntimeDb
+    FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+    if (!rtdb)
+    {
+        LOG(ERROR) << "FairRuntimeDb not opened!";
+    }
+
+    fMap_Par = (R3BCalifaMappingPar*)rtdb->getContainer("califaMappingPar");
+    if (!fMap_Par)
+    {
+        LOG(ERROR) << "R3BCalifaOnlineSpectra::Couldn't get handle on califaMappingPar container";
+    }
+    else
+    {
+        LOG(INFO) << "R3BCalifaOnlineSpectra::CalifaMappingPar container open";
+    }
+}
+
+void R3BCalifaOnlineSpectra::SetParameter()
+{
+    if (!fMap_Par)
+    {
+        LOG(ERROR) << "R3BCalifaOnlineSpectra::CalifaMappingPar container not found";
+    }
+    //--- Parameter Container ---
+    fNbCalifaCrystals = fMap_Par->GetNumCrystals(); // Number of crystals x 2
+    LOG(INFO) << "R3BCalifaOnlineSpectra::NumCry " << fNbCalifaCrystals;
+    // fMap_Par->printParams();
+}
+
+InitStatus R3BCalifaOnlineSpectra::Init()
+{
+    LOG(INFO) << "R3BCalifaOnlineSpectra::Init ";
+
+    // try to get a handle on the EventHeader. EventHeader may not be
+    // present though and hence may be null. Take care when using.
+
+    FairRootManager* mgr = FairRootManager::Instance();
+    if (NULL == mgr)
+        LOG(FATAL) << "R3BCalifaOnlineSpectra::Init FairRootManager not found";
+
+    // Define Preamp sequence for histograms
+    Int_t PreampOrder[Nb_PreampCh];
+    PreampOrder[0] = 6;
+    PreampOrder[1] = 5;
+    PreampOrder[2] = 4;
+    PreampOrder[3] = 3;
+    PreampOrder[4] = 2;
+    PreampOrder[5] = 1;
+    PreampOrder[6] = 0;
+    PreampOrder[7] = 7;
+    PreampOrder[8] = 8;
+    PreampOrder[9] = 15;
+    PreampOrder[10] = 14;
+    PreampOrder[11] = 13;
+    PreampOrder[12] = 12;
+    PreampOrder[13] = 11;
+    PreampOrder[14] = 10;
+    PreampOrder[15] = 9;
+
+    for (Int_t i = 0; i < Nb_PreampCh; i++)
+    {
+        fOrderFebexPreamp[i] = PreampOrder[i];
+    }
+
+    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    FairRunOnline* run = FairRunOnline::Instance();
+    run->GetHttpServer()->Register("", this);
+
+    // get access to Mapped data
+    fMappedItemsCalifa = (TClonesArray*)mgr->GetObject("CalifaMappedData");
+    if (!fMappedItemsCalifa)
+    {
+        LOG(WARNING) << "R3BCalifaOnlineSpectra::CalifaCrystalMappedData not found";
+        return kFATAL;
+    }
+
+    // get access to Cal data
+    fCalItemsCalifa = (TClonesArray*)mgr->GetObject("CalifaCrystalCalData");
+    if (!fCalItemsCalifa)
+    {
+        LOG(WARNING) << "R3BCalifaOnlineSpectra::CalifaCrystalCalData not found";
+        fCalON = kFALSE;
+    }
+
+    // get access to Hit data
+    fHitItemsCalifa = (TClonesArray*)mgr->GetObject("CalifaHitData");
+    if (!fHitItemsCalifa)
+    {
+        LOG(WARNING) << "R3BCalifaOnlineSpectra::CalifaHitData not found";
+    }
+
+    SetParameter();
+
+    /*   // reading the file
+           Bool_t noFile = kFALSE;
+           ifstream* FileHistos = new ifstream(fCalifaFile);
+           if (!FileHistos->is_open())
+           {
+               LOG(WARNING) << "R3BCalifaOnlineSpectra:  No Histogram definition file";
+               noFile = kTRUE;
+           }
+
+           Double_t arry_bins[fNumRings * fNumPreamps * fNumCrystalPreamp];
+           Double_t arry_maxE[fNumRings * fNumPreamps * fNumCrystalPreamp];
+           Double_t arry_minE[fNumRings * fNumPreamps * fNumCrystalPreamp];
+
+           Double_t bins = fMapHistos_bins;
+           Double_t maxE = fMapHistos_max;
+           Double_t minE = 0.;
+
+           if (!noFile)
+           {
+               for (Int_t i = 0; i < fNumRings * fNumPreamps * fNumCrystalPreamp; i++)
+               {
+                   *FileHistos >> arry_bins[i] >> arry_minE[i] >> arry_maxE[i];
+               }
+           }
+           else
+           {
+               for (Int_t i = 0; i < fNumRings * fNumPreamps * fNumCrystalPreamp; i++)
+               {
+                   arry_bins[i] = fMapHistos_bins;
+                   arry_minE[i] = 0;
+                   arry_maxE[i] = fMapHistos_max;
+               }
+           }
+   */
+    // Create histograms for detectors
+    char Name1[255];
+    char Name2[255];
+    char Name3[255];
+    char Name4[255];
+    TString Xaxis;
+    Double_t bins = fMapHistos_bins;
+    Double_t maxE = fMapHistos_max;
+    Double_t minE = 0.;
+
+    // CANVAS Crystal_ID vs energy
+    cCalifa_cry_energy = new TCanvas("Califa_Map_cryID_energy", "Califa_Map energy vs cryID", 10, 10, 500, 500);
+    fh2_Califa_cryId_energy = new TH2F("fh2_Califa_Map_cryID_energy",
+                                       "Califa: CryID vs energy",
+                                       fMap_Par->GetNumCrystals(),
+                                       0.5,
+                                       fMap_Par->GetNumCrystals() + 0.5,
+                                       fBinsChannelFebex,
+                                       0.0,
+                                       fMaxBinChannelFebex);
+    fh2_Califa_cryId_energy->GetXaxis()->SetTitle("Crystal ID");
+    fh2_Califa_cryId_energy->GetYaxis()->SetTitle("Energy [Channels]");
+    fh2_Califa_cryId_energy->GetYaxis()->SetTitleOffset(1.4);
+    fh2_Califa_cryId_energy->GetXaxis()->CenterTitle(true);
+    fh2_Califa_cryId_energy->GetYaxis()->CenterTitle(true);
+    gPad->SetLogz();
+    fh2_Califa_cryId_energy->Draw("COLZ");
+
+    // CANVAS Crystal_ID vs energy
+    cCalifa_cry_energy_cal = new TCanvas("Califa_Cal_cryID_energy", "Califa_Cal energy vs cryID", 10, 10, 500, 500);
+    fh2_Califa_cryId_energy_cal = new TH2F("fh2_Califa_Cal_cryID_energy",
+                                           "Califa: CryID vs calibrated energy",
+                                           fMap_Par->GetNumCrystals(),
+                                           0.5,
+                                           fMap_Par->GetNumCrystals() + 0.5,
+                                           bins,
+                                           minE,
+                                           maxE);
+    fh2_Califa_cryId_energy_cal->GetXaxis()->SetTitle("Crystal ID");
+    fh2_Califa_cryId_energy_cal->GetYaxis()->SetTitle("Energy [keV]");
+    fh2_Califa_cryId_energy_cal->GetYaxis()->SetTitleOffset(1.4);
+    fh2_Califa_cryId_energy_cal->GetXaxis()->CenterTitle(true);
+    fh2_Califa_cryId_energy_cal->GetYaxis()->CenterTitle(true);
+    gPad->SetLogz();
+    fh2_Califa_cryId_energy_cal->Draw("COLZ");
+
+    // Map data
+    for (Int_t i = 0; i < fNumRings; i++)
+    {
+        // Left side
+        sprintf(Name1, "Ring_%d_Left", i + 1);
+        cMap_RingL[i] = new TCanvas(Name1, Name1, 10, 10, 800, 700);
+
+        sprintf(Name1, "fh2_Ring_%d_Left", i + 1);
+        sprintf(Name2, "Ring %d left: Preamp number vs channel number", i + 1);
+        fh2_Preamp_vs_ch_L[i] = new TH2F(
+            Name1, Name2, fNumPreamps, 0.5, fNumPreamps + 0.5, fNumCrystalPreamp, 0.5, fNumCrystalPreamp + 0.5);
+        sprintf(Name3, "Channel number [1-%d]", fNumCrystalPreamp);
+        fh2_Preamp_vs_ch_L[i]->GetXaxis()->SetTitle("Preamp number [1-16]");
+        fh2_Preamp_vs_ch_L[i]->GetYaxis()->SetTitle(Name3);
+        fh2_Preamp_vs_ch_L[i]->GetYaxis()->SetTitleOffset(1.2);
+        fh2_Preamp_vs_ch_L[i]->GetXaxis()->CenterTitle(true);
+        fh2_Preamp_vs_ch_L[i]->GetYaxis()->CenterTitle(true);
+        fh2_Preamp_vs_ch_L[i]->Draw("colz");
+
+        // Right side
+        sprintf(Name1, "Ring_%d_Right", i + 1);
+        cMap_RingR[i] = new TCanvas(Name1, Name1, 10, 10, 800, 700);
+
+        sprintf(Name1, "fh2_Ring_%d_Right", i + 1);
+        sprintf(Name2, "Ring %d right: Preamp number vs channel number", i + 1);
+        fh2_Preamp_vs_ch_R[i] = new TH2F(
+            Name1, Name2, fNumPreamps, 0.5, fNumPreamps + 0.5, fNumCrystalPreamp, 0.5, fNumCrystalPreamp + 0.5);
+        fh2_Preamp_vs_ch_R[i]->GetXaxis()->SetTitle("Preamp number [1-16]");
+        fh2_Preamp_vs_ch_R[i]->GetYaxis()->SetTitle(Name3);
+        fh2_Preamp_vs_ch_R[i]->GetYaxis()->SetTitleOffset(1.2);
+        fh2_Preamp_vs_ch_R[i]->GetXaxis()->CenterTitle(true);
+        fh2_Preamp_vs_ch_R[i]->GetYaxis()->CenterTitle(true);
+        fh2_Preamp_vs_ch_R[i]->Draw("colz");
+    }
+
+    char Side[255];
+
+    for (Int_t s = 0; s < fNumSides; s++) // Side
+    {
+        if (s == 1)
+            sprintf(Side, "Left");
+        else
+            sprintf(Side, "Right");
+        for (Int_t r = 0; r < fNumRings; r++)       // Ring
+            for (Int_t p = 0; p < fNumPreamps; p++) // Preamp
+            {
+                sprintf(Name1, "Ring_%d_%s_Preamp_%d", r + 1, Side, p + 1);
+                sprintf(Name2, "Ring %d, %s side, Preamp %d", r + 1, Side, p + 1);
+                cMapCry[s][r][p] = new TCanvas(Name1, Name2, 10, 10, 500, 500);
+                cMapCry[s][r][p]->Divide(4, 4);
+
+                sprintf(Name1, "Ring_%d_%s_Preamp_%d_pr", r + 1, Side, p + 1);
+                sprintf(Name2, "Ring %d, %s side, Preamp %d for PR", r + 1, Side, p + 1);
+                cMapCryP[s][r][p] = new TCanvas(Name1, Name2, 10, 10, 500, 500);
+                cMapCryP[s][r][p]->Divide(4, 4);
+
+                for (Int_t j = 0; j < fNumCrystalPreamp; j++)
+                { // Channel
+                    Xaxis = "Energy [channels]";
+
+                    sprintf(Name1, "fh1_Map_Side_%s_Ring_%d_Preamp_%d_Ch_%d_energy", Side, r + 1, p + 1, j);
+                    sprintf(Name2, "Map level, Side %s Ring %d, Preamp %d, ch. %d", Side, r + 1, p + 1, j);
+
+                    fh1_crystals[s][r][p][j] = new TH1F(Name1, Name2, fBinsChannelFebex, 0, fMaxBinChannelFebex);
+                    fh1_crystals[s][r][p][j]->SetTitleSize(1.6, "t");
+                    fh1_crystals[s][r][p][j]->GetXaxis()->SetTitle(Xaxis);
+                    fh1_crystals[s][r][p][j]->GetXaxis()->SetLabelSize(0.06);
+                    fh1_crystals[s][r][p][j]->GetYaxis()->SetLabelSize(0.07);
+                    fh1_crystals[s][r][p][j]->GetXaxis()->SetTitleSize(0.05);
+                    fh1_crystals[s][r][p][j]->GetXaxis()->CenterTitle(true);
+                    fh1_crystals[s][r][p][j]->GetYaxis()->CenterTitle(true);
+                    fh1_crystals[s][r][p][j]->GetXaxis()->SetTitleOffset(1.);
+                    fh1_crystals[s][r][p][j]->SetFillColor(kGreen);
+                    cMapCry[s][r][p]->cd(j + 1);
+                    gPad->SetLogy();
+                    fh1_crystals[s][r][p][j]->Draw();
+
+                    if (r == 4)
+                    { // histograms for proton range
+                        sprintf(Name1, "fh1_Map_Side_%s_Ring_%d_Preamp_%d_Ch_%d_energy_pr", Side, r + 1, p + 1, j);
+                        sprintf(Name2, "Map level (PR), Side %s Ring %d, Preamp %d, ch. %d", Side, r + 1, p + 1, j);
+                        fh1_crystals_p[s][r][p][j] = new TH1F(Name1, Name2, fBinsChannelFebex, 0, fMaxBinChannelFebex);
+                        fh1_crystals_p[s][r][p][j]->SetTitleSize(1.6, "t");
+                        fh1_crystals_p[s][r][p][j]->GetXaxis()->SetTitle(Xaxis);
+                        fh1_crystals_p[s][r][p][j]->GetXaxis()->SetLabelSize(0.06);
+                        fh1_crystals_p[s][r][p][j]->GetYaxis()->SetLabelSize(0.07);
+                        fh1_crystals_p[s][r][p][j]->GetXaxis()->SetTitleSize(0.05);
+                        fh1_crystals_p[s][r][p][j]->GetXaxis()->CenterTitle(true);
+                        fh1_crystals_p[s][r][p][j]->GetYaxis()->CenterTitle(true);
+                        fh1_crystals_p[s][r][p][j]->GetXaxis()->SetTitleOffset(1.);
+                        fh1_crystals_p[s][r][p][j]->SetFillColor(kGreen);
+                        cMapCryP[s][r][p]->cd(j + 1);
+                        gPad->SetLogy();
+                        fh1_crystals_p[s][r][p][j]->Draw();
+                    }
+                }
+            }
+    }
+
+    // Cal data
+    for (Int_t s = 0; s < fNumSides; s++) // Side
+    {
+        if (s == 1)
+            sprintf(Side, "Left");
+        else
+            sprintf(Side, "Right");
+        for (Int_t r = 0; r < fNumRings; r++) // Ring
+
+            for (Int_t p = 0; p < fNumPreamps; p++) // Preamp
+            {
+                sprintf(Name1, "Ring_%d_%s_Preamp_%d_cal", r + 1, Side, p + 1);
+                sprintf(Name2, "Ring %d, %s side, Preamp %d Cal", r + 1, Side, p + 1);
+                cMapCryCal[s][r][p] = new TCanvas(Name1, Name2, 10, 10, 500, 500);
+                cMapCryCal[s][r][p]->Divide(4, 4);
+
+                sprintf(Name1, "Ring_%d_%s_Preamp_%d_calpr", r + 1, Side, p + 1);
+                sprintf(Name2, "Ring %d, %s side, Preamp %d for PR Cal", r + 1, Side, p + 1);
+                cMapCryPCal[s][r][p] = new TCanvas(Name1, Name2, 10, 10, 500, 500);
+                cMapCryPCal[s][r][p]->Divide(4, 4);
+
+                for (Int_t j = 0; j < fNumCrystalPreamp; j++)
+                { // Channel
+                    Xaxis = "Energy [keV]";
+
+                    sprintf(Name1, "fh1_Cal_Side_%s_Ring_%d_Preamp_%d_Ch_%d_energy", Side, r + 1, p + 1, j);
+                    sprintf(Name2, "Cal level, Side %s Ring %d, Preamp %d, ch. %d", Side, r + 1, p + 1, j);
+
+                    fh1_crystals_cal[s][r][p][j] = new TH1F(Name1, Name2, bins, minE, maxE);
+                    fh1_crystals_cal[s][r][p][j]->SetTitleSize(1.6, "t");
+                    fh1_crystals_cal[s][r][p][j]->GetXaxis()->SetTitle(Xaxis);
+                    fh1_crystals_cal[s][r][p][j]->GetXaxis()->SetLabelSize(0.06);
+                    fh1_crystals_cal[s][r][p][j]->GetYaxis()->SetLabelSize(0.07);
+                    fh1_crystals_cal[s][r][p][j]->GetXaxis()->SetTitleSize(0.05);
+                    fh1_crystals_cal[s][r][p][j]->GetXaxis()->CenterTitle(true);
+                    fh1_crystals_cal[s][r][p][j]->GetYaxis()->CenterTitle(true);
+                    fh1_crystals_cal[s][r][p][j]->GetXaxis()->SetTitleOffset(1.);
+                    fh1_crystals_cal[s][r][p][j]->SetFillColor(kGreen);
+                    cMapCryCal[s][r][p]->cd(j + 1);
+                    gPad->SetLogy();
+                    fh1_crystals_cal[s][r][p][j]->Draw();
+
+                    if (r == 4)
+                    { // histograms for proton range
+                        sprintf(Name1, "fh1_Cal_Side_%s_Ring_%d_Preamp_%d_Ch_%d_energy_pr", Side, r + 1, p + 1, j);
+                        sprintf(Name2, "Cal level (PR), Side %s Ring %d, Preamp %d, ch. %d", Side, r + 1, p + 1, j);
+                        fh1_crystals_p_cal[s][r][p][j] = new TH1F(Name1, Name2, bins, minE, maxE);
+                        fh1_crystals_p_cal[s][r][p][j]->SetTitleSize(1.6, "t");
+                        fh1_crystals_p_cal[s][r][p][j]->GetXaxis()->SetTitle(Xaxis);
+                        fh1_crystals_p_cal[s][r][p][j]->GetXaxis()->SetLabelSize(0.06);
+                        fh1_crystals_p_cal[s][r][p][j]->GetYaxis()->SetLabelSize(0.07);
+                        fh1_crystals_p_cal[s][r][p][j]->GetXaxis()->SetTitleSize(0.05);
+                        fh1_crystals_p_cal[s][r][p][j]->GetXaxis()->CenterTitle(true);
+                        fh1_crystals_p_cal[s][r][p][j]->GetYaxis()->CenterTitle(true);
+                        fh1_crystals_p_cal[s][r][p][j]->GetXaxis()->SetTitleOffset(1.);
+                        fh1_crystals_p_cal[s][r][p][j]->SetFillColor(kGreen);
+                        cMapCryPCal[s][r][p]->cd(j + 1);
+                        gPad->SetLogy();
+                        fh1_crystals_p_cal[s][r][p][j]->Draw();
+                    }
+                }
+            }
+    }
+
+    // CANVAS Multiplicity
+    cCalifaMult = new TCanvas("Califa_Multiplicity", "Califa_Multiplicity", 10, 10, 500, 500);
+    fh1_Califa_Mult = new TH1F("fh1_Califa_Mult", "Califa multiplicity (crystal:blue, cluster:red)", 21, -0.5, 20.5);
+    fh1_Califa_MultHit = new TH1F("fh1_Califa_MultHit", "Califa multiplicity", 21, -0.5, 20.5);
+    fh1_Califa_Mult->GetXaxis()->SetTitle("Multiplicity");
+    fh1_Califa_Mult->GetXaxis()->CenterTitle(true);
+    fh1_Califa_Mult->GetYaxis()->CenterTitle(true);
+    fh1_Califa_Mult->GetYaxis()->SetTitleOffset(1.2);
+    fh1_Califa_Mult->GetXaxis()->SetTitleOffset(1.1);
+    gPad->SetLogy();
+    fh1_Califa_Mult->Draw();
+    fh1_Califa_MultHit->SetLineColor(kRed);
+    fh1_Califa_MultHit->Draw("SAME");
+
+    // CANVAS Theta vs Phi
+    cCalifa_angles = new TCanvas("Califa_Theta_vs_Phi", "Theta vs Phi", 10, 10, 500, 500);
+    fh2_Califa_theta_phi = new TH2F("fh2_Califa_theta_vs_phi", "Califa theta vs phi", 90, 0, 180, 180, -180, 180);
+    fh2_Califa_theta_phi->GetXaxis()->SetTitle("Theta [degrees]");
+    fh2_Califa_theta_phi->GetYaxis()->SetTitle("Phi [degrees]");
+    fh2_Califa_theta_phi->GetYaxis()->SetTitleOffset(1.2);
+    fh2_Califa_theta_phi->GetXaxis()->CenterTitle(true);
+    fh2_Califa_theta_phi->GetYaxis()->CenterTitle(true);
+    fh2_Califa_theta_phi->Draw("COLZ");
+
+    // CANVAS Theta vs energy
+    sprintf(Name1, "Califa_calorimeter_theta_vs_energy");
+    sprintf(Name2, "fh_Califa_theta_vs_total_energy");
+    sprintf(Name3, "Califa theta vs energy for full calorimeter");
+    cCalifa_theta_energy = new TCanvas(Name1, Name1, 10, 10, 500, 500);
+    fh2_Califa_theta_energy = new TH2F(Name2, Name3, 45, 0, 90, bins, minE, maxE);
+    fh2_Califa_theta_energy->GetXaxis()->SetTitle("Theta [degrees]");
+    fh2_Califa_theta_energy->GetYaxis()->SetTitle("Energy [keV]");
+    fh2_Califa_theta_energy->GetYaxis()->SetTitleOffset(1.4);
+    fh2_Califa_theta_energy->GetXaxis()->CenterTitle(true);
+    fh2_Califa_theta_energy->GetYaxis()->CenterTitle(true);
+    fh2_Califa_theta_energy->Draw("COLZ");
+
+    // CANVAS Total energy
+    sprintf(Name1, "Califa_calorimeter_total_energy_per_hit");
+    sprintf(Name2, "fh_Califa_Petal_total_energy");
+    sprintf(Name3, "Califa total energy per hit for full calorimeter");
+    cCalifa_hitenergy = new TCanvas(Name1, Name1, 10, 10, 500, 500);
+    fh1_Califa_total_energy = new TH1F(Name2, Name3, bins, minE, maxE);
+    fh1_Califa_total_energy->GetXaxis()->SetTitle("Energy [keV]");
+    fh1_Califa_total_energy->GetYaxis()->SetTitle("Counts");
+    fh1_Califa_total_energy->GetYaxis()->SetTitleOffset(1.4);
+    fh1_Califa_total_energy->GetXaxis()->CenterTitle(true);
+    fh1_Califa_total_energy->GetYaxis()->CenterTitle(true);
+    fh1_Califa_total_energy->Draw("");
+    gPad->SetLogy();
+
+    // FOLDERS for Califa
+    TFolder* folder_sta = new TFolder("Statistics_per_ring", "Statistics info");
+    for (Int_t i = 2; i < fNumRings; i++)
+    { // FIXME in the future
+        folder_sta->Add(cMap_RingR[i]);
+        folder_sta->Add(cMap_RingL[i]);
+    }
+
+    TFolder* folder_el = new TFolder("Energy_Map_per_crystal_Left", "Energy per crystal, left side info");
+    for (Int_t r = 2; r < fNumRings; r++) // FIXME in the future
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            folder_el->Add(cMapCry[1][r][p]);
+
+    TFolder* folder_eprl = new TFolder("Energy_Map_per_crystal_Left_PR", "Energy per crystal, left side info for PR");
+    for (Int_t r = 4; r < fNumRings; r++) // FIXME in the future
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            folder_eprl->Add(cMapCryP[1][r][p]);
+
+    TFolder* folder_er = new TFolder("Energy_Map_per_crystal_Right", "Energy per crystal, right side info");
+    for (Int_t r = 2; r < fNumRings; r++) // FIXME in the future
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            folder_er->Add(cMapCry[0][r][p]);
+
+    TFolder* folder_eprr = new TFolder("Energy_Map_per_crystal_Right_PR", "Energy per crystal, right side info for PR");
+    for (Int_t r = 4; r < fNumRings; r++) // FIXME in the future
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            folder_eprr->Add(cMapCryP[0][r][p]);
+
+    TFolder* folder_ecall = new TFolder("Energy_Cal_per_crystal_Left", "Energy Cal per crystal, left side info");
+    for (Int_t r = 2; r < fNumRings; r++) // FIXME in the future
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            folder_ecall->Add(cMapCryCal[1][r][p]);
+
+    TFolder* folder_eprcall =
+        new TFolder("Energy_Cal_per_crystal_Left_PR", "Energy Cal per crystal, left side info for PR");
+    for (Int_t r = 4; r < fNumRings; r++) // FIXME in the future
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            folder_eprcall->Add(cMapCryPCal[1][r][p]);
+
+    TFolder* folder_ecalr = new TFolder("Energy_Cal_per_crystal_Right", "Energy Cal per crystal, right side info");
+    for (Int_t r = 2; r < fNumRings; r++) // FIXME in the future
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            folder_ecalr->Add(cMapCryCal[0][r][p]);
+
+    TFolder* folder_eprcalr =
+        new TFolder("Energy_Cal_per_crystal_Right_PR", "Energy Cal per crystal, right side info for PR");
+    for (Int_t r = 4; r < fNumRings; r++) // FIXME in the future
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            folder_eprcalr->Add(cMapCryPCal[0][r][p]);
+
+    // MAIN FOLDER-Califa
+    TFolder* mainfolCalifa = new TFolder("CALIFA", "CALIFA info");
+    mainfolCalifa->Add(cCalifaMult);
+    mainfolCalifa->Add(cCalifa_cry_energy);
+    mainfolCalifa->Add(folder_sta);
+    mainfolCalifa->Add(folder_el);
+    mainfolCalifa->Add(folder_eprl);
+    mainfolCalifa->Add(folder_er);
+    mainfolCalifa->Add(folder_eprr);
+    if (fCalON)
+    {
+        mainfolCalifa->Add(cCalifa_cry_energy_cal);
+        mainfolCalifa->Add(folder_ecall);
+        mainfolCalifa->Add(folder_eprcall);
+        mainfolCalifa->Add(folder_ecalr);
+        mainfolCalifa->Add(folder_eprcalr);
+    }
+    if (fHitItemsCalifa)
+    {
+        mainfolCalifa->Add(cCalifa_angles);
+        mainfolCalifa->Add(cCalifa_theta_energy);
+        mainfolCalifa->Add(cCalifa_hitenergy);
+    }
+    run->AddObject(mainfolCalifa);
+
+    // Register command to reset histograms
+    run->GetHttpServer()->RegisterCommand("Reset_Califa", Form("/Objects/%s/->Reset_CALIFA_Histo()", GetName()));
+    // Register command to change the histogram scales (Log/Lineal)
+    run->GetHttpServer()->RegisterCommand("Log_Califa", Form("/Objects/%s/->Log_CALIFA_Histo()", GetName()));
+
+    return kSUCCESS;
+}
+
+// -----   Public method ReInit   ----------------------------------------------
+InitStatus R3BCalifaOnlineSpectra::ReInit()
+{
+    SetParContainers();
+    return kSUCCESS;
+}
+
+void R3BCalifaOnlineSpectra::Reset_CALIFA_Histo()
+{
+    LOG(INFO) << "R3BCalifaOnlineSpectra::Reset_CALIFA_Histo";
+
+    if (fMappedItemsCalifa)
+    {
+        fh1_Califa_Mult->Reset();
+        fh2_Califa_cryId_energy->Reset();
+        for (Int_t i = 0; i < fNumRings; i++)
+        {
+            fh2_Preamp_vs_ch_R[i]->Reset();
+            fh2_Preamp_vs_ch_L[i]->Reset();
+        }
+        for (Int_t s = 0; s < fNumSides; s++)
+            for (Int_t r = 0; r < fNumRings; r++)
+                for (Int_t p = 0; p < fNumPreamps; p++)
+                    for (Int_t ch = 0; ch < fNumCrystalPreamp; ch++)
+                    {
+                        fh1_crystals[s][r][p][ch]->Reset();
+                        if (r == 4)
+                            fh1_crystals_p[s][r][p][ch]->Reset();
+                    }
+    }
+
+    if (fCalItemsCalifa)
+    {
+        fh2_Califa_cryId_energy_cal->Reset();
+        for (Int_t s = 0; s < fNumSides; s++)
+            for (Int_t r = 0; r < fNumRings; r++)
+                for (Int_t p = 0; p < fNumPreamps; p++)
+                    for (Int_t ch = 0; ch < fNumCrystalPreamp; ch++)
+                    {
+                        fh1_crystals_cal[s][r][p][ch]->Reset();
+                        if (r == 4)
+                            fh1_crystals_p_cal[s][r][p][ch]->Reset();
+                    }
+    }
+
+    if (fHitItemsCalifa)
+    {
+        fh1_Califa_MultHit->Reset();
+        fh2_Califa_theta_phi->Reset();
+        fh2_Califa_theta_energy->Reset();
+        fh1_Califa_total_energy->Reset();
+    }
+}
+
+void R3BCalifaOnlineSpectra::Log_CALIFA_Histo()
+{
+
+    LOG(INFO) << "R3BCalifaOnlineSpectra::Log_CALIFA_Histo";
+
+    cCalifa_cry_energy->cd();
+    if (fLogScale)
+    {
+        gPad->SetLogz(0);
+    }
+    else
+    {
+        gPad->SetLogz(1);
+    }
+
+    cCalifaMult->cd();
+    if (fLogScale)
+    {
+        gPad->SetLogy(0);
+    }
+    else
+    {
+        gPad->SetLogy(1);
+    }
+
+    for (Int_t s = 0; s < fNumSides; s++)
+    {
+        for (Int_t r = 0; r < fNumRings; r++)
+        {
+            for (Int_t p = 0; p < fNumPreamps; p++)
+            {
+
+                for (Int_t j = 0; j < fNumCrystalPreamp; j++)
+                {
+                    cMapCry[s][r][p]->cd(j + 1);
+                    if (fLogScale)
+                    {
+                        gPad->SetLogy(0);
+                    }
+                    else
+                    {
+                        gPad->SetLogy(1);
+                    }
+                    if (r == 4)
+                    { // histograms for proton range
+                        cMapCryP[s][r][p]->cd(j + 1);
+                        if (fLogScale)
+                        {
+                            gPad->SetLogy(0);
+                        }
+                        else
+                        {
+                            gPad->SetLogy(1);
+                        }
+                    }
+                    if (fCalItemsCalifa)
+                    {
+                        cMapCryCal[s][r][p]->cd(p + 1);
+                        if (fLogScale)
+                        {
+                            gPad->SetLogy(0);
+                        }
+                        else
+                        {
+                            gPad->SetLogy(1);
+                        }
+                        if (r == 4)
+                        { // histograms for proton range
+                            cMapCryPCal[s][r][p]->cd(j + 1);
+                            if (fLogScale)
+                            {
+                                gPad->SetLogy(0);
+                            }
+                            else
+                            {
+                                gPad->SetLogy(1);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (fCalItemsCalifa)
+    {
+        cCalifa_cry_energy_cal->cd();
+        if (fLogScale)
+        {
+            gPad->SetLogz(0);
+        }
+        else
+        {
+            gPad->SetLogz(1);
+        }
+    }
+
+    if (fHitItemsCalifa)
+    {
+        cCalifa_hitenergy->cd();
+        if (fLogScale)
+        {
+            gPad->SetLogy(0);
+        }
+        else
+        {
+            gPad->SetLogy(1);
+        }
+    }
+
+    if (fLogScale)
+        fLogScale = kFALSE;
+    else
+        fLogScale = kTRUE;
+}
+
+void R3BCalifaOnlineSpectra::Map2Cal_CALIFA_Histo() { LOG(INFO) << "R3BCalifaOnlineSpectra::Map2Cal_CALIFA_Histo"; }
+
+void R3BCalifaOnlineSpectra::Febex2Preamp_CALIFA_Histo()
+{
+    LOG(INFO) << "R3BCalifaOnlineSpectra::Febex2Preamp_CALIFA_Histo";
+}
+
+void R3BCalifaOnlineSpectra::Exec(Option_t* option)
+{
+    FairRootManager* mgr = FairRootManager::Instance();
+    if (NULL == mgr)
+        LOG(FATAL) << "R3BCalifaOnlineSpectra::Exec FairRootManager not found";
+
+    // Mapped data
+    if (fMappedItemsCalifa && fMappedItemsCalifa->GetEntriesFast() > 0)
+    {
+        Int_t nHits = fMappedItemsCalifa->GetEntriesFast();
+        Int_t Crymult = 0;
+        for (Int_t ihit = 0; ihit < nHits; ihit++)
+        {
+            R3BCalifaMappedData* hit = (R3BCalifaMappedData*)fMappedItemsCalifa->At(ihit);
+            if (!hit)
+                continue;
+
+            Int_t cryId = hit->GetCrystalId();
+            if (cryId <= fNbCalifaCrystals / 2)
+                Crymult++;
+
+            fh2_Califa_cryId_energy->Fill(cryId, hit->GetEnergy());
+
+            if (fMap_Par->GetHalf(cryId) == 2)
+                fh2_Preamp_vs_ch_L[fMap_Par->GetRing(cryId) - 1]->Fill(fMap_Par->GetPreamp(cryId),
+                                                                       fMap_Par->GetChannel(cryId));
+            if (fMap_Par->GetHalf(cryId) == 1)
+                fh2_Preamp_vs_ch_R[fMap_Par->GetRing(cryId) - 1]->Fill(fMap_Par->GetPreamp(cryId),
+                                                                       fMap_Par->GetChannel(cryId));
+
+            if (fMap_Par->GetInUse(cryId) == 1 && cryId <= fNbCalifaCrystals / 2)
+                fh1_crystals[fMap_Par->GetHalf(cryId) - 1][fMap_Par->GetRing(cryId) - 1][fMap_Par->GetPreamp(cryId) - 1]
+                            [fMap_Par->GetChannel(cryId) - 1]
+                                ->Fill(hit->GetEnergy());
+
+            else if (fMap_Par->GetInUse(cryId) == 1 && cryId > fNbCalifaCrystals / 2)
+                fh1_crystals_p[fMap_Par->GetHalf(cryId) - 1][fMap_Par->GetRing(cryId) - 1]
+                              [fMap_Par->GetPreamp(cryId) - 1][fMap_Par->GetChannel(cryId) - 1]
+                                  ->Fill(hit->GetEnergy());
+        }
+        fh1_Califa_Mult->Fill(Crymult);
+    }
+
+    // Cal data
+    if (fCalON == kTRUE && fCalItemsCalifa && fCalItemsCalifa->GetEntriesFast() > 0)
+    {
+        Int_t nHits = fCalItemsCalifa->GetEntriesFast();
+
+        for (Int_t ihit = 0; ihit < nHits; ihit++)
+        {
+            R3BCalifaCrystalCalData* hit = (R3BCalifaCrystalCalData*)fCalItemsCalifa->At(ihit);
+            if (!hit)
+                continue;
+
+            Int_t cryId = hit->GetCrystalId();
+
+            fh2_Califa_cryId_energy_cal->Fill(cryId, hit->GetEnergy());
+
+            if (fMap_Par->GetInUse(cryId) == 1 && cryId <= fNbCalifaCrystals / 2)
+                fh1_crystals_cal[fMap_Par->GetHalf(cryId) - 1][fMap_Par->GetRing(cryId) - 1]
+                                [fMap_Par->GetPreamp(cryId) - 1][fMap_Par->GetChannel(cryId) - 1]
+                                    ->Fill(hit->GetEnergy());
+            else if (fMap_Par->GetInUse(cryId) == 1 && cryId > fNbCalifaCrystals / 2)
+                fh1_crystals_p_cal[fMap_Par->GetHalf(cryId) - 1][fMap_Par->GetRing(cryId) - 1]
+                                  [fMap_Par->GetPreamp(cryId) - 1][fMap_Par->GetChannel(cryId) - 1]
+                                      ->Fill(hit->GetEnergy());
+        }
+    }
+
+    // Hit data
+    if (fHitItemsCalifa && fHitItemsCalifa->GetEntriesFast() > 0)
+    {
+        Int_t nHits = fHitItemsCalifa->GetEntriesFast();
+        fh1_Califa_MultHit->Fill(nHits);
+
+        Double_t theta = 0., phi = 0.;
+
+        for (Int_t ihit = 0; ihit < nHits; ihit++)
+        {
+            R3BCalifaHitData* hit = (R3BCalifaHitData*)fHitItemsCalifa->At(ihit);
+            if (!hit)
+                continue;
+            theta = hit->GetTheta() / TMath::Pi() * 180.;
+            phi = hit->GetPhi() / TMath::Pi() * 180.;
+            fh2_Califa_theta_phi->Fill(theta, phi);
+            fh2_Califa_theta_energy->Fill(theta, hit->GetEnergy());
+            fh1_Califa_total_energy->Fill(hit->GetEnergy());
+        }
+    }
+
+    fNEvents += 1;
+}
+
+void R3BCalifaOnlineSpectra::FinishEvent()
+{
+    if (fMappedItemsCalifa)
+    {
+        fMappedItemsCalifa->Clear();
+    }
+    if (fCalItemsCalifa)
+    {
+        fCalItemsCalifa->Clear();
+    }
+    if (fHitItemsCalifa)
+    {
+        fHitItemsCalifa->Clear();
+    }
+}
+
+void R3BCalifaOnlineSpectra::FinishTask()
+{
+    // Write canvas for Mapped data
+    if (fMappedItemsCalifa)
+    {
+        cCalifaMult->Write();
+        cCalifa_cry_energy->Write();
+        for (Int_t i = 0; i < fNumRings; i++)
+        {
+            cMap_RingR[i]->Write();
+            cMap_RingL[i]->Write();
+        }
+        for (Int_t s = 0; s < fNumSides; s++)
+            for (Int_t r = 0; r < fNumRings; r++)
+                for (Int_t p = 0; p < fNumPreamps; p++)
+                {
+                    cMapCry[s][r][p]->Write();
+                    if (r == 4)
+                        cMapCryP[s][r][p]->Write();
+                }
+    }
+
+    // Write canvas for Cal data
+    if (fCalItemsCalifa)
+    {
+        cCalifa_cry_energy_cal->Write();
+        for (Int_t s = 0; s < fNumSides; s++)
+            for (Int_t r = 0; r < fNumRings; r++)
+                for (Int_t p = 0; p < fNumPreamps; p++)
+                {
+                    cMapCryCal[s][r][p]->Write();
+                    if (r == 4)
+                        cMapCryPCal[s][r][p]->Write();
+                }
+    }
+
+    // Write canvas for Hit data
+    if (fHitItemsCalifa)
+    {
+        cCalifa_angles->Write();
+        cCalifa_theta_energy->Write();
+        cCalifa_hitenergy->Write();
+    }
+}
+
+ClassImp(R3BCalifaOnlineSpectra)

--- a/califa/unpack/R3BCalifaDemoOnlineSpectra.cxx
+++ b/califa/unpack/R3BCalifaDemoOnlineSpectra.cxx
@@ -11,7 +11,7 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 
-#include "R3BCalifaOnlineSpectra.h"
+#include "R3BCalifaDemoOnlineSpectra.h"
 #include "R3BCalifaCrystalCalData.h"
 #include "R3BCalifaHitData.h"
 #include "R3BCalifaMappedData.h"
@@ -41,7 +41,7 @@
 
 using namespace std;
 
-R3BCalifaOnlineSpectra::R3BCalifaOnlineSpectra()
+R3BCalifaDemoOnlineSpectra::R3BCalifaDemoOnlineSpectra()
     : FairTask("CALIFAOnlineSpectra", 1)
     , fMappedItemsCalifa(NULL)
     , fCalItemsCalifa(NULL)
@@ -61,7 +61,7 @@ R3BCalifaOnlineSpectra::R3BCalifaOnlineSpectra()
 {
 }
 
-R3BCalifaOnlineSpectra::R3BCalifaOnlineSpectra(const char* name, Int_t iVerbose)
+R3BCalifaDemoOnlineSpectra::R3BCalifaDemoOnlineSpectra(const char* name, Int_t iVerbose)
     : FairTask(name, iVerbose)
     , fMappedItemsCalifa(NULL)
     , fCalItemsCalifa(NULL)
@@ -81,9 +81,9 @@ R3BCalifaOnlineSpectra::R3BCalifaOnlineSpectra(const char* name, Int_t iVerbose)
 {
 }
 
-R3BCalifaOnlineSpectra::~R3BCalifaOnlineSpectra()
+R3BCalifaDemoOnlineSpectra::~R3BCalifaDemoOnlineSpectra()
 {
-    LOG(INFO) << "R3BCalifaOnlineSpectra: Delete instance";
+    LOG(INFO) << "R3BCalifaDemoOnlineSpectra: Delete instance";
     delete fMappedItemsCalifa;
     delete fCalItemsCalifa;
     delete fHitItemsCalifa;
@@ -91,17 +91,17 @@ R3BCalifaOnlineSpectra::~R3BCalifaOnlineSpectra()
     delete fWRItemsMaster;
 }
 
-InitStatus R3BCalifaOnlineSpectra::Init()
+InitStatus R3BCalifaDemoOnlineSpectra::Init()
 {
 
-    LOG(INFO) << "R3BCalifaOnlineSpectra::Init ";
+    LOG(INFO) << "R3BCalifaDemoOnlineSpectra::Init ";
 
     // try to get a handle on the EventHeader. EventHeader may not be
     // present though and hence may be null. Take care when using.
 
     FairRootManager* mgr = FairRootManager::Instance();
     if (NULL == mgr)
-        LOG(FATAL) << "R3BCalifaOnlineSpectra::Init FairRootManager not found";
+        LOG(FATAL) << "R3BCalifaDemoOnlineSpectra::Init FairRootManager not found";
 
     // Define Preamp sequence for histograms
     Int_t PreampOrder[16] = { 6, 5, 4, 3, 2, 1, 0, 7, 8, 15, 14, 13, 12, 11, 10, 9 };
@@ -127,7 +127,7 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     fCalItemsCalifa = (TClonesArray*)mgr->GetObject("CalifaCrystalCalData");
     if (!fCalItemsCalifa)
     {
-        LOG(INFO) << "R3BCalifaOnlineSpectra::Init CalifaCrystalCalData not found";
+        LOG(INFO) << "R3BCalifaDemoOnlineSpectra::Init CalifaCrystalCalData not found";
         fCalON = kFALSE;
     }
 
@@ -135,21 +135,21 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     fHitItemsCalifa = (TClonesArray*)mgr->GetObject("CalifaHitData");
     if (!fHitItemsCalifa)
     {
-        LOG(INFO) << "R3BCalifaOnlineSpectra::Init CalifaHitData not found";
+        LOG(INFO) << "R3BCalifaDemoOnlineSpectra::Init CalifaHitData not found";
     }
 
     // get access to WR-Califa data
     fWRItemsCalifa = (TClonesArray*)mgr->GetObject("WRCalifaData");
     if (!fWRItemsCalifa)
     {
-        LOG(INFO) << "R3BCalifaOnlineSpectra::Init WRCalifaData not found";
+        LOG(INFO) << "R3BCalifaDemoOnlineSpectra::Init WRCalifaData not found";
     }
 
     // get access to WR-Master data
     fWRItemsMaster = (TClonesArray*)mgr->GetObject("WRMasterData");
     if (!fWRItemsMaster)
     {
-        LOG(INFO) << "R3BCalifaOnlineSpectra::Init WRMasterData not found";
+        LOG(INFO) << "R3BCalifaDemoOnlineSpectra::Init WRMasterData not found";
     }
 
     // reading the file
@@ -157,7 +157,7 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     ifstream* FileHistos = new ifstream(fCalifaFile);
     if (!FileHistos->is_open())
     {
-        LOG(WARNING) << "R3BCalifaOnlineSpectra:  No Histogram definition file";
+        LOG(WARNING) << "R3BCalifaDemoOnlineSpectra:  No Histogram definition file";
         noFile = kTRUE;
     }
 
@@ -612,9 +612,9 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     return kSUCCESS;
 }
 
-void R3BCalifaOnlineSpectra::Reset_CALIFA_Histo()
+void R3BCalifaDemoOnlineSpectra::Reset_CALIFA_Histo()
 {
-    LOG(INFO) << "R3BCalifaOnlineSpectra::Reset_CALIFA_Histo";
+    LOG(INFO) << "R3BCalifaDemoOnlineSpectra::Reset_CALIFA_Histo";
 
     fh_Califa_cryId_petal->Reset();
     fh_Califa_wr->Reset();
@@ -660,9 +660,9 @@ void R3BCalifaOnlineSpectra::Reset_CALIFA_Histo()
     }
 }
 
-void R3BCalifaOnlineSpectra::Log_CALIFA_Histo()
+void R3BCalifaDemoOnlineSpectra::Log_CALIFA_Histo()
 {
-    LOG(INFO) << "R3BCalifaOnlineSpectra::Log_CALIFA_Histo";
+    LOG(INFO) << "R3BCalifaDemoOnlineSpectra::Log_CALIFA_Histo";
 
     for (Int_t i = 0; i < fCalifaNumPetals; i++)
     {
@@ -723,9 +723,9 @@ void R3BCalifaOnlineSpectra::Log_CALIFA_Histo()
         fLogScale = kTRUE;
 }
 
-void R3BCalifaOnlineSpectra::Map2Cal_CALIFA_Histo()
+void R3BCalifaDemoOnlineSpectra::Map2Cal_CALIFA_Histo()
 {
-    LOG(INFO) << "R3BCalifaOnlineSpectra::Map2Cal_CALIFA_Histo";
+    LOG(INFO) << "R3BCalifaDemoOnlineSpectra::Map2Cal_CALIFA_Histo";
 
     char Name[255];
 
@@ -925,9 +925,9 @@ void R3BCalifaOnlineSpectra::Map2Cal_CALIFA_Histo()
     }
 }
 
-void R3BCalifaOnlineSpectra::Febex2Preamp_CALIFA_Histo()
+void R3BCalifaDemoOnlineSpectra::Febex2Preamp_CALIFA_Histo()
 {
-    LOG(INFO) << "R3BCalifaOnlineSpectra::Febex2Preamp_CALIFA_Histo";
+    LOG(INFO) << "R3BCalifaDemoOnlineSpectra::Febex2Preamp_CALIFA_Histo";
 
     char Name[255];
 
@@ -1065,12 +1065,12 @@ void R3BCalifaOnlineSpectra::Febex2Preamp_CALIFA_Histo()
     }
 }
 
-void R3BCalifaOnlineSpectra::Exec(Option_t* option)
+void R3BCalifaDemoOnlineSpectra::Exec(Option_t* option)
 {
 
     FairRootManager* mgr = FairRootManager::Instance();
     if (NULL == mgr)
-        LOG(FATAL) << "R3BCalifaOnlineSpectra::Exec FairRootManager not found";
+        LOG(FATAL) << "R3BCalifaDemoOnlineSpectra::Exec FairRootManager not found";
 
     uint64_t wrc = 0;
     if (fWRItemsCalifa && fWRItemsCalifa->GetEntriesFast())
@@ -1129,11 +1129,11 @@ void R3BCalifaOnlineSpectra::Exec(Option_t* option)
             // energy(channels) sum for each petal
             if (petal < 7)
                 fh_Califa_energy_per_petal[petal]->Fill(hit->GetEnergy()); // s444
-            if (petal == 7 & cryId > 447 & cryId < 480)
+            if (petal == 7 && cryId > 447 && cryId < 480)
             {
                 fh_Califa_energy_per_petal[petal]->Fill(hit->GetEnergy());
             }
-            if (petal == 7 & cryId > 479)
+            if (petal == 7 && cryId > 479)
             {
                 fh_Califa_energy_per_petal[8]->Fill(hit->GetEnergy());
             }
@@ -1182,12 +1182,12 @@ void R3BCalifaOnlineSpectra::Exec(Option_t* option)
                 E5 = E5 + hit->GetEnergy();
             if (petal == 6)
                 E6 = E6 + hit->GetEnergy();
-            if (petal == 7 & cryId > 447 & cryId < 480)
+            if (petal == 7 && cryId > 447 && cryId < 480)
             {
                 E0p = E0p + hit->GetEnergy();
                 fh_Califa_energy_per_petal_cal[petal]->Fill(hit->GetEnergy());
             }
-            if (petal == 7 & cryId > 479)
+            if (petal == 7 && cryId > 479)
             {
                 E1p = E1p + hit->GetEnergy();
                 fh_Califa_energy_per_petal_cal[8]->Fill(hit->GetEnergy());
@@ -1278,7 +1278,7 @@ void R3BCalifaOnlineSpectra::Exec(Option_t* option)
     fNEvents += 1;
 }
 
-void R3BCalifaOnlineSpectra::FinishEvent()
+void R3BCalifaDemoOnlineSpectra::FinishEvent()
 {
     if (fMappedItemsCalifa)
     {
@@ -1302,7 +1302,7 @@ void R3BCalifaOnlineSpectra::FinishEvent()
     }
 }
 
-void R3BCalifaOnlineSpectra::FinishTask()
+void R3BCalifaDemoOnlineSpectra::FinishTask()
 {
 
     if (fWRItemsCalifa && fWRItemsMaster)
@@ -1369,7 +1369,7 @@ void R3BCalifaOnlineSpectra::FinishTask()
     }
 }
 
-Int_t R3BCalifaOnlineSpectra::Map_For_s444(Int_t val)
+Int_t R3BCalifaDemoOnlineSpectra::Map_For_s444(Int_t val)
 {
     // With this mapping all the code can remain unchanged
     // with the new software mapping for s444 (after 12 Feb 2019).
@@ -1500,4 +1500,4 @@ Int_t R3BCalifaOnlineSpectra::Map_For_s444(Int_t val)
     return nbcry;
 }
 
-ClassImp(R3BCalifaOnlineSpectra)
+ClassImp(R3BCalifaDemoOnlineSpectra)

--- a/califa/unpack/R3BCalifaDemoOnlineSpectra.h
+++ b/califa/unpack/R3BCalifaDemoOnlineSpectra.h
@@ -1,0 +1,201 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BCALIFADEMOONLINESPECTRA
+#define R3BCALIFADEMOONLINESPECTRA
+#define N_MAX_CRY 64
+#define N_MAX_PETALS 8
+
+#include "FairTask.h"
+#include "TCanvas.h"
+#include "TMath.h"
+#include <array>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+class TClonesArray;
+class TH1F;
+class TH2F;
+class R3BEventHeader;
+
+/**
+ * This taks reads CALIFA data and plots online histograms
+ */
+class R3BCalifaDemoOnlineSpectra : public FairTask
+{
+
+  public:
+    /**
+     * Default constructor.
+     * Creates an instance of the task with default parameters.
+     */
+    R3BCalifaDemoOnlineSpectra();
+
+    /**
+     * Standard constructor.
+     * Creates an instance of the task.
+     * @param name a name of the task.
+     * @param iVerbose a verbosity level.
+     */
+    R3BCalifaDemoOnlineSpectra(const char* name, Int_t iVerbose = 1);
+
+    /**
+     * Destructor.
+     * Frees the memory used by the object.
+     */
+    virtual ~R3BCalifaDemoOnlineSpectra();
+
+    /**
+     * Method for task initialization.
+     * This function is called by the framework before
+     * the event loop.
+     * @return Initialization status. kSUCCESS, kERROR or kFATAL.
+     */
+    virtual InitStatus Init();
+
+    /**
+     * Method for event loop implementation.
+     * Is called by the framework every time a new event is read.
+     * @param option an execution option.
+     */
+    virtual void Exec(Option_t* option);
+
+    /**
+     * A method for finish of processing of an event.
+     * Is called by the framework for each event after executing
+     * the tasks.
+     */
+    virtual void FinishEvent();
+
+    /**
+     * Method for finish of the task execution.
+     * Is called by the framework after processing the event loop.
+     */
+    virtual void FinishTask();
+
+    /**
+     * Method for setting number of petals
+     */
+    inline void SetPetals(Int_t petals) { fCalifaNumPetals = petals; }
+
+    /**
+     * Method for setting the configuration parameters file
+     */
+    inline void SetCalifaConfigFile(TString file) { fCalifaFile = file; }
+
+    /**
+     * Method to select binning and max range
+     */
+    void SetRange_bins(Int_t Histos_bins) { fMapHistos_bins = Histos_bins; }
+    void SetRange_max(Int_t Histos_max) { fMapHistos_max = Histos_max; }
+
+    /**
+     * Method to reset histograms
+     */
+    void Reset_CALIFA_Histo();
+
+  private:
+
+    /**
+     * Method to change histogram scales
+     */
+    void Log_CALIFA_Histo();
+
+    /**
+     * Method for setting the Data Level (Mapped or Cal)
+     */
+    void Map2Cal_CALIFA_Histo();
+
+    /**
+     * Method for setting histogram sequence (Febex or Preamp. channels)
+     */
+    void Febex2Preamp_CALIFA_Histo();
+
+    /**
+     * Mapping s444 crystals
+     */
+    Int_t Map_For_s444(Int_t val);
+
+
+    Int_t fMapHistos_max;
+    Int_t fMapHistos_bins;
+
+    TClonesArray* fMappedItemsCalifa; /**< Array with mapped items.    */
+    TClonesArray* fCalItemsCalifa;    /**< Array with cal items.       */
+    TClonesArray* fHitItemsCalifa;    /**< Array with hit items.       */
+    TClonesArray* fWRItemsCalifa;     /**< Array with WR-Califa items. */
+    TClonesArray* fWRItemsMaster;     /**< Array with WR-Master items. */
+
+    // Check for trigger should be done globablly (somewhere else)
+    R3BEventHeader* header; /**< Event header.  */
+    Int_t fTrigger;         /**< Trigger value. */
+    Int_t fNEvents;         /**< Event counter. */
+
+    Int_t fCalifaNumPetals;      /**< Number of Petals.   */
+    Int_t fNumCrystalPetal;      /**< Crystals per Petal. */
+    Int_t fOrderFebexPreamp[16]; /**< Selector for febex or preamp sequence. */
+
+    // Multiplicities
+    TH1F* fh_Califa_Mult[N_MAX_PETALS + 1];
+    TH1F* fh_Califa_MultHit[N_MAX_PETALS + 1];
+
+    // WR data
+    TH1F* fh_Califa_wr;
+
+    // Raw data
+    TH2F* fh_Califa_cryId_petal;
+    TH1F* fh_Califa_energy_per_petal[N_MAX_PETALS + 1]; //+1 for proton range:s444
+    TH1F* fh_Califa_crystals[N_MAX_PETALS][N_MAX_CRY];
+    TH2F* fh_Califa_cryId_energy;
+    TH2F* fh_Califa_coinc_petal1;
+    TH2F* fh_Califa_coinc_petal2;
+    TH2F* fh_Califa_coinc_petal3;
+
+    // Cal data
+    TH2F* fh_Califa_cryId_energy_cal;
+    TH1F* fh_Califa_energy_per_petal_cal[N_MAX_PETALS + 1]; //+1 for proton range:s444
+    TH1F* fh_Califa_crystals_cal[N_MAX_PETALS][N_MAX_CRY];
+
+    // Hit data
+    TH2F* fh_Califa_theta_phi;
+    TH2F* fh_Califa_theta_energy[N_MAX_PETALS];
+    TH1F* fh_Califa_total_energy;
+
+    TString fCalifaFile;  /**< Config file name. */
+    Bool_t fCalON;        /**< Cal selector. */
+    Bool_t fLogScale;     /**< Selecting scale. */
+    Bool_t fRaw2Cal;      /**< Mapped or Cal selector. */
+    Bool_t fFebex2Preamp; /**< Febex or Preamp selector. */
+
+    TCanvas* cMap;
+    TCanvas* cCalifa_wr;
+    TCanvas* cCalifa1;
+    TCanvas* cCalifa2;
+    TCanvas* cCalifa3;
+    TCanvas* cCalifa3b; // proton range
+    TCanvas* cCalifa4[N_MAX_PETALS][4];
+    TCanvas* cCalifa5;
+    TCanvas* cCalifa6;
+    TCanvas* cCalifa7;
+    TCanvas* cCalifa8;
+    TCanvas* cCalifa_hitpetal[N_MAX_PETALS];
+    TCanvas* cCalifa10;
+    TCanvas* cCalifa_hitenergy;
+
+  public:
+    ClassDef(R3BCalifaDemoOnlineSpectra, 1)
+};
+
+#endif

--- a/califa/unpack/R3BCalifaMapped2CrystalCalPar.cxx
+++ b/califa/unpack/R3BCalifaMapped2CrystalCalPar.cxx
@@ -31,6 +31,7 @@
 #include "R3BCalifaCrystalCalPar.h"
 #include "R3BCalifaMapped2CrystalCalPar.h"
 #include "R3BCalifaMappedData.h"
+#include "R3BCalifaMappingPar.h"
 #include "R3BEventHeader.h"
 
 #include <iostream>
@@ -40,6 +41,7 @@ using namespace std;
 
 R3BCalifaMapped2CrystalCalPar::R3BCalifaMapped2CrystalCalPar()
     : FairTask("R3B CALIFA Calibration Parameters Finder ", 1)
+    , fMap_Par(NULL)
     , fCal_Par(NULL)
     , fCalifaMappedDataCA(NULL)
     , fNumCrystals(0)
@@ -55,13 +57,13 @@ R3BCalifaMapped2CrystalCalPar::R3BCalifaMapped2CrystalCalPar()
     , fSigma(0)
     , fThreshold(0)
     , fEnergyPeaks(NULL)
-    , fOutputFile(NULL)
     , fDebugMode(0)
 {
 }
 
 R3BCalifaMapped2CrystalCalPar::R3BCalifaMapped2CrystalCalPar(const char* name, Int_t iVerbose)
     : FairTask(name, iVerbose)
+    , fMap_Par(NULL)
     , fCal_Par(NULL)
     , fCalifaMappedDataCA(NULL)
     , fNumCrystals(0)
@@ -77,48 +79,60 @@ R3BCalifaMapped2CrystalCalPar::R3BCalifaMapped2CrystalCalPar(const char* name, I
     , fSigma(0)
     , fThreshold(0)
     , fEnergyPeaks(NULL)
-    , fOutputFile(NULL)
     , fDebugMode(0)
 {
 }
 
 R3BCalifaMapped2CrystalCalPar::~R3BCalifaMapped2CrystalCalPar()
 {
+    LOG(INFO) << "R3BCalifaMapped2CrystalCalPar: Delete instance";
+    if (fCalifaMappedDataCA)
+        delete fCalifaMappedDataCA;
     if (fEnergyPeaks)
         delete fEnergyPeaks;
 }
 
+void R3BCalifaMapped2CrystalCalPar::SetParContainers()
+{
+    // Parameter Container
+    // Reading califaMappingPar from FairRuntimeDb
+    FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+    if (!rtdb)
+    {
+        LOG(ERROR) << "FairRuntimeDb not opened!";
+    }
+
+    fMap_Par = (R3BCalifaMappingPar*)rtdb->getContainer("califaMappingPar");
+    if (!fMap_Par)
+    {
+        LOG(ERROR) << "R3BCalifaMapped2CrystalCalPar::Init() Couldn't get handle on califaMappingPar container";
+    }
+    else
+    {
+        LOG(INFO) << "R3BCalifaMapped2CrystalCalPar:: califaMappingPar container open";
+    }
+}
+
+void R3BCalifaMapped2CrystalCalPar::SetParameter()
+{
+    if (!fMap_Par)
+    {
+        LOG(WARNING) << "R3BCalifaMapped2CrystalCalPar::Container califaMappingPar not found.";
+    }
+    //--- Parameter Container ---
+    fNumCrystals = fMap_Par->GetNumCrystals(); // Number of crystals x 2
+    LOG(INFO) << "R3BCalifaMapped2CrystalCalPar::NumCry " << fNumCrystals;
+    // fMap_Par->printParams();
+}
+
 InitStatus R3BCalifaMapped2CrystalCalPar::Init()
 {
-
     LOG(INFO) << "R3BCalifaMapped2CrystalCalPar::Init";
 
     if (!fEnergyPeaks)
     {
         fEnergyPeaks = new TArrayF;
         fEnergyPeaks->Set(fNumPeaks);
-    }
-
-    char name[100];
-    Int_t fright, fleft, fbins;
-
-    fh_Map_energy_crystal = new TH1F*[fNumCrystals];
-    for (Int_t i = 0; i < fNumCrystals; i++)
-    {
-        sprintf(name, "fh_Map_energy_crystal_%i", i + 1);
-        if (Searchrange(i + 1))
-        {
-            fright = fMapHistos_right;
-            fleft = fMapHistos_left;
-            fbins = fMapHistos_bins;
-        }
-        else
-        {
-            fright = fMapHistos_rightp;
-            fleft = fMapHistos_leftp;
-            fbins = fMapHistos_binsp;
-        }
-        fh_Map_energy_crystal[i] = new TH1F(name, name, fbins, fleft, fright);
     }
 
     FairRootManager* rootManager = FairRootManager::Instance();
@@ -146,21 +160,44 @@ InitStatus R3BCalifaMapped2CrystalCalPar::Init()
         return kFATAL;
     }
 
+    // Set container with mapping parameters
+    SetParameter();
+
+    // Create histograms for crystal calibration
+    char name[100];
+    Int_t fright, fleft, fbins;
+    fh_Map_energy_crystal = new TH1F*[fNumCrystals];
+    for (Int_t i = 0; i < fNumCrystals; i++)
+        if (fMap_Par->GetInUse(i + 1) == 1)
+        {
+
+            sprintf(name, "fh_Map_energy_crystal_%i", i + 1);
+            if (i < fMap_Par->GetNumCrystals() / 2)
+            {
+                fright = fMapHistos_right;
+                fleft = fMapHistos_left;
+                fbins = fMapHistos_bins;
+            }
+            else
+            {
+                fright = fMapHistos_rightp;
+                fleft = fMapHistos_leftp;
+                fbins = fMapHistos_binsp;
+            }
+            fh_Map_energy_crystal[i] = new TH1F(name, name, fbins, fleft, fright);
+        }
+
     return kSUCCESS;
 }
 
 InitStatus R3BCalifaMapped2CrystalCalPar::ReInit()
 {
-
-    // MOVE PAR SETTINGS IN INIT TO SETPARCONTAINERS AND CALL ALSO IT HERE
-    // SetParContainers();
-
+    SetParContainers();
     return kSUCCESS;
 }
 
 void R3BCalifaMapped2CrystalCalPar::Exec(Option_t* opt)
 {
-
     Int_t nHits = fCalifaMappedDataCA->GetEntries();
     if (!nHits)
         return;
@@ -172,7 +209,7 @@ void R3BCalifaMapped2CrystalCalPar::Exec(Option_t* opt)
     {
         MapHit = (R3BCalifaMappedData*)(fCalifaMappedDataCA->At(i));
         crystalId = MapHit->GetCrystalId();
-        // Fill Histos
+        // Fill histograms
         fh_Map_energy_crystal[crystalId - 1]->Fill(MapHit->GetEnergy());
     }
 }
@@ -183,37 +220,19 @@ void R3BCalifaMapped2CrystalCalPar::FinishEvent() {}
 
 void R3BCalifaMapped2CrystalCalPar::FinishTask()
 {
-
+    // Look for the peaks in each spectrum
     SearchPeaks();
-
-    // obtain an output file
-    /*FILE *fout = NULL;
-      if(fOutputFile)
-      {
-      fout = fopen(fOutputFile, "w");
-      if(!fout)
-      {
-      cerr << "Could not open " << fOutputFile << " for writing!\n";
-      }
-      else
-      fprintf(fout, "# CrystalId Ratio NumEvents\n");
-      }*/
+    // fCal_Par->printParams();
 }
 
 void R3BCalifaMapped2CrystalCalPar::SearchPeaks()
 {
-
     Int_t nfound = 0;
-
-    Int_t numPars;
+    Int_t numPars = 2; // Number of parameters=2 by default
     if (fNumParam)
     {
         numPars = fNumParam;
     }
-    else
-    {
-        numPars = 2;
-    } // by default! number of parameters=2
 
     fCal_Par->SetNumCrystals(fNumCrystals);
     fCal_Par->SetNumParametersFit(fNumParam);
@@ -224,257 +243,104 @@ void R3BCalifaMapped2CrystalCalPar::SearchPeaks()
     Int_t fright, fleft;
 
     for (Int_t i = 0; i < fNumCrystals; i++)
-    {
-
-        if (fh_Map_energy_crystal[i]->GetEntries() > fMinStadistics)
+        if (fMap_Par->GetInUse(i + 1) == 1)
         {
 
-            if (fDebugMode)
-                nfound = ss->Search(fh_Map_energy_crystal[i], fSigma, "", fThreshold);
-            else
-                nfound = ss->Search(fh_Map_energy_crystal[i], fSigma, "goff", fThreshold);
-            //	std::cout<< i << " " << nfound <<" "<< fThreshold << std::endl;
-            fChannelPeaks = (Double_t*)ss->GetPositionX();
-
-            Int_t idx[nfound];
-            TMath::Sort(nfound, fChannelPeaks, idx, kTRUE);
-
-            // Calibrated Spectrum
-            Double_t X[nfound + 1];
-            Double_t Y[nfound + 1];
-
-            for (Int_t j = 0; j < nfound; j++)
-            {
-                X[j] = fChannelPeaks[idx[nfound - j - 1]];
-                Y[j] = fEnergyPeaks->GetAt(nfound - j - 1);
-                // std::cout<<"CrystalId="<<i+1<<" "<< j+1  <<" "<< X[j+1]  << std::endl;
-            }
-            X[nfound] = 0.;
-            Y[nfound] = 0.;
-
-            if (Searchrange(i + 1))
-            {
-                fright = fMapHistos_right;
-                fleft = fMapHistos_left;
-            }
-            else
-            {
-                fright = fMapHistos_rightp;
-                fleft = fMapHistos_leftp;
-            }
-
-            TF1* f1;
-            if (fNumParam)
+            if (fh_Map_energy_crystal[i]->GetEntries() > fMinStadistics)
             {
 
-                if (fNumParam == 1)
+                if (fDebugMode)
+                    nfound = ss->Search(fh_Map_energy_crystal[i], fSigma, "", fThreshold);
+                else
+                    nfound = ss->Search(fh_Map_energy_crystal[i], fSigma, "goff", fThreshold);
+                // std::cout<< i << " " << nfound <<" "<< fThreshold << std::endl;
+                fChannelPeaks = (Double_t*)ss->GetPositionX();
+
+                Int_t idx[nfound];
+                TMath::Sort(nfound, fChannelPeaks, idx, kTRUE);
+
+                // Calibrated Spectrum
+                Double_t X[nfound + 1];
+                Double_t Y[nfound + 1];
+
+                for (Int_t j = 0; j < nfound; j++)
                 {
-                    f1 = new TF1("f1", "[0]*x", fleft, fright);
+                    X[j] = fChannelPeaks[idx[nfound - j - 1]];
+                    Y[j] = fEnergyPeaks->GetAt(nfound - j - 1);
+                    // std::cout<<"CrystalId="<<i+1<<" "<< j+1  <<" "<< X[j+1]  << std::endl;
                 }
-                if (fNumParam == 2)
+                X[nfound] = 0.;
+                Y[nfound] = 0.;
+
+                if (i < fMap_Par->GetNumCrystals() / 2)
                 {
+                    fright = fMapHistos_right;
+                    fleft = fMapHistos_left;
+                }
+                else
+                {
+                    fright = fMapHistos_rightp;
+                    fleft = fMapHistos_leftp;
+                }
+
+                TF1* f1;
+                if (fNumParam)
+                {
+
+                    if (fNumParam == 1)
+                    {
+                        f1 = new TF1("f1", "[0]*x", fleft, fright);
+                    }
+                    if (fNumParam == 2)
+                    {
+                        f1 = new TF1("f1", "[0]+[1]*x", fleft, fright);
+                    }
+                    if (fNumParam == 3)
+                    {
+                        f1 = new TF1("f1", "[0]+[1]*x+[2]*pow(x,2)", fleft, fright);
+                    }
+                    if (fNumParam == 4)
+                    {
+                        f1 = new TF1("f1", "[0]+[1]*x+[2]*pow(x,2)+[3]*pow(x,3)", fleft, fright);
+                    }
+                    if (fNumParam == 5)
+                    {
+                        f1 = new TF1("f1", "[0]+[1]*x+[2]*pow(x,2)+[3]*pow(x,3)+[4]*pow(x,4)", fleft, fright);
+                    }
+                    if (fNumParam > 5)
+                    {
+                        LOG(WARNING)
+                            << "R3BCalifaMapped2CrystalCalPar:: The number of fit parameters can not be higher than 5";
+                    }
+                }
+                else
+                {
+                    LOG(INFO)
+                        << "R3BCalifaMapped2CrystalCalPar:: No imput number of fit parameters, therefore, by default "
+                           "NumberParameters=2";
                     f1 = new TF1("f1", "[0]+[1]*x", fleft, fright);
                 }
-                if (fNumParam == 3)
+
+                TGraph* graph = new TGraph(fNumPeaks + 1, X, Y);
+                graph->Fit("f1", "Q"); // Quiet mode (minimum printing)
+
+                for (Int_t h = 0; h < numPars; h++)
                 {
-                    f1 = new TF1("f1", "[0]+[1]*x+[2]*pow(x,2)", fleft, fright);
+                    fCal_Par->SetCryCalParams(f1->GetParameter(h), numPars * i + h);
                 }
-                if (fNumParam == 4)
-                {
-                    f1 = new TF1("f1", "[0]+[1]*x+[2]*pow(x,2)+[3]*pow(x,3)", fleft, fright);
-                }
-                if (fNumParam == 5)
-                {
-                    f1 = new TF1("f1", "[0]+[1]*x+[2]*pow(x,2)+[3]*pow(x,3)+[4]*pow(x,4)", fleft, fright);
-                }
-                if (fNumParam > 5)
-                {
-                    LOG(WARNING)
-                        << "R3BCalifaMapped2CrystalCalPar:: The number of fit parameters can not be higher than 5";
-                }
+
+                if (fDebugMode)
+                    fh_Map_energy_crystal[i]->Write();
             }
             else
             {
-                LOG(INFO) << "R3BCalifaMapped2CrystalCalPar:: No imput number of fit parameters, therefore, by default "
-                             "NumberParameters=2";
-                f1 = new TF1("f1", "[0]+[1]*x", fleft, fright);
+                LOG(WARNING) << "R3BCalifaMapped2CrystalCalPar::Histogram NO Fitted number " << i;
             }
-
-            TGraph* graph = new TGraph(fNumPeaks + 1, X, Y);
-            graph->Fit("f1", "Q"); // Quiet mode (minimum printing)
-
-            // if(i<5000){
-            for (Int_t h = 0; h < numPars; h++)
-            {
-                fCal_Par->SetCryCalParams(f1->GetParameter(h), numPars * i + h);
-                // Double_t par;
-                // par=f1->GetParameter(h);
-            }
-            /* }else{
-             for(Int_t h=0; h<numPars;h++){
-           if(h==0)fCal_Par->SetCryCalParams(f1->GetParameter(h),numPars*i+h);
-                else fCal_Par->SetCryCalParams(f1->GetParameter(h),numPars*i+h);
-           //Double_t par;
-           //par=f1->GetParameter(h);
-             }
-             }  */
-
-            if (fDebugMode)
-                fh_Map_energy_crystal[i]->Write();
         }
-        else
-        {
-            LOG(WARNING) << "R3BCalifaMapped2CrystalCalPar::Histogram NO Fitted number " << i;
-        }
-    }
 
     delete ss;
     fCal_Par->setChanged();
     return;
 }
 
-bool R3BCalifaMapped2CrystalCalPar::Searchrange(Int_t val)
-{
-    // With this mapping all the code can remain unchanged
-    // with the new software mapping for s444 (after 12 Feb 2019).
-    // This is only valid for the s444 experiment
-    // (but this is the case for all the code in this class!!)
-    Int_t id_1[512] = {
-        1142, 1144, 1138, 1140, 1141, 1143, 1137, 1139, 1014, 1016, 1010, 1012, 1013, 1015, 1009, 1011, 1398, 1400,
-        1394, 1396, 1397, 1399, 1393, 1395, 1270, 1272, 1266, 1268, 1269, 1271, 1265, 1267, 1654, 1655, 1650, 1651,
-        1653, 1656, 1649, 1652, 1526, 1528, 1522, 1524, 1525, 1527, 1521, 1523, 6654, 6655, 6650, 6651, 6653, 6656,
-        6649, 6652, 6526, 6528, 6522, 6524, 6525, 6527, 6521, 6523, 1910, 1911, 1906, 1907, 1909, 1912, 1905, 1908,
-        1782, 1783, 1778, 1779, 1781, 1784, 1777, 1780, 6910, 6911, 6906, 6907, 6909, 6912, 6905, 6908, 6782, 6783,
-        6778, 6779, 6781, 6784, 6777, 6780, 1126, 1128, 1122, 1124, 1125, 1127, 1121, 1123, 998,  1000, 994,  996,
-        997,  999,  993,  995,  1382, 1384, 1378, 1380, 1381, 1383, 1377, 1379, 1254, 1256, 1250, 1252, 1253, 1255,
-        1249, 1251, 1638, 1639, 1634, 1635, 1637, 1640, 1633, 1636, 1510, 1512, 1506, 1508, 1509, 1511, 1505, 1507,
-        1894, 1895, 1890, 1891, 1893, 1896, 1889, 1892, 1766, 1767, 1762, 1763, 1765, 1768, 1761, 1764, 1102, 1104,
-        1098, 1100, 1101, 1103, 1097, 1099, 974,  976,  970,  972,  973,  975,  969,  971,  1358, 1360, 1354, 1356,
-        1357, 1359, 1353, 1355, 1230, 1232, 1226, 1228, 1229, 1231, 1225, 1227, 1614, 1615, 1610, 1611, 1613, 1616,
-        1609, 1612, 1486, 1488, 1482, 1484, 1485, 1487, 1481, 1483, 1870, 1871, 1866, 1867, 1869, 1872, 1865, 1868,
-        1742, 1743, 1738, 1739, 1741, 1744, 1737, 1740, 1094, 1096, 1090, 1092, 1093, 1095, 1089, 1091, 966,  968,
-        962,  964,  965,  967,  961,  963,  1350, 1352, 1346, 1348, 1349, 1351, 1345, 1347, 1222, 1224, 1218, 1220,
-        1221, 1223, 1217, 1219, 1606, 1607, 1602, 1603, 1605, 1608, 1601, 1604, 1478, 1480, 1474, 1476, 1477, 1479,
-        1473, 1475, 6606, 6607, 6602, 6603, 6605, 6608, 6601, 6604, 6478, 6480, 6474, 6476, 6477, 6479, 6473, 6475,
-        1862, 1863, 1858, 1859, 1861, 1864, 1857, 1860, 1734, 1735, 1730, 1731, 1733, 1736, 1729, 1732, 6862, 6863,
-        6858, 6859, 6861, 6864, 6857, 6860, 6734, 6735, 6730, 6731, 6733, 6736, 6729, 6732, 1078, 1080, 1074, 1076,
-        1077, 1079, 1073, 1075, 950,  952,  946,  948,  949,  951,  945,  947,  1334, 1336, 1330, 1332, 1333, 1335,
-        1329, 1331, 1206, 1208, 1202, 1204, 1205, 1207, 1201, 1203, 1590, 1591, 1586, 1587, 1589, 1592, 1585, 1588,
-        1462, 1464, 1458, 1460, 1461, 1463, 1457, 1459, 1846, 1847, 1842, 1843, 1845, 1848, 1841, 1844, 1718, 1719,
-        1714, 1715, 1717, 1720, 1713, 1716, 1070, 1072, 1066, 1068, 1069, 1071, 1065, 1067, 942,  944,  938,  940,
-        941,  943,  937,  939,  1326, 1328, 1322, 1324, 1325, 1327, 1321, 1323, 1198, 1200, 1194, 1196, 1197, 1199,
-        1193, 1195, 1582, 1583, 1578, 1579, 1581, 1584, 1577, 1580, 1454, 1456, 1450, 1452, 1453, 1455, 1449, 1451,
-        1838, 1839, 1834, 1835, 1837, 1840, 1833, 1836, 1710, 1711, 1706, 1707, 1709, 1712, 1705, 1708, 1062, 1064,
-        1058, 1060, 1061, 1063, 1057, 1059, 934,  936,  930,  932,  933,  935,  929,  931,  1318, 1320, 1314, 1316,
-        1317, 1319, 1313, 1315, 1190, 1192, 1186, 1188, 1189, 1191, 1185, 1187, 1574, 1575, 1570, 1571, 1573, 1576,
-        1569, 1572, 1446, 1448, 1442, 1444, 1445, 1447, 1441, 1443, 1830, 1831, 1826, 1827, 1829, 1832, 1825, 1828,
-        1702, 1703, 1698, 1699, 1701, 1704, 1697, 1700
-    };
-    Int_t id_2[512] = {
-        246, 245, 244, 243, 242, 241, 240, 247, 248, 255, 254, 253, 252, 251, 250, 249, 230, 229, 228, 227, 226, 225,
-        224, 231, 232, 239, 238, 237, 236, 235, 234, 233, 214, 213, 212, 211, 210, 209, 208, 215, 216, 223, 222, 221,
-        220, 219, 218, 217, 198, 197, 196, 195, 194, 193, 192, 199, 200, 207, 206, 205, 204, 203, 202, 201, 182, 181,
-        180, 179, 178, 177, 176, 183, 184, 191, 190, 189, 188, 187, 186, 185, 166, 165, 164, 163, 162, 161, 160, 167,
-        168, 175, 174, 173, 172, 171, 170, 169, 502, 501, 500, 499, 498, 497, 496, 503, 504, 511, 510, 509, 508, 507,
-        506, 505, 486, 485, 484, 483, 482, 481, 480, 487, 488, 495, 494, 493, 492, 491, 490, 489, 470, 469, 468, 467,
-        466, 465, 464, 471, 472, 479, 478, 477, 476, 475, 474, 473, 454, 453, 452, 451, 450, 449, 448, 455, 456, 463,
-        462, 461, 460, 459, 458, 457, 54,  53,  52,  51,  50,  49,  48,  55,  56,  63,  62,  61,  60,  59,  58,  57,
-        38,  37,  36,  35,  34,  33,  32,  39,  40,  47,  46,  45,  44,  43,  42,  41,  22,  21,  20,  19,  18,  17,
-        16,  23,  24,  31,  30,  29,  28,  27,  26,  25,  6,   5,   4,   3,   2,   1,   0,   7,   8,   15,  14,  13,
-        12,  11,  10,  9,   150, 149, 148, 147, 146, 145, 144, 151, 152, 159, 158, 157, 156, 155, 154, 153, 134, 133,
-        132, 131, 130, 129, 128, 135, 136, 143, 142, 141, 140, 139, 138, 137, 118, 117, 116, 115, 114, 113, 112, 119,
-        120, 127, 126, 125, 124, 123, 122, 121, 102, 101, 100, 99,  98,  97,  96,  103, 104, 111, 110, 109, 108, 107,
-        106, 105, 86,  85,  84,  83,  82,  81,  80,  87,  88,  95,  94,  93,  92,  91,  90,  89,  70,  69,  68,  67,
-        66,  65,  64,  71,  72,  79,  78,  77,  76,  75,  74,  73,  310, 309, 308, 307, 306, 305, 304, 311, 312, 319,
-        318, 317, 316, 315, 314, 313, 294, 293, 292, 291, 290, 289, 288, 295, 296, 303, 302, 301, 300, 299, 298, 297,
-        278, 277, 276, 275, 274, 273, 272, 279, 280, 287, 286, 285, 284, 283, 282, 281, 262, 261, 260, 259, 258, 257,
-        256, 263, 264, 271, 270, 269, 268, 267, 266, 265, 374, 373, 372, 371, 370, 369, 368, 375, 376, 383, 382, 381,
-        380, 379, 378, 377, 358, 357, 356, 355, 354, 353, 352, 359, 360, 367, 366, 365, 364, 363, 362, 361, 342, 341,
-        340, 339, 338, 337, 336, 343, 344, 351, 350, 349, 348, 347, 346, 345, 326, 325, 324, 323, 322, 321, 320, 327,
-        328, 335, 334, 333, 332, 331, 330, 329, 438, 437, 436, 435, 434, 433, 432, 439, 440, 447, 446, 445, 444, 443,
-        442, 441, 422, 421, 420, 419, 418, 417, 416, 423, 424, 431, 430, 429, 428, 427, 426, 425, 406, 405, 404, 403,
-        402, 401, 400, 407, 408, 415, 414, 413, 412, 411, 410, 409, 390, 389, 388, 387, 386, 385, 384, 391, 392, 399,
-        398, 397, 396, 395, 394, 393
-    };
-    Int_t nbcry = 0;
-    for (Int_t i = 0; i < 512; i++)
-    {
-        if (id_1[i] == val)
-            nbcry = id_2[i];
-    }
-
-    // New arrangement due to dual preamps
-    if (nbcry >= 0 && nbcry < 64)
-    {
-        nbcry = nbcry + 128; // USC1: petal 3
-    }
-    else if (nbcry > 63 && nbcry < 80)
-    {
-        nbcry = nbcry - 64 + 448 + 32; // USC2: proton range, preamp 1, section 1
-    }
-    else if (nbcry > 79 && nbcry < 96)
-    {
-        nbcry = nbcry - 80 + 192; // USC2: gamma range, preamp 1, section 1
-    }
-    else if (nbcry > 95 && nbcry < 112)
-    {
-        nbcry = nbcry - 96 + 448 + 48; // USC2: proton range, preamp 1, section 2
-    }
-    else if (nbcry > 111 && nbcry < 128)
-    {
-        nbcry = nbcry - 112 + 192 + 16; // USC2: gamma range, preamp 1, section 2
-    }
-    else if (nbcry > 127 && nbcry < 144)
-    {
-        nbcry = nbcry - 128 + 192 + 32; // USC2: preamp 2, section 1
-    }
-    else if (nbcry > 143 && nbcry < 160)
-    {
-        nbcry = nbcry - 144 + 192 + 48; // USC2: preamp 2, section 2
-    }
-    else if (nbcry > 159 && nbcry < 176)
-    {
-        nbcry = nbcry - 160 + 448; // TUDA1: proton range, preamp 1, section 1
-    }
-    else if (nbcry > 175 && nbcry < 192)
-    {
-        nbcry = nbcry - 176; // TUDA1: gamma range, preamp 1, section 1
-    }
-    else if (nbcry > 191 && nbcry < 208)
-    {
-        nbcry = nbcry - 192 + 448 + 16; // TUDA1: proton range, preamp 1, section 2
-    }
-    else if (nbcry > 207 && nbcry < 224)
-    {
-        nbcry = nbcry - 208 + 16; // TUDA1: gamma range, preamp 1, section 2
-    }
-    else if (nbcry > 223 && nbcry < 240)
-    {
-        nbcry = nbcry - 224 + 32; // TUDA1: preamp 2, section 1
-    }
-    else if (nbcry > 239 && nbcry < 256)
-    {
-        nbcry = nbcry - 240 + 48; // TUDA1: preamp 2, section 2
-    }
-    else if (nbcry > 447)
-    {
-        nbcry = nbcry - 448 + 64; // TUDA2: petal 2
-    }
-
-    if (nbcry < 32)
-        return kTRUE;
-    else if (nbcry > 191 && nbcry < 224)
-        return kTRUE;
-    else if (nbcry > 255 && nbcry < 448)
-        return kTRUE;
-    else
-        return kFALSE;
-}
-
-/*
-  void R3BCalifaMapped2CrystalCalPar::SetOutputFile(const char *outFile)
-  {
-  fOutputFile = const_cast<char*>(outFile);
-  }
-*/
 ClassImp(R3BCalifaMapped2CrystalCalPar)

--- a/califa/unpack/R3BCalifaMapped2CrystalCalPar.h
+++ b/califa/unpack/R3BCalifaMapped2CrystalCalPar.h
@@ -18,6 +18,7 @@
 #include "TH1F.h"
 
 class TClonesArray;
+class R3BCalifaMappingPar;
 class R3BCalifaCrystalCalPar;
 class R3BEventHeader;
 
@@ -55,10 +56,8 @@ class R3BCalifaMapped2CrystalCalPar : public FairTask
     /** Virtual method Search peaks and calibrate **/
     virtual void SearchPeaks();
 
-    /** Method to Search for preamp ranges **/
-    bool Searchrange(Int_t val);
-
-    void SetOutputFile(const char* outFile);
+    /** Virtual method SetParContainers **/
+    virtual void SetParContainers();
 
     /** Accessor functions **/
     const Int_t GetNumCrystals() { return fNumCrystals; }
@@ -95,6 +94,8 @@ class R3BCalifaMapped2CrystalCalPar : public FairTask
     }
 
   protected:
+    void SetParameter();
+    Int_t fDebugMode;
     Int_t fNumCrystals;
     Int_t fMapHistos_left; // gamma range
     Int_t fMapHistos_right;
@@ -113,13 +114,11 @@ class R3BCalifaMapped2CrystalCalPar : public FairTask
     TArrayF* fEnergyPeaks;
     Double_t* fChannelPeaks;
 
-    Int_t fDebugMode;
-
-    R3BCalifaCrystalCalPar* fCal_Par;  /**< Parameter container. >*/
-    TClonesArray* fCalifaMappedDataCA; /**< Array with CALIFA Mapped- input data. >*/
+    R3BCalifaMappingPar* fMap_Par;     /**< Parameter container with mapping. >*/
+    R3BCalifaCrystalCalPar* fCal_Par;  /**< Container for Cal parameters. >*/
+    TClonesArray* fCalifaMappedDataCA; /**< Array with CALIFA Mapped-input data. >*/
 
     TH1F** fh_Map_energy_crystal;
-    char* fOutputFile;
 
   public:
     ClassDef(R3BCalifaMapped2CrystalCalPar, 2);


### PR DESCRIPTION
Removed WR histograms from califa online

Removed all califa online histograms and old code

Califa: First histograms for commissioning

Added more histograms for califa online

Added califaMappingPar container to CalifaMapped2CrystalCalPar to manage automatically the crystal calibration

Added hit level histograms for califa online

CALIFA: Changed crystal ID for gamma range to 2432

Added more histograms to califa online and clang-format