### PR TITLE
Fixed a missing conversion after a hint from Sonja Storck

### DIFF
--- a/atima/AtimaLinkDef.h
+++ b/atima/AtimaLinkDef.h
@@ -21,5 +21,7 @@
 
 #pragma link C++ class R3BAtima+;
 #pragma link C++ class R3BAtimaCache+;
+#pragma link C++ class R3BAtimaTargetMaterial+;
+#pragma link C++ class R3BAtimaMaterialCompound+;
 
 #endif

--- a/atima/R3BAtima.cxx
+++ b/atima/R3BAtima.cxx
@@ -82,7 +82,7 @@ R3BAtimaTransportResult R3BAtima::Calculate(Double_t projMass_u,
     Double_t density = targetMaterial.Density;
     Int_t tGas = 0;
     if (targetMaterial.IsGas)
-        ++tGas;
+        tGas = 1;
 
     calculate_(proj,
                &pn,
@@ -108,6 +108,7 @@ R3BAtimaTransportResult R3BAtima::Calculate(Double_t projMass_u,
     res.EStrag_AMeV *= res.dEdXOut_MeVcm2_per_mg;
     res.ELoss_AMeV = res.EnergyIn_AMeV - res.EnergyOut_AMeV;
     res.AngStrag_mrad *= 1e3;
-
+    res.dEdXIn_MeVcm2_per_mg *= projMass_u;
+    res.dEdXOut_MeVcm2_per_mg *= projMass_u;
     return res;
 }

--- a/atima/R3BAtima.h
+++ b/atima/R3BAtima.h
@@ -21,7 +21,7 @@
 
 struct R3BAtimaMaterialCompound
 {
-    R3BAtimaMaterialCompound(const Double_t mass_u, const Double_t charge_e)
+    R3BAtimaMaterialCompound(const Double_t mass_u = 1, const Double_t charge_e = 1)
         : Mass_u(mass_u)
         , Charge_e(charge_e)
         , Ratio(1.)


### PR DESCRIPTION
The stopping power at entrance and exit was missing a multiplication with the mass of the projectile.
I also added the target structs for more comfort over the CLI.