### PR TITLE
Support for the new version of ext_data_setup() in R3BUcesbSource.

### DIFF
--- a/r3bsource/R3BUcesbSource.cxx
+++ b/r3bsource/R3BUcesbSource.cxx
@@ -97,7 +97,13 @@ Bool_t R3BUcesbSource::InitUnpackers()
     }
 
     /* Setup client */
+#ifdef EXT_DATA_ITEM_MAP_MATCH
+    /* this is the version for ucesb setup with extended mapping info */
+    uint32_t struct_map_success = 0;
+    Bool_t status = fClient.setup(NULL, 0, &fStructInfo, &struct_map_success, fEventSize);
+#else
     Bool_t status = fClient.setup(NULL, 0, &fStructInfo, fEventSize);
+#endif
     if (status != 0)
     {
         perror("ext_data_clnt::setup()");
@@ -105,6 +111,22 @@ Bool_t R3BUcesbSource::InitUnpackers()
         LOG(fatal) << "ucesb: %s" << fClient.last_error();
         return kFALSE;
     }
+#ifdef EXT_DATA_ITEM_MAP_MATCH
+    /*
+     * It is not needed, that *all* items are matched.
+     * However, mapping should fail, if items are requested that don't exist
+     * on the server, or if items are requested with wrong parameters.
+     * See ucesb/hbook/ext_data_client.h for more information.
+     */
+    uint32_t map_ok = EXT_DATA_ITEM_MAP_OK | EXT_DATA_ITEM_MAP_NO_DEST;
+    if (struct_map_success & ~(map_ok))
+    {
+        perror("ext_data_clnt::setup()");
+        LOG(error) << "ext_data_clnt::setup() failed";
+        ext_data_struct_info_print_map_success(fStructInfo, stderr, map_ok);
+        return kFALSE;
+    }
+#endif
 
     return kTRUE;
 }

--- a/r3bsource/R3BUcesbSource.h
+++ b/r3bsource/R3BUcesbSource.h
@@ -32,7 +32,7 @@
 
 /* External data structure
  * This structure is produced using ucesb in the following way:
- * ./ucesb --ntuple=UNPACK:EVENTNO,UNPACK:TRIGGER,RAW,STRUCT_HH,ext_h101.h
+ * ./ucesb --ntuple=RAW,STRUCT_HH,ext_h101.h
  * */
 struct EXT_STR_h101_t;
 typedef struct EXT_STR_h101_t EXT_STR_h101;


### PR DESCRIPTION
Ucesb has gained the ability to get more detailed information about how the mapping went during the setup(). This introduces also a change in the interface, so quick action is needed.

Also fix up a comment that was outdated.