### PR TITLE
Mass handling in Generators and R3BMCTrack:

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -6,9 +6,6 @@ line_width = 100
 # How many spaces to tab for indent
 tab_size = 4
 
-# If arglists are longer than this, break them always
-max_subargs_per_line = 3
-
 # If true, separate flow control names from their parentheses with a space
 separate_ctrl_name_with_space = False
 
@@ -36,3 +33,6 @@ keyword_case = u'unchanged'
 
 # A list of command names which should always be wrapped
 always_wrap = []
+
+# Don't reformat comments
+enable_markup = False

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ unset(Boost_INCLUDE_DIR CACHE)
 unset(Boost_LIBRARY_DIRS CACHE)
 find_package2(PUBLIC Boost
   VERSION 1.67 ${FairMQ_Boost_VERSION}
-  COMPONENTS thread system timer program_options random filesystem chrono exception 
+  COMPONENTS thread system timer program_options random filesystem chrono exception iostreams
 regex serialization log log_setup atomic date_time signals ${FairMQ_Boost_COMPONENTS}
 )
 if(Boost_FOUND)

--- a/neuland/reconstruction/Neutron2DCalibr.cxx
+++ b/neuland/reconstruction/Neutron2DCalibr.cxx
@@ -12,52 +12,40 @@
  ******************************************************************************/
 
 #include "Neutron2DCalibr.h"
-#include "FairMCPoint.h"
 #include "FairParRootFileIo.h"
 #include "FairRuntimeDb.h"
 #include "Math/Factory.h"
 #include "Math/Functor.h"
 #include "Math/Minimizer.h"
 #include "R3BMCTrack.h"
+#include "R3BNeulandCluster.h"
 #include "R3BNeulandNeutron2DPar.h"
-#include "TBranch.h"
 #include "TCanvas.h"
 #include "TClonesArray.h"
 #include "TColor.h"
 #include "TCutG.h"
 #include "TFile.h"
-#include "TH2D.h"
 #include "TStyle.h"
 #include "TTree.h"
 
-unsigned int GetNin(const TClonesArray* tracks)
-{
-    unsigned int n = 0;
-
-    const Int_t nTracks = tracks->GetEntries();
-    for (Int_t i = 0; i < nTracks; i++)
-    {
-        auto track = (R3BMCTrack*)tracks->At(i);
-        if (track->GetMotherId() == -1 && track->GetPdgCode() == 2112)
-        {
-            n++;
-        }
-    }
-    return n;
-}
-
-TH2D* GetOrBuildHist(std::map<UInt_t, TH2D*>& map, const unsigned int i, const TString& name, const TString& title)
+std::unique_ptr<TH2D>& GetOrBuildHist(std::map<unsigned int, std::unique_ptr<TH2D>>& map,
+                                      const unsigned int i,
+                                      const TString& name,
+                                      const TString& title)
 {
     if (map.find(i) == map.end())
     {
-        map[i] = new TH2D(name + TString::UItoa(i, 10), TString::UItoa(i, 10) + title, 300, 0, 3000, 50, 0, 50);
+        map[i] = std::unique_ptr<TH2D>(
+            new TH2D(name + std::to_string(i), std::to_string(i) + title, 300, 0, 3000, 50, 0, 50));
         map.at(i)->GetXaxis()->SetTitle("Total Energy [MeV]");
         map.at(i)->GetYaxis()->SetTitle("Number of Clusters");
     }
     return map.at(i);
 }
 
-void DoPrint(std::ostream& out, const std::map<UInt_t, TH2D*>& map, const std::map<UInt_t, TCutG*>& cuts)
+void DoPrint(std::ostream& out,
+             const std::map<unsigned int, std::unique_ptr<TH2D>>& map,
+             const std::map<unsigned int, TCutG*>& cuts)
 {
     out << "\t";
     for (const auto& nh : map)
@@ -69,20 +57,20 @@ void DoPrint(std::ostream& out, const std::map<UInt_t, TH2D*>& map, const std::m
 
     for (const auto& nc : cuts)
     {
-        const UInt_t nOut = nc.first;
+        const unsigned int nOut = nc.first;
         const TCutG* cut = nc.second;
 
         out << nOut << "n:\t";
 
-        Double_t sum = 0.;
+        double sum = 0.;
         for (const auto& nh : map)
         {
-            sum += ((Double_t)cut->IntegralHist(nh.second) / (Double_t)nh.second->GetEntries());
-            out << ((Double_t)cut->IntegralHist(nh.second) / (Double_t)nh.second->GetEntries()) << "\t";
+            sum += ((double)cut->IntegralHist(nh.second.get()) / (double)nh.second->GetEntries());
+            out << ((double)cut->IntegralHist(nh.second.get()) / (double)nh.second->GetEntries()) << "\t";
         }
         if (map.find(nOut) != map.end())
         {
-            out << (Double_t)cut->IntegralHist(map.at(nOut)) / (Double_t)(map.at(nOut)->GetEntries()) / sum;
+            out << (double)cut->IntegralHist(map.at(nOut).get()) / (double)(map.at(nOut)->GetEntries()) / sum;
         }
         out << std::endl;
     }
@@ -90,41 +78,34 @@ void DoPrint(std::ostream& out, const std::map<UInt_t, TH2D*>& map, const std::m
 
 namespace Neuland
 {
-    Neutron2DCalibr::Neutron2DCalibr(UInt_t nmax)
+    Neutron2DCalibr::Neutron2DCalibr(unsigned int nmax)
         : fNMax(nmax)
     {
+        TH2::AddDirectory(false);
     }
 
     void Neutron2DCalibr::AddClusterFile(const TString& filename)
     {
-        auto file = new TFile(filename, "READ");
-        auto tree = (TTree*)file->Get("evt");
-        tree->AddFriend("evt2=evt", TString(filename).ReplaceAll(".digi.root", ".simu.root"));
+        TFile file(filename, "READ");
+        auto tree = (TTree*)file.Get("evt");
 
-        TBranch* branch = tree->GetBranch("NeulandClusters");
         auto clusters = new TClonesArray("R3BNeulandCluster");
-        branch->SetAddress(&clusters);
+        tree->SetBranchAddress("NeulandClusters", &clusters);
+        auto primaryPoints = new TClonesArray("R3BNeulandPoint");
+        tree->SetBranchAddress("NeulandPrimaryPoints", &primaryPoints);
+        auto neutronTracks = new TClonesArray("R3BMCTrack");
+        tree->SetBranchAddress("NeulandPrimaryTracks", &neutronTracks);
 
-        TBranch* branch2 = tree->GetBranch("NeulandPrimaryPoints");
-        auto npnips = new TClonesArray("FairMCPoint");
-        branch2->SetAddress(&npnips);
-
-        TBranch* branch3 = tree->GetBranch("MCTrack");
-        auto tracks = new TClonesArray("R3BMCTrack");
-        branch3->SetAddress(&tracks);
-
-        const Int_t nEntries = tree->GetEntries();
-        for (Int_t ei = 0; ei < nEntries; ei++)
+        const int nEntries = tree->GetEntries();
+        for (int ei = 0; ei < nEntries; ei++)
         {
-            branch->GetEntry(ei);
-            branch2->GetEntry(ei);
-            branch3->GetEntry(ei);
+            tree->GetEntry(ei);
 
-            Double_t Etot = 0.;
-            Int_t validClusters = 0;
-            const Int_t nClusters = clusters->GetEntries();
+            double Etot = 0.;
+            int validClusters = 0;
 
-            for (Int_t ci = 0; ci < nClusters; ci++)
+            const int nClusters = clusters->GetEntries();
+            for (int ci = 0; ci < nClusters; ci++)
             {
                 auto cluster = (R3BNeulandCluster*)clusters->At(ci);
                 Etot += cluster->GetE();
@@ -134,40 +115,45 @@ namespace Neuland
                 }
             }
 
-            const unsigned int nNPNIPs = npnips->GetEntries();
-            if (nNPNIPs <= fNMax)
+            const unsigned int nPrimaryPoints = primaryPoints->GetEntries();
+            if (nPrimaryPoints <= fNMax)
             {
-                auto h = GetOrBuildHist(fHistsNreac, nNPNIPs, "hEC", "n reacted");
-                h->Fill(Etot, validClusters);
+                GetOrBuildHist(fHistsNreac, nPrimaryPoints, "hnPP", "n reacted")->Fill(Etot, validClusters);
             }
 
-            const unsigned int nNin = GetNin(tracks);
-            if (nNin <= fNMax)
+            const unsigned int nNeutrons = neutronTracks->GetEntries();
+            if (nNeutrons <= fNMax)
             {
-                auto h = GetOrBuildHist(fHistsNin, nNin, "hNin", "n incoming");
-                h->Fill(Etot, validClusters);
+                GetOrBuildHist(fHistsNreac, nPrimaryPoints, "hnPP", "n reacted")->Fill(Etot, validClusters);
             }
         }
+
+        clusters->Delete();
+        delete clusters;
+        primaryPoints->Delete();
+        delete primaryPoints;
+        neutronTracks->Delete();
+        delete neutronTracks;
     }
 
-    void Neutron2DCalibr::Optimize(std::vector<Double_t> slope,
-                                   std::vector<Double_t> distance,
-                                   std::vector<Double_t> dist_off)
+    void Neutron2DCalibr::Optimize(std::vector<double> slope,
+                                   std::vector<double> distance,
+                                   std::vector<double> dist_off)
     {
-        const UInt_t nVars = 3;
+        const unsigned int nVars = 3;
 
         ROOT::Math::Minimizer* min = ROOT::Math::Factory::CreateMinimizer("Minuit2", "Simplex");
         min->SetMaxFunctionCalls(100000000);
         min->SetMaxIterations(10000000);
         min->SetTolerance(0.05);
 
-        ROOT::Math::Functor f([&](const Double_t* d) { return WastedEfficiency(d); }, nVars);
+        ROOT::Math::Functor f([&](const double* d) { return WastedEfficiency(d); }, nVars);
         min->SetFunction(f);
 
-        /*Double_t step[nVars] = { 0.001, 0.5, 0.5 };
-        Double_t variable[nVars] = { 0.04, 10, 3 };
-        Double_t lower[nVars] = { 0.001, 1, 3 };
-        Double_t upper[nVars] = { 10, 20, 6 };*/
+        /*double step[nVars] = { 0.001, 0.5, 0.5 };
+        double variable[nVars] = { 0.04, 10, 3 };
+        double lower[nVars] = { 0.001, 1, 3 };
+        double upper[nVars] = { 10, 20, 6 };*/
         min->SetLimitedVariable(0, "slope", slope.at(0), slope.at(1), slope.at(2), slope.at(3));
         min->SetLimitedVariable(1, "distance", distance.at(0), distance.at(1), distance.at(2), distance.at(3));
         min->SetLimitedVariable(2, "distance offset", dist_off.at(0), dist_off.at(1), dist_off.at(2), dist_off.at(3));
@@ -177,16 +163,16 @@ namespace Neuland
         std::cout << "Neutron2DCalibr::Optimize done!" << std::endl;
     }
 
-    TCutG* Neutron2DCalibr::GetCut(const UInt_t nNeutrons, const Double_t k, const Double_t k0, const Double_t m)
+    TCutG* Neutron2DCalibr::GetCut(const unsigned int nNeutrons, const double k, const double k0, const double m)
     {
         if (!fCuts[nNeutrons])
         {
-            fCuts[nNeutrons] = new TCutG(TString::UItoa(nNeutrons, 10), 4);
+            fCuts[nNeutrons] = new TCutG(TString(std::to_string(nNeutrons)), 4);
             fCuts.at(nNeutrons)->SetVarX("Total Energy [MeV]");
             fCuts.at(nNeutrons)->SetVarY("Number of Clusters");
         }
 
-        Double_t y0;
+        double y0;
         if (nNeutrons != 0)
         {
             y0 = (nNeutrons - 1) * k + k0;
@@ -196,9 +182,9 @@ namespace Neuland
             y0 = -1;
         }
 
-        const Double_t y3 = nNeutrons * k + k0;
-        const Double_t x1 = y0 / m;
-        const Double_t x2 = y3 / m;
+        const double y3 = nNeutrons * k + k0;
+        const double x1 = y0 / m;
+        const double x2 = y3 / m;
         // std::cout << "(0, " << y0 << ") (" << x1 << ", 0) (" << x2 << ", 0) ( 0, " << y3 << ")" << std::endl;
 
         TCutG* cut = fCuts[nNeutrons];
@@ -217,19 +203,19 @@ namespace Neuland
         return cut;
     }
 
-    Double_t Neutron2DCalibr::WastedEfficiency(const Double_t* d)
+    double Neutron2DCalibr::WastedEfficiency(const double* d)
     {
-        Double_t m = d[0];
-        Double_t k = d[1];
-        Double_t k0 = d[2];
+        double m = d[0];
+        double k = d[1];
+        double k0 = d[2];
         GetCut(0, k, k0, m);
 
-        Double_t wasted_efficiency = 0;
+        double wasted_efficiency = 0;
         for (auto& nh : fHistsNreac)
         {
-            const UInt_t nNeutrons = nh.first;
-            wasted_efficiency += 1. - ((Double_t)GetCut(nNeutrons, k, k0, m)->IntegralHist(nh.second) /
-                                       (Double_t)nh.second->GetEntries());
+            const unsigned int nNeutrons = nh.first;
+            wasted_efficiency += 1. - ((double)GetCut(nNeutrons, k, k0, m)->IntegralHist(nh.second.get()) /
+                                       (double)nh.second->GetEntries());
         }
         return wasted_efficiency;
     }
@@ -237,17 +223,11 @@ namespace Neuland
     void Neutron2DCalibr::Draw(const TString& img) const
     {
         gStyle->SetOptStat(0);
-        // reverse viridis
-        Double_t stops[9] = { 0.0000, 0.1250, 0.2500, 0.3750, 0.5000, 0.6250, 0.7500, 0.8750, 1.0000 };
-        Double_t red[9] = { 246. / 255., 144. / 255., 74. / 255., 35. / 255., 28. / 255.,
-                            33. / 255.,  43. / 255.,  51. / 255., 26. / 255. };
-        Double_t green[9] = { 222. / 255., 200. / 255., 180. / 255., 150. / 255., 118. / 255.,
-                              87. / 255.,  55. / 255.,  24. / 255.,  9. / 255. };
-        Double_t blue[9] = { 0. / 255.,   35. / 255.,  72. / 255., 101. / 255., 112. / 255.,
-                             114. / 255., 112. / 255., 96. / 255., 30. / 255. };
-        TColor::CreateGradientColorTable(9, stops, red, green, blue, 255, 1);
+        gStyle->SetPalette(-1);
+        gStyle->SetPalette(kViridis);
+        TColor::InvertPalette();
 
-        auto c = new TCanvas("Neutron2DCalibr", "Neuland Neutron2D Calibr", 500 * fNMax, 500);
+        std::unique_ptr<TCanvas> c(new TCanvas("Neutron2DCalibr", "Neuland Neutron2D Calibr", 500 * fNMax, 500));
         c->Divide(fNMax, 1);
 
         for (auto& nh : fHistsNreac)
@@ -263,7 +243,7 @@ namespace Neuland
             gPad->SetLeftMargin(0.06);
             gPad->SetRightMargin(0.13);
 
-            auto hist = nh.second;
+            auto& hist = nh.second;
             hist->SetLineWidth(1);
             hist->SetTitle("");
             hist->SetXTitle("");
@@ -284,8 +264,6 @@ namespace Neuland
         {
             c->Print(img);
         }
-
-        c->Draw();
     }
 
     void Neutron2DCalibr::Print(std::ostream& out) const
@@ -301,21 +279,17 @@ namespace Neuland
 
     void Neutron2DCalibr::WriteParameterFile(const TString& parFile) const
     {
-        FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+        std::unique_ptr<FairRuntimeDb> rtdb(FairRuntimeDb::instance());
+        FairParRootFileIo io(kTRUE);
+        io.open(parFile);
+        rtdb->setOutput(&io);
 
-        FairParRootFileIo* io = new FairParRootFileIo(kTRUE);
-        io->open(parFile);
-        rtdb->setOutput(io);
-
-        R3BNeulandNeutron2DPar* par = (R3BNeulandNeutron2DPar*)rtdb->getContainer("R3BNeulandNeutron2DPar");
+        auto par = (R3BNeulandNeutron2DPar*)rtdb->getContainer("R3BNeulandNeutron2DPar");
 
         rtdb->addRun(1);
         par->SetNeutronCuts(fCuts);
         par->setChanged();
         rtdb->writeContainers();
-
-        rtdb->saveOutput();
-        rtdb->print();
 
         for (auto& nh : fHistsNreac)
         {
@@ -326,5 +300,20 @@ namespace Neuland
         {
             nh.second->Write();
         }
+
+        rtdb->saveOutput();
+        rtdb->print();
+        rtdb->closeOutput();
     }
+
+    Neutron2DCalibr::~Neutron2DCalibr()
+    {
+        for (auto& nc : fCuts)
+        {
+            delete nc.second;
+        }
+    }
+
 }; // namespace Neuland
+
+ClassImp(Neuland::Neutron2DCalibr);

--- a/neuland/reconstruction/Neutron2DCalibr.h
+++ b/neuland/reconstruction/Neutron2DCalibr.h
@@ -15,14 +15,14 @@
 #define NEULANDNEUTRON2DCALIBR
 
 #include "Filterable.h"
-#include "R3BNeulandCluster.h"
-#include "Rtypes.h"
+#include "TH2D.h"
 #include "TString.h"
 #include <iostream>
 #include <map>
+#include <memory>
 
 class TCutG;
-class TH2D;
+class R3BNeulandCluster;
 
 /*
 
@@ -44,26 +44,29 @@ namespace Neuland
     class Neutron2DCalibr
     {
       public:
-        Neutron2DCalibr(UInt_t nmax);
+        Neutron2DCalibr(unsigned int nmax);
+        virtual ~Neutron2DCalibr();
 
         void AddClusterFile(const TString& file);
-        void Optimize(std::vector<Double_t> slope = { 0.04, 0.001, 0.001, 10 },
-                      std::vector<Double_t> distance = { 10, 0.5, 1, 20 },
-                      std::vector<Double_t> dist_off = { 3, 0.5, 3, 6 });
+        void Optimize(std::vector<double> slope = { 0.04, 0.001, 0.001, 10 },
+                      std::vector<double> distance = { 10, 0.5, 1, 20 },
+                      std::vector<double> dist_off = { 3, 0.5, 3, 6 });
         void Print(std::ostream& out = std::cout) const;
         void Draw(const TString& img = "") const;
         void WriteParameterFile(const TString& parFile) const;
-        void AddFilter(const Filterable<R3BNeulandCluster*>::Filter f) { fClusterFilters.Add(f); }
+        void AddFilter(const Filterable<R3BNeulandCluster*>::Filter& f) { fClusterFilters.Add(f); }
 
       private:
-        TCutG* GetCut(const UInt_t nNeutrons, const Double_t k, const Double_t k0, const Double_t m);
-        Double_t WastedEfficiency(const Double_t* d);
+        TCutG* GetCut(unsigned int nNeutrons, double k, double k0, double m);
+        double WastedEfficiency(const double* d);
 
-        UInt_t fNMax;
-        std::map<UInt_t, TH2D*> fHistsNreac;
-        std::map<UInt_t, TH2D*> fHistsNin;
-        std::map<UInt_t, TCutG*> fCuts;
+        unsigned int fNMax;
+        std::map<unsigned int, std::unique_ptr<TH2D>> fHistsNreac;
+        std::map<unsigned int, std::unique_ptr<TH2D>> fHistsNin;
+        std::map<unsigned int, TCutG*> fCuts;
         Filterable<R3BNeulandCluster*> fClusterFilters;
+
+        ClassDef(Neutron2DCalibr, 0);
     };
 
 }; // namespace Neuland

--- a/neuland/simulation/R3BNeulandMCMon.h
+++ b/neuland/simulation/R3BNeulandMCMon.h
@@ -78,7 +78,9 @@ class R3BNeulandMCMon : public FairTask
 
     TH1D* fhPDG;
     TH1D* fhEPrimarys;
+    TH1D* fhEPrimarys2;
     TH1D* fhEPrimaryNeutrons;
+    TH1D* fhErelMC;
     TH1D* fhEtot;
     TH1D* fhEtotPrim;
     TH1D* fhESecondaryNeutrons;

--- a/neuland/simulation/R3BNeulandPrimaryInteractionFinder.cxx
+++ b/neuland/simulation/R3BNeulandPrimaryInteractionFinder.cxx
@@ -116,11 +116,13 @@ R3BNeulandHit* FindFirstHit(const R3BMCTrack* track,
 R3BNeulandPrimaryInteractionFinder::R3BNeulandPrimaryInteractionFinder(TString pointsIn,
                                                                        TString hitsIn,
                                                                        TString pointsOut,
-                                                                       TString hitsOut)
+                                                                       TString hitsOut,
+                                                                       TString tracksOut)
     : FairTask("R3BNeulandPrimaryInteractionFinder")
-    , fTracks("MCTrack")
+    , fTracksIn("MCTrack")
     , fPointsIn(std::move(pointsIn))
     , fHitsIn(std::move(hitsIn))
+    , fTracksOut(std::move(tracksOut))
     , fPointsOut(std::move(pointsOut))
     , fHitsOut(std::move(hitsOut))
     , fhDistance(new TH1D("fhDistance", "Distance firstPoint to firstHit", 10000, 0, 1000))
@@ -137,9 +139,10 @@ R3BNeulandPrimaryInteractionFinder::R3BNeulandPrimaryInteractionFinder(TString p
 
 InitStatus R3BNeulandPrimaryInteractionFinder::Init()
 {
-    fTracks.Init();
+    fTracksIn.Init();
     fPointsIn.Init();
     fHitsIn.Init();
+    fTracksOut.Init();
     fPointsOut.Init();
     fHitsOut.Init();
     return kSUCCESS;
@@ -147,9 +150,10 @@ InitStatus R3BNeulandPrimaryInteractionFinder::Init()
 
 void R3BNeulandPrimaryInteractionFinder::Exec(Option_t*)
 {
-    const auto tracks = fTracks.Retrieve();
+    const auto tracks = fTracksIn.Retrieve();
     const auto points = fPointsIn.Retrieve();
     const auto hits = fHitsIn.Retrieve();
+    fTracksOut.Reset();
     fPointsOut.Reset();
     fHitsOut.Reset();
 
@@ -174,6 +178,8 @@ void R3BNeulandPrimaryInteractionFinder::Exec(Option_t*)
     {
         if (IsPrimaryTrack(track))
         {
+            fTracksOut.Insert(track);
+
             const auto firstPoint = FindFirstPoint(track, p2t);
             const auto firstHit = FindFirstHit(track, p2t, p2h);
 

--- a/neuland/simulation/R3BNeulandPrimaryInteractionFinder.h
+++ b/neuland/simulation/R3BNeulandPrimaryInteractionFinder.h
@@ -28,7 +28,8 @@ class R3BNeulandPrimaryInteractionFinder : public FairTask
     explicit R3BNeulandPrimaryInteractionFinder(TString pointsIn = "NeulandPoints",
                                                 TString hitsIn = "NeulandHits",
                                                 TString pointsOut = "NeulandPrimaryPoints",
-                                                TString hitsOut = "NeulandPrimaryHits");
+                                                TString hitsOut = "NeulandPrimaryHits",
+                                                TString tracksOut = "NeulandPrimaryTracks");
 
     ~R3BNeulandPrimaryInteractionFinder() override = default;
 
@@ -46,10 +47,11 @@ class R3BNeulandPrimaryInteractionFinder : public FairTask
     void Exec(Option_t*) override;
 
   private:
-    TCAInputConnector<R3BMCTrack> fTracks;
+    TCAInputConnector<R3BMCTrack> fTracksIn;
     TCAInputConnector<R3BNeulandPoint> fPointsIn;
     TCAInputConnector<R3BNeulandHit> fHitsIn;
 
+    TCAOutputConnector<R3BMCTrack> fTracksOut;
     TCAOutputConnector<R3BNeulandPoint> fPointsOut;
     TCAOutputConnector<R3BNeulandHit> fHitsOut;
 

--- a/neuland/test/CMakeLists.txt
+++ b/neuland/test/CMakeLists.txt
@@ -41,7 +41,8 @@ set(TEST_DEPENDENCIES
     R3Bbase
     R3BData
     R3BNeulandShared
-    R3BNeulandReconstruction)
+    R3BNeulandReconstruction
+    Alignment)
 
 add_executable(${PROJECT_TEST_NAME} ${TEST_SRC_FILES})
 target_link_libraries(${PROJECT_TEST_NAME} ${TEST_DEPENDENCIES})

--- a/passive/CMakeLists.txt
+++ b/passive/CMakeLists.txt
@@ -47,6 +47,7 @@ R3BGeoVacVesselCool.cxx
 R3BGeoTarget.cxx
 R3BAladinMagnet.cxx
 R3BGladMagnet.cxx
+R3BNeutronWindowAndSomeAir.cxx
 R3BPassiveContFact.cxx
 R3BPipe.cxx
 R3BVacVesselCool.cxx

--- a/passive/PassiveLinkDef.h
+++ b/passive/PassiveLinkDef.h
@@ -27,7 +27,7 @@
 #pragma link C++ class R3BPipe+;
 #pragma link C++ class R3BVacVesselCool+;
 #pragma link C++ class R3BCave+;
-
+#pragma link C++ class R3BNeutronWindowAndSomeAir+;
 #pragma link C++ class R3BGeoCave;
 #pragma link C++ class R3BGeoGDML+;
 #pragma link C++ class R3BGeoPipe;

--- a/passive/R3BNeutronWindowAndSomeAir.cxx
+++ b/passive/R3BNeutronWindowAndSomeAir.cxx
@@ -1,0 +1,53 @@
+#include "R3BNeutronWindowAndSomeAir.h"
+#include "FairGeoBuilder.h"
+#include "FairGeoInterface.h"
+#include "FairGeoLoader.h"
+#include "FairGeoMedia.h"
+#include "FairLogger.h"
+#include "TGeoManager.h"
+#include "TGeoMedium.h"
+
+R3BNeutronWindowAndSomeAir::R3BNeutronWindowAndSomeAir(double xstart, double xstop)
+    : FairModule("NeutronWindowAndSomeAir", "NeutronWindowAndSomeAir", false)
+    , fStart(xstart)
+    , fStop(xstop)
+{
+}
+
+void R3BNeutronWindowAndSomeAir::ConstructRootGeometry(TGeoMatrix*)
+{
+    if (gGeoManager == nullptr)
+    {
+        LOG(FATAL) << __FUNCTION__ << ": No gGeoManager";
+    }
+
+    auto volSomeAir = gGeoManager->MakeBox("SomeAir", FindMaterial("Air"), 125, 125, (fStop - fStart) / 2.);
+    gGeoManager->GetTopVolume()->AddNode(volSomeAir, 1, new TGeoTranslation(0, 0, fStart + (fStop - fStart) / 2.));
+    auto volWindow = gGeoManager->MakeTube("NeutronWindow", FindMaterial("Steel"), 0, 70, 0.2);
+    gGeoManager->GetTopVolume()->AddNode(volWindow, 1, new TGeoTranslation(0, 0, fStart - 0.2));
+}
+
+// TODO: Simulation crashes without this. It should not be necessary to do this?!
+TGeoMedium* R3BNeutronWindowAndSomeAir::FindMaterial(const std::string& mat) const
+{
+    auto geoLoad = FairGeoLoader::Instance();
+    auto geoFace = geoLoad->getGeoInterface();
+    auto geoBuild = geoLoad->getGeoBuilder();
+    auto geoMedia = geoFace->getMedia();
+
+    auto fairMedium = geoMedia->getMedium(mat.c_str());
+    if (!fairMedium)
+    {
+        LOG(FATAL) << __FUNCTION__ << ": FairGeoMedium " << mat << " not found";
+    }
+    geoBuild->createMedium(fairMedium);
+
+    auto med = gGeoManager->GetMedium(mat.c_str());
+    if (!med)
+    {
+        LOG(FATAL) << __FUNCTION__ << ": TGeoMedium " << mat << " not found";
+    }
+    return med;
+}
+
+ClassImp(R3BNeutronWindowAndSomeAir)

--- a/passive/R3BNeutronWindowAndSomeAir.h
+++ b/passive/R3BNeutronWindowAndSomeAir.h
@@ -1,0 +1,45 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BROOT_R3BNEUTRONWINDOWANDSOMEAIR_H
+#define R3BROOT_R3BNEUTRONWINDOWANDSOMEAIR_H
+
+/* Place a neutron window (4mm steel) at xstart and air between start and stop
+ * This can be used for NeuLAND simulations as there is currently no vacuum chamber implemented.
+ * Instead, invert the problem: Use vacuum in the Cave and place a bunch o' air. Presto!
+ * Bonus: No need to adjust the magnetic field for different beam energies.
+ * The heavy ion will always fly through vacuum, and the neutrons through the right amount of material
+ */
+
+#include "FairModule.h"
+
+class TGeoMedium;
+
+class R3BNeutronWindowAndSomeAir : public FairModule
+{
+  public:
+    explicit R3BNeutronWindowAndSomeAir(double start = 700, double stop = 1300);
+
+    void ConstructGeometry() override { ConstructRootGeometry(); }
+    void ConstructRootGeometry(TGeoMatrix* _ = nullptr) override;
+
+  private:
+    TGeoMedium* FindMaterial(const std::string& mat) const;
+
+    double fStart;
+    double fStop;
+
+    ClassDefOverride(R3BNeutronWindowAndSomeAir, 1)
+};
+
+#endif // R3BROOT_R3BNEUTRONWINDOWANDSOMEAIR_H

--- a/r3bdata/R3BMCStack.cxx
+++ b/r3bdata/R3BMCStack.cxx
@@ -277,11 +277,8 @@ void R3BStack::FillTrackArray()
 
         if (store)
         {
-            R3BMCTrack* track = new ((*fTracks)[fNTracks]) R3BMCTrack(GetParticle(iPart), fMC);
+            new ((*fTracks)[fNTracks]) R3BMCTrack(GetParticle(iPart), fPointsMap[iPart], fMC);
             fIndexMap[iPart] = fNTracks;
-            // --> Set the number of points in the detectors for this track
-            track->SetNPoints(fPointsMap[iPart]);
-
             fNTracks++;
             // cout << "-I- TParticle time " << GetParticle(iPart)->T() << endl;
             // cout << "-I- MC Track time " << track->GetStartT() << endl;

--- a/r3bdata/R3BMCTrack.cxx
+++ b/r3bdata/R3BMCTrack.cxx
@@ -11,155 +11,63 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 
-// -------------------------------------------------------------------------
-// -----                      R3BMCTrack source file                   -----
-// -----                  Created 03/08/04                             -----
-// -------------------------------------------------------------------------
 #include "R3BMCTrack.h"
-
 #include "FairLogger.h"
-
 #include <iostream>
+#include <utility>
 
-using std::cout;
-using std::endl;
-
-// -----   Default constructor   -------------------------------------------
 R3BMCTrack::R3BMCTrack()
     : fPdgCode(0)
-    , fMotherId(-1)
-    , fPx(0.)
-    , fPy(0.)
-    , fPz(0.)
-    , fStartX(0.)
-    , fStartY(0.)
-    , fStartZ(0.)
-    , fStartT(0.)
-    , fNPoints({})
-    , fMass(0.)
+    , fMotherId(0)
+    , fStartVertex()
+    , fMomentumMass()
+    , fNPoints()
 {
 }
-// -------------------------------------------------------------------------
 
-// -----   Standard constructor   ------------------------------------------
-R3BMCTrack::R3BMCTrack(Int_t pdgCode,
-                       Int_t motherId,
-                       Double_t px,
-                       Double_t py,
-                       Double_t pz,
-                       Double_t x,
-                       Double_t y,
-                       Double_t z,
-                       Double_t t,
+R3BMCTrack::R3BMCTrack(int pdgCode,
+                       int motherId,
+                       ROOT::Math::XYZTVector xyzt,
+                       ROOT::Math::PxPyPzMVector pm,
                        std::array<int, kLAST + 1> nPoints)
     : fPdgCode(pdgCode)
     , fMotherId(motherId)
-    , fPx(px)
-    , fPy(py)
-    , fPz(pz)
-    , fStartX(x)
-    , fStartY(y)
-    , fStartZ(z)
-    , fStartT(t)
+    , fStartVertex(std::move(xyzt))
+    , fMomentumMass(std::move(pm))
     , fNPoints(nPoints)
-    , fMass(0.)
 {
 }
-// -------------------------------------------------------------------------
 
-// -----   Copy constructor   ----------------------------------------------
-R3BMCTrack::R3BMCTrack(const R3BMCTrack& right)
-    : fPdgCode(right.fPdgCode)
-    , fMotherId(right.fMotherId)
-    , fPx(right.fPx)
-    , fPy(right.fPy)
-    , fPz(right.fPz)
-    , fStartX(right.fStartX)
-    , fStartY(right.fStartY)
-    , fStartZ(right.fStartZ)
-    , fStartT(right.fStartT)
-    , fNPoints(right.fNPoints)
-    , fMass(right.fMass)
-{
-}
-// -------------------------------------------------------------------------
-
-// -----   Constructor from TParticle   ------------------------------------
-R3BMCTrack::R3BMCTrack(TParticle* part, Int_t fMC)
+R3BMCTrack::R3BMCTrack(TParticle* part, std::array<int, kLAST + 1> nPoints, int fMC)
     : fPdgCode(part->GetPdgCode())
     , fMotherId(part->GetMother(0))
-    , fPx(part->Px())
-    , fPy(part->Py())
-    , fPz(part->Pz())
-    , fStartX(part->Vx())
-    , fStartY(part->Vy())
-    , fStartZ(part->Vz())
-    , fStartT(0.)
-    , fNPoints({})
-    , fMass(part->GetMass())
+    , fStartVertex(part->Vx(), part->Vy(), part->Vz(), fMC == 0 ? part->T() * 1e09 : part->T()) // G3 == 0 ?!
+    , fMomentumMass(part->Px(), part->Py(), part->Pz(), part->GetMass())
+    , fNPoints(nPoints)
 {
-    if (fMC == 0)
-    {
-        // G3
-        fStartT = part->T() * 1e09;
-    }
-    else if (fMC == 1)
-    {
-        // G4
-        fStartT = part->T();
-    }
 }
-// -------------------------------------------------------------------------
 
-// -----   Destructor   ----------------------------------------------------
-R3BMCTrack::~R3BMCTrack() {}
-// -------------------------------------------------------------------------
-
-// -----   Public method Print   -------------------------------------------
 void R3BMCTrack::Print(Option_t* option) const
 {
-    cout << "Track " << option << ", mother : " << fMotherId << ", Type " << fPdgCode << ", momentum (" << fPx << ", "
-         << fPy << ", " << fPz << ") GeV" << endl;
-    cout << "       Ref " << GetNPoints(kREF) << ", DCH " << GetNPoints(kDCH) << ", CAL " << GetNPoints(kCAL)
-         << ", LAND " << GetNPoints(kLAND) << ", GFI " << GetNPoints(kGFI) << ", TOFd " << GetNPoints(kTOFD) << ", TOF "
-         << GetNPoints(kTOF) << ", TRACKER " << GetNPoints(kTRA) << ", CALIFA " << GetNPoints(kCALIFA) << ", MFI "
-         << GetNPoints(kMFI) << ", PSP " << GetNPoints(kPSP) << ", VETO " << GetNPoints(kVETO) << ", STARTRACK "
-         << GetNPoints(kSTARTRACK) << ", LUMON " << GetNPoints(kLUMON) << ", NeuLAND " << GetNPoints(kNEULAND) << endl;
+    std::cout << "Track " << option << ", mother : " << fMotherId << ", Type " << fPdgCode << ", momentum ("
+              << fMomentumMass.Px() << ", " << fMomentumMass.Py() << ", " << fMomentumMass.Pz() << ") GeV" << std::endl;
+    std::cout << "       Ref " << GetNPoints(kREF) << ", DCH " << GetNPoints(kDCH) << ", CAL " << GetNPoints(kCAL)
+              << ", LAND " << GetNPoints(kLAND) << ", GFI " << GetNPoints(kGFI) << ", TOFd " << GetNPoints(kTOFD)
+              << ", TOF " << GetNPoints(kTOF) << ", TRACKER " << GetNPoints(kTRA) << ", CALIFA " << GetNPoints(kCALIFA)
+              << ", MFI " << GetNPoints(kMFI) << ", PSP " << GetNPoints(kPSP) << ", VETO " << GetNPoints(kVETO)
+              << ", STARTRACK " << GetNPoints(kSTARTRACK) << ", LUMON " << GetNPoints(kLUMON) << ", NeuLAND "
+              << GetNPoints(kNEULAND) << std::endl;
 #ifdef SOFIA
-    cout << ", SCI " << GetNPoints(kSOFSCI) << ", AT " << GetNPoints(kSOFAT) << ", TRIM " << GetNPoints(kSOFTRIM)
-         << ", MWPC1 " << GetNPoints(kSOFMWPC1) << ", TWIM " << GetNPoints(kSOFTWIM) << ", MWPC2 "
-         << GetNPoints(kSOFMWPC2) << ", SOF ToF Wall " << GetNPoints(kSOFTofWall) << endl;
+    std::cout << ", SCI " << GetNPoints(kSOFSCI) << ", AT " << GetNPoints(kSOFAT) << ", TRIM " << GetNPoints(kSOFTRIM)
+              << ", MWPC1 " << GetNPoints(kSOFMWPC1) << ", TWIM " << GetNPoints(kSOFTWIM) << ", MWPC2 "
+              << GetNPoints(kSOFMWPC2) << ", SOF ToF Wall " << GetNPoints(kSOFTofWall) << std::endl;
 #endif
 #ifdef GTPC
-    cout << ", GTPC " << GetNPoints(kGTPC) << endl;
+    std::cout << ", GTPC " << GetNPoints(kGTPC) << std::endl;
 #endif
 }
-// -------------------------------------------------------------------------
 
-// -----   Public method GetMass   -----------------------------------------
-Double_t R3BMCTrack::GetMass() const
-{
-    //  if ( TDatabasePDG::Instance() ) {
-    //    TParticlePDG* particle = TDatabasePDG::Instance()->GetParticle(fPdgCode);
-    //    if ( particle ) return particle->Mass();
-    //    else return 0.;
-    //  }
-    //  return 0.;
-    return fMass;
-}
-// -------------------------------------------------------------------------
-
-// -----   Public method GetRapidity   -------------------------------------
-Double_t R3BMCTrack::GetRapidity() const
-{
-    Double_t e = GetEnergy();
-    Double_t y = 0.5 * TMath::Log((e + fPz) / (e - fPz));
-    return y;
-}
-// -------------------------------------------------------------------------
-
-// -----   Public method GetNPoints   --------------------------------------
-Int_t R3BMCTrack::GetNPoints(DetectorId detId) const
+int R3BMCTrack::GetNPoints(DetectorId detId) const
 {
     if (detId < 0 || detId >= fNPoints.size())
     {
@@ -168,18 +76,5 @@ Int_t R3BMCTrack::GetNPoints(DetectorId detId) const
     }
     return fNPoints.at(detId);
 }
-// -------------------------------------------------------------------------
-
-// -----   Public method SetNPoints   --------------------------------------
-void R3BMCTrack::SetNPoints(Int_t iDet, Int_t nP)
-{
-    if (iDet < 0 || iDet >= fNPoints.size())
-    {
-        LOG(ERROR) << "Unknown detector ID " << iDet;
-        return;
-    }
-    fNPoints[iDet] = nP;
-}
-// -------------------------------------------------------------------------
 
 ClassImp(R3BMCTrack)

--- a/r3bdata/R3BMCTrack.h
+++ b/r3bdata/R3BMCTrack.h
@@ -11,31 +11,15 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 
-// -------------------------------------------------------------------------
-// -----                      R3BMCTrack header file                   -----
-// -----                  Created 03/08/04                             -----
-// -------------------------------------------------------------------------
-
-/** R3BMCTrack.h
- **/
-
 #ifndef R3BMCTRACK_H
-#define R3BMCTRACK_H 1
+#define R3BMCTRACK_H
 
+#include "Math/Vector4D.h"
 #include "R3BDetectorList.h"
-
 #include "TLorentzVector.h"
 #include "TObject.h"
 #include "TParticle.h"
 #include "TVector3.h"
-
-#ifndef ROOT_TParticlePDG
-#include "TParticlePDG.h"
-#endif
-#ifndef ROOT_TDatabasePDG
-#include "TDatabasePDG.h"
-#endif
-
 #include <array>
 
 class R3BMCTrack : public TObject
@@ -46,98 +30,65 @@ class R3BMCTrack : public TObject
     R3BMCTrack();
 
     /**  Standard constructor  **/
-    R3BMCTrack(Int_t pdgCode,
-               Int_t motherID,
-               Double_t px,
-               Double_t py,
-               Double_t pz,
-               Double_t x,
-               Double_t y,
-               Double_t z,
-               Double_t t,
+    R3BMCTrack(int pdgCode,
+               int motherID,
+               ROOT::Math::XYZTVector xyzt,
+               ROOT::Math::PxPyPzMVector pm,
                std::array<int, kLAST + 1> nPoints);
 
-    /**  Copy constructor  **/
-    R3BMCTrack(const R3BMCTrack&);
-
     /**  Constructor from TParticle  **/
-    R3BMCTrack(TParticle* particle, Int_t fMC);
+    R3BMCTrack(TParticle* particle, std::array<int, kLAST + 1> nPoints, int fMC);
 
     /**  Destructor  **/
-    virtual ~R3BMCTrack();
-
-    R3BMCTrack& operator=(const R3BMCTrack&) { return *this; }
+    ~R3BMCTrack() override = default;
 
     /**  Output to screen  **/
-    virtual void Print(Option_t* option = "") const;
+    void Print(Option_t* option = "") const override;
 
     /**  Accessors  **/
-    Int_t GetPdgCode() const { return fPdgCode; }
-    Int_t GetMotherId() const { return fMotherId; }
-    Double_t GetPx() const { return fPx; }
-    Double_t GetPy() const { return fPy; }
-    Double_t GetPz() const { return fPz; }
-    Double_t GetStartX() const { return fStartX; }
-    Double_t GetStartY() const { return fStartY; }
-    Double_t GetStartZ() const { return fStartZ; }
-    Double_t GetStartT() const { return fStartT; }
-    Double_t GetMass() const;
-    Double_t GetEnergy() const;
-    Double_t GetPt() const { return TMath::Sqrt(fPx * fPx + fPy * fPy); }
-    Double_t GetP() const { return TMath::Sqrt(fPx * fPx + fPy * fPy + fPz * fPz); }
-    Double_t GetRapidity() const;
-    void GetMomentum(TVector3& momentum);
-    void Get4Momentum(TLorentzVector& momentum);
-    void GetStartVertex(TVector3& vertex);
+    int GetPdgCode() const { return fPdgCode; }
+    int GetMotherId() const { return fMotherId; }
+
+    double GetStartX() const { return fStartVertex.X(); }
+    double GetStartY() const { return fStartVertex.Y(); }
+    double GetStartZ() const { return fStartVertex.Z(); }
+    double GetStartT() const { return fStartVertex.T(); }
+    ROOT::Math::XYZTVector GetStartVertex() const { return fStartVertex; }
+
+    double GetPx() const { return fMomentumMass.Px(); }
+    double GetPy() const { return fMomentumMass.Py(); }
+    double GetPz() const { return fMomentumMass.Pz(); }
+    double GetMass() const { return fMomentumMass.M(); }
+    ROOT::Math::PxPyPzMVector GetMomentumMass() const { return fMomentumMass; };
+    ROOT::Math::PxPyPzEVector GetFourMomentum() const { return ROOT::Math::PxPyPzEVector(fMomentumMass); };
+    double GetEnergy() const { return fMomentumMass.E(); }
+    double GetPt() const { return fMomentumMass.Pt(); }
+    double GetP() const { return fMomentumMass.P(); }
+    double GetRapidity() const { return fMomentumMass.Rapidity(); };
 
     /** Accessors to the number of MCPoints in the detectors **/
-    Int_t GetNPoints(DetectorId detId) const;
+    int GetNPoints(DetectorId detId) const;
 
     /**  Modifiers  **/
-    void SetMotherId(Int_t id) { fMotherId = id; }
-    void SetNPoints(Int_t iDet, Int_t np);
-    void SetNPoints(std::array<int, kLAST + 1> nPoints) { fNPoints = nPoints; }
+    void SetMotherId(int id) { fMotherId = id; } // Used by R3BMCStack UpdateTrackIndex. Needed? -> Could make const!
 
   private:
     /**  PDG particle code  **/
-    Int_t fPdgCode;
+    const int fPdgCode;
 
     /**  Index of mother track. -1 for primary particles.  **/
-    Int_t fMotherId;
-
-    /** Momentum components at start vertex [GeV]  **/
-    Double32_t fPx, fPy, fPz;
+    int fMotherId;
 
     /** Coordinates of start vertex [cm, ns]  **/
-    Double32_t fStartX, fStartY, fStartZ, fStartT;
+    const ROOT::Math::XYZTVector fStartVertex;
 
-    /**  Bitvector representing the number of MCPoints for this track in
-     **  each subdetector. The detectors are represented by
-     **  REF:         Bit  0      (1 bit,  max. value  1)
-     **  The respective point numbers can be accessed and modified
-     **  with the inline functions.
-     **  Bits 26-31 are spare for potential additional detectors.
-     **/
-    std::array<int, kLAST + 1> fNPoints;
+    /** Momentum and mass at start vertex [GeV]  **/
+    const ROOT::Math::PxPyPzMVector fMomentumMass;
 
-    // case of HIons
-    Double32_t fMass;
+    /**  Array representing the number of MCPoints for this track in each subdetector. **/
+    const std::array<int, kLAST + 1> fNPoints;
 
-    ClassDef(R3BMCTrack, 2);
+    ClassDefOverride(R3BMCTrack, 3);
 };
-
-// ==========   Inline functions   ========================================
-
-inline Double_t R3BMCTrack::GetEnergy() const
-{
-    Double_t mass = GetMass();
-    return TMath::Sqrt(mass * mass + fPx * fPx + fPy * fPy + fPz * fPz);
-}
-
-inline void R3BMCTrack::GetMomentum(TVector3& momentum) { momentum.SetXYZ(fPx, fPy, fPz); }
-
-inline void R3BMCTrack::Get4Momentum(TLorentzVector& momentum) { momentum.SetXYZT(fPx, fPy, fPz, GetEnergy()); }
-
-inline void R3BMCTrack::GetStartVertex(TVector3& vertex) { vertex.SetXYZ(fStartX, fStartY, fStartZ); }
 
 #endif

--- a/r3bgen/CMakeLists.txt
+++ b/r3bgen/CMakeLists.txt
@@ -11,94 +11,72 @@
 # or submit itself to any jurisdiction.                                      #
 ##############################################################################
 
-# Create a library called "libBase" which includes the source files given in
-# the array .
-# The extension is already found.  Any number of sources could be listed here.
-
-# Check for gcc version, since for gcc 4 one has to add friend-injection
-# as option to compile FairPlutoGenerator
-#EXEC_PROGRAM( gcc ARGS "-dumpversion" OUTPUT_VARIABLE GCC_VERSION )
-#STRING(REGEX REPLACE "^([0-9]+)\\.[0-9]+\\.[0-9]" "\\1" req_gcc_major_vers "${GCC_VERSION}")
-#STRING(REGEX REPLACE "^[0-9]+\\.([0-9]+)\\.[0-9]" "\\1" req_gcc_minor_vers "${GCC_VERSION}")
-#IF(${req_gcc_major_vers} MATCHES "4" AND NOT ${req_gcc_minor_vers} MATCHES "0")
-#  SET_SOURCE_FILES_PROPERTIES(FairPlutoGenerator.cxx PROPERTIES COMPILE_FLAGS
-#  "-ffriend-injection")
-#ENDIF(${req_gcc_major_vers} MATCHES "4" AND NOT ${req_gcc_minor_vers} MATCHES "0")
-
-
 #########################################################
 # temporary workaround for testR3BPhaseSpaceGenerator.cxx
 # while FairVersion.h is not working
 execute_process(COMMAND ${FAIRROOTPATH}/bin/fairroot-config --major_version
-    OUTPUT_VARIABLE fairroot_major_version)
+                OUTPUT_VARIABLE fairroot_major_version)
 execute_process(COMMAND ${FAIRROOTPATH}/bin/fairroot-config --minor_version
-    OUTPUT_VARIABLE fairroot_minor_version) 
+                OUTPUT_VARIABLE fairroot_minor_version)
 
-if((${fairroot_major_version} EQUAL 17 AND ${fairroot_minor_version} EQUAL 10) OR ${fairroot_major_version} GREATER 17)
-message("using new FairPrimaryGenerator interface")
-add_definitions(-DFairPrimaryGeneratorAddTrackNewInterface)
-endif((${fairroot_major_version} EQUAL 17 AND ${fairroot_minor_version} EQUAL 10) OR ${fairroot_major_version} GREATER 17)
+if((${fairroot_major_version} EQUAL 17 AND ${fairroot_minor_version} EQUAL 10)
+   OR ${fairroot_major_version} GREATER 17)
+    message("using new FairPrimaryGenerator interface")
+    add_definitions(-DFairPrimaryGeneratorAddTrackNewInterface)
+endif((${fairroot_major_version} EQUAL 17 AND ${fairroot_minor_version} EQUAL 10)
+      OR ${fairroot_major_version} GREATER 17)
 #########################################################
 
-Set(SYSTEM_INCLUDE_DIRECTORIES 
-${SYSTEM_INCLUDE_DIRECTORIES}
-${BASE_INCLUDE_DIRECTORIES}
-#${PLUTO_INCLUDE_DIR}
-)
+set(SYSTEM_INCLUDE_DIRECTORIES ${SYSTEM_INCLUDE_DIRECTORIES} ${BASE_INCLUDE_DIRECTORIES})
 
 set(INCLUDE_DIRECTORIES
-${R3BROOT_SOURCE_DIR}/field 
-${R3BROOT_SOURCE_DIR}/generators 
-${R3BROOT_SOURCE_DIR}/r3bgen 
-${R3BROOT_SOURCE_DIR}/r3bdata
-)
+    ${R3BROOT_SOURCE_DIR}/field ${R3BROOT_SOURCE_DIR}/generators ${R3BROOT_SOURCE_DIR}/r3bgen
+    ${R3BROOT_SOURCE_DIR}/r3bdata ${Geant4_INCLUDE_DIRS})
 
-include_directories( ${INCLUDE_DIRECTORIES})
+include_directories(${INCLUDE_DIRECTORIES})
 include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
-set(LINK_DIRECTORIES
-${ROOT_LIBRARY_DIR}
-${FairLogger_LIBDIR}
-#${PLUTO_LIBRARY_DIR}
-${FAIRROOT_LIBRARY_DIR}
-)
- 
-link_directories( ${LINK_DIRECTORIES})
+set(LINK_DIRECTORIES ${ROOT_LIBRARY_DIR} ${FairLogger_LIBDIR} ${FAIRROOT_LIBRARY_DIR}
+                     ${Geant4_LIBRARY_DIR})
+
+link_directories(${LINK_DIRECTORIES})
 
 set(SRCS
-R3BSpecificGenerator.cxx
-R3BReadKinematics.cxx
-R3BCDGenerator.cxx
-R3BBeamInfo.cxx
-R3BBackTracking.cxx
-R3BBackTrackingStorageState.cxx
-R3BAsciiGenerator.cxx
-R3BCosmicGenerator.cxx
-R3Bp2pGenerator.cxx
-R3BLandGenerator.cxx
-R3BCALIFATestGenerator.cxx
-R3BIonGenerator.cxx
-R3BGammaGenerator.cxx
-R3BPhaseSpaceGenerator.cxx
-R3BDistribution1D.cxx
-R3BDistribution2D.cxx
-R3BDistribution3D.cxx
-R3Bp2pevtGenerator.cxx
-)
+    R3BSpecificGenerator.cxx
+    R3BReadKinematics.cxx
+    R3BCDGenerator.cxx
+    R3BBeamInfo.cxx
+    R3BBackTracking.cxx
+    R3BBackTrackingStorageState.cxx
+    R3BAsciiGenerator.cxx
+    R3BCosmicGenerator.cxx
+    R3Bp2pGenerator.cxx
+    R3BLandGenerator.cxx
+    R3BCALIFATestGenerator.cxx
+    R3BIonGenerator.cxx
+    R3BGammaGenerator.cxx
+    R3BPhaseSpaceGenerator.cxx
+    R3BDistribution1D.cxx
+    R3BDistribution2D.cxx
+    R3BDistribution3D.cxx
+    R3Bp2pevtGenerator.cxx)
 
 # fill list of header files from list of source files
 # by exchanging the file extension
-CHANGE_FILE_EXTENSION(*.cxx *.h HEADERS "${SRCS}")
+change_file_extension(*.cxx *.h HEADERS "${SRCS}")
 
 set(LINKDEF R3BGenLinkDef.h)
 set(LIBRARY_NAME R3BGen)
 set(DEPENDENCIES
-    FairTools Field Gen R3BData)
+    FairTools
+    Field
+    Gen
+    R3BData
+    G4materials
+    Boost::iostreams
+    Boost::filesystem)
 
-GENERATE_LIBRARY()
+generate_library()
 
 # Testing
-enable_testing()
-Set(GTEST_ROOT ${SIMPATH})
-find_package(GTest REQUIRED)
-include_directories(${GTEST_INCLUDE_DIRS})
+add_subdirectory(test)

--- a/r3bgen/R3BAsciiGenerator.h
+++ b/r3bgen/R3BAsciiGenerator.h
@@ -16,13 +16,13 @@
 
 #include "FairGenerator.h"
 #include "TString.h"
+#include <boost/iostreams/filtering_streambuf.hpp>
 #include <fstream>
-#include <map>
+#include <iostream>
+#include <sstream>
 #include <string>
 
-class TDatabasePDG;
 class FairPrimaryGenerator;
-class FairIon;
 
 class R3BAsciiGenerator : public FairGenerator
 {
@@ -51,25 +51,23 @@ class R3BAsciiGenerator : public FairGenerator
     void SetDxDyDz(Double32_t sx = 0, Double32_t sy = 0, Double32_t sz = 0);
 
   private:
-    std::ifstream fInputFile;    //! Input file stream
-    const std::string fFileName; //! Input file Name
-    TDatabasePDG* fPDG;          //!  PDG database (non-owning)
+    const std::string fFileName;                                         //! Input file name
+    std::ifstream fFile;                                                 //! Input file handle
+    boost::iostreams::filtering_streambuf<boost::iostreams::input> fBuf; //! Streambuf for decompression
+    std::istream fInput;                                                 //! Input stream
 
     /** Private method RegisterIons. Goes through the input file and registers
-     ** any ion needed. **/
-    int RegisterIons();
+     ** any ion needed. TODO: Should not be needed by FairRoot. **/
+    void RegisterIons();
 
-    void CheckAndOpen();
-
-    /** STL map from ion name to FairIon **/
-    std::map<TString, FairIon*> fIonMap; //!
+    void OpenOrRewindFile();
 
     Double32_t fX, fY, fZ;    // Point vertex coordinates [cm]
     bool fPointVtxIsSet;      // True if point vertex is set
     Double32_t fDX, fDY, fDZ; // Point vertex coordinates [cm]
     bool fBoxVtxIsSet;        // True if point vertex is set
 
-    ClassDefOverride(R3BAsciiGenerator, 1);
+    ClassDefOverride(R3BAsciiGenerator, 0);
 };
 
 #endif

--- a/r3bgen/R3BPhaseSpaceGenerator.h
+++ b/r3bgen/R3BPhaseSpaceGenerator.h
@@ -16,24 +16,21 @@
 
 // Wrapper for TGenPhaseSpace
 
-#include <string>
-#include <vector>
-
-#include "TGenPhaseSpace.h"
-#include "TRandom3.h"
-
 #include "FairGenerator.h"
 #include "FairIon.h"
-
 #include "R3BDistribution.h"
+#include "TGenPhaseSpace.h"
+#include "TRandom3.h"
+#include <string>
+#include <vector>
 
 class R3BPhaseSpaceGenerator : public FairGenerator
 {
   public:
-    R3BPhaseSpaceGenerator(UInt_t seed = 0);
+    R3BPhaseSpaceGenerator(unsigned int seed = 0);
 
-    void AddParticle(const Int_t PDGCode);
-    void AddHeavyIon(const FairIon& ion);
+    void AddParticle(int PDGCode);
+    void AddHeavyIon(int z, int a);
 
     void SetVertexDistribution_cm(R3BDistribution<3> vertexDistribution) { fVertex_cm = vertexDistribution; }
     R3BDistribution<3>& GetVertexDistribution_cm() { return fVertex_cm; }
@@ -50,9 +47,8 @@ class R3BPhaseSpaceGenerator : public FairGenerator
     void SetErelDistribution_keV(R3BDistribution<1> ErelDistribution) { fErel_keV = ErelDistribution; }
     R3BDistribution<1>& GetErelDistribution_keV() { return fErel_keV; }
 
-    Bool_t Init() override;
-    Bool_t ReadEvent(FairPrimaryGenerator* primGen) override;
-    // FairGenerator* CloneGenerator() const override;
+    bool Init() override;
+    bool ReadEvent(FairPrimaryGenerator* primGen) override;
 
   private:
     R3BDistribution<3> fVertex_cm;       //!
@@ -60,13 +56,13 @@ class R3BPhaseSpaceGenerator : public FairGenerator
     R3BDistribution<1> fBeamEnergy_AMeV; //!
     R3BDistribution<1> fErel_keV;        //!
 
-    Double_t fTotMass;
+    double fTotMass;
     TRandom3 fRngGen;
     TGenPhaseSpace fPhaseSpace;
-    std::vector<Int_t> fPDGCodes;
-    std::vector<Double_t> fMasses;
+    std::vector<int> fPDGCodes;
+    std::vector<double> fMasses;
 
-    ClassDefOverride(R3BPhaseSpaceGenerator, 2);
+    ClassDefOverride(R3BPhaseSpaceGenerator, 3);
 };
 
 #endif // R3BROOT_R3BPHASESPACEGENERATOR_H

--- a/r3bgen/test/CMakeLists.txt
+++ b/r3bgen/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+generate_root_test_script(${R3BROOT_SOURCE_DIR}/r3bgen/test/testR3BPhaseSpaceGeneratorIntegration.C)
+add_test(testR3BPhaseSpaceGeneratorIntegration ${R3BROOT_BINARY_DIR}/r3bgen/test/testR3BPhaseSpaceGeneratorIntegration.sh)
+set_tests_properties(testR3BPhaseSpaceGeneratorIntegration PROPERTIES TIMEOUT "100")
+set_tests_properties(testR3BPhaseSpaceGeneratorIntegration PROPERTIES PASS_REGULAR_EXPRESSION "TestPassed;All ok")

--- a/r3bgen/test/testR3BPhaseSpaceGeneratorIntegration.C
+++ b/r3bgen/test/testR3BPhaseSpaceGeneratorIntegration.C
@@ -1,0 +1,89 @@
+void testR3BPhaseSpaceGeneratorIntegration()
+{
+    // System paths
+    const TString workDirectory = getenv("VMCWORKDIR");
+    gSystem->Setenv("GEOMPATH", workDirectory + "/geometry");
+    gSystem->Setenv("CONFIG_DIR", workDirectory + "/gconfig");
+
+    // Simulation Base
+    FairRunSim run;
+    run.SetName("TGeant4");
+    run.SetOutputFile("testR3BPhaseSpaceGeneratorIntegration.root");
+    run.SetMaterials("media_r3b.geo");
+
+    // World
+    auto cave = new R3BCave("Cave");
+    cave->SetGeometryFileName("r3b_cave_vacuum.geo");
+    run.AddModule(cave);
+
+    // Magnet
+    run.AddModule(new R3BGladMagnet("glad_v17_flange.geo.root"));
+    auto magField = new R3BGladFieldMap("R3BGladMap");
+    magField->SetScale(-0.6);
+    run.SetField(magField);
+
+    // Primaries
+    auto primGen = new FairPrimaryGenerator();
+    auto gen = new R3BPhaseSpaceGenerator();
+    gen->SetBeamEnergyDistribution_AMeV(R3BDistribution1D::Delta(600));
+    gen->SetErelDistribution_keV(R3BDistribution1D::Delta(100));
+    gen->AddHeavyIon(5, 17);
+    gen->AddParticle(2112);
+    gen->AddParticle(2112);
+    primGen->AddGenerator(gen);
+    run.SetGenerator(primGen);
+
+    // Logging
+    run.SetStoreTraj(false);
+    FairLogger::GetLogger()->SetLogVerbosityLevel("LOW");
+    FairLogger::GetLogger()->SetLogScreenLevel("INFO");
+
+    // Init & Special MC Settings
+    run.Init();
+
+    // Database
+    auto rtdb = run.GetRuntimeDb();
+    auto fieldPar = (R3BFieldPar*)rtdb->getContainer("R3BFieldPar");
+    fieldPar->SetParameters(magField);
+    fieldPar->setChanged();
+    auto parOut = new FairParRootFileIo(true);
+    parOut->open("testR3BPhaseSpaceGeneratorIntegration.para.root");
+    rtdb->setOutput(parOut);
+    rtdb->saveOutput();
+    rtdb->print();
+
+    // Go
+    run.Run(1);
+
+    // Test Output
+    auto file = TFile::Open("testR3BPhaseSpaceGeneratorIntegration.root");
+    auto tree = (TTree*)file->Get("evt");
+    auto mctc = new TClonesArray("R3BMCTrack");
+    tree->SetBranchAddress("MCTrack", &mctc);
+
+    tree->GetEvent(0);
+    if (mctc->GetEntries() < 3)
+    {
+        cout << "Not enough particles produced" << endl;
+        return;
+    }
+
+    auto track = (R3BMCTrack*)mctc->At(1);
+    if (track->GetPdgCode() != 2112 || track->GetMotherId() != -1)
+    {
+        cout << "Not the correct primary particle" << endl;
+        return;
+    }
+
+    const Double_t ekin = track->GetEnergy() - track->GetMass();
+    cout << "Ekin of primary neutron:" << ekin << endl;
+    if (abs(ekin - 0.6) > 0.02)
+    {
+        cout << "Primary neutron doesn't have the correct energy!" << endl;
+        return;
+    }
+
+    // Note: Prevent test from succeeding if macro gets dumped on error
+    cout << " Test " << "passed" << endl;
+    cout << " All " << "ok " << endl;
+}


### PR DESCRIPTION
Change Ascii Generator to take masses from Geant4 NIST and compressed input files. Can still read input files with masses, will discard those.
R3BPhaseGen no longer takes a FairIon, but (Z,A) and retrieves the mass from Geant4 NIST.
Rework R3BMCTrack to use context sensitve ROOT/Math/Vector4Ds. Fixes MCTracks not storing mass.
Provide an Erel spectra in R3BNeulandMCMon.
Copy primary neutron tracks in R3BNeulandPrimaryInteractionFinder.
Refactor calorimetric method, fix leaks when using Neutron2DCalibr multiple times without closing the shell/process.

Fixes #338