### PR TITLE
Improvement of the TPAT reconstruction, and Updated R3BMusic classes

### DIFF
--- a/music/R3BMusicCal2Hit.cxx
+++ b/music/R3BMusicCal2Hit.cxx
@@ -255,8 +255,8 @@ void R3BMusicCal2Hit::Exec(Option_t* option)
 
         Double_t zhit = fZ0 + fZ1 * TMath::Sqrt(Esum / nba) + fZ2 * TMath::Sqrt(Esum / nba) * TMath::Sqrt(Esum / nba);
         if (zhit > 0)
-	  //AddHitData(theta, zhit);
-	  AddHitData(theta, zhit, Esum / nba);
+            // AddHitData(theta, zhit);
+            AddHitData(theta, zhit, Esum / nba);
     }
 
     if (CalDat)

--- a/music/R3BMusicCal2Hit.cxx
+++ b/music/R3BMusicCal2Hit.cxx
@@ -255,7 +255,8 @@ void R3BMusicCal2Hit::Exec(Option_t* option)
 
         Double_t zhit = fZ0 + fZ1 * TMath::Sqrt(Esum / nba) + fZ2 * TMath::Sqrt(Esum / nba) * TMath::Sqrt(Esum / nba);
         if (zhit > 0)
-            AddHitData(theta, zhit);
+	  //AddHitData(theta, zhit);
+	  AddHitData(theta, zhit, Esum / nba);
     }
 
     if (CalDat)
@@ -281,4 +282,12 @@ R3BMusicHitData* R3BMusicCal2Hit::AddHitData(Double_t theta, Double_t charge_z)
     TClonesArray& clref = *fMusicHitDataCA;
     Int_t size = clref.GetEntriesFast();
     return new (clref[size]) R3BMusicHitData(theta, charge_z);
+}
+// -----   For later analysis with reconstructed beta -----
+R3BMusicHitData* R3BMusicCal2Hit::AddHitData(Double_t theta, Double_t charge_z, Double_t ene_ave)
+{
+    // It fills the R3BMusicHitData
+    TClonesArray& clref = *fMusicHitDataCA;
+    Int_t size = clref.GetEntriesFast();
+    return new (clref[size]) R3BMusicHitData(theta, charge_z, ene_ave);
 }

--- a/music/R3BMusicCal2Hit.h
+++ b/music/R3BMusicCal2Hit.h
@@ -83,6 +83,7 @@ class R3BMusicCal2Hit : public FairTask
     /** Private method MusicHitData **/
     //** Adds a MusicHitData to the detector
     R3BMusicHitData* AddHitData(Double_t theta, Double_t charge_z);
+    R3BMusicHitData* AddHitData(Double_t theta, Double_t charge_z, Double_t ene_ave);
 
   public:
     // Class definition

--- a/r3bdata/musicData/R3BMusicHitData.cxx
+++ b/r3bdata/musicData/R3BMusicHitData.cxx
@@ -33,4 +33,13 @@ R3BMusicHitData::R3BMusicHitData(Double_t theta, Double_t z)
 }
 // -------------------------------------------------------------------------
 
+// -----   For later analysis with reconstructed beta   --------------------
+R3BMusicHitData::R3BMusicHitData(Double_t theta, Double_t z, Double_t ene)
+    : fTheta(theta)
+    , fZ(z)
+    , fE(ene)
+{
+}
+// -------------------------------------------------------------------------
+
 ClassImp(R3BMusicHitData)

--- a/r3bdata/musicData/R3BMusicHitData.h
+++ b/r3bdata/musicData/R3BMusicHitData.h
@@ -32,6 +32,7 @@ class R3BMusicHitData : public TObject
      *@param z        Atomic number Z in charge units
      **/
     R3BMusicHitData(Double_t theta, Double_t z);
+    R3BMusicHitData(Double_t theta, Double_t z, Double_t ene);
 
     /** Destructor **/
     virtual ~R3BMusicHitData() {}
@@ -39,13 +40,15 @@ class R3BMusicHitData : public TObject
     /** Accessors **/
     inline const Double_t& GetTheta() const { return fTheta; }
     inline const Double_t& GetZcharge() const { return fZ; }
+    inline const Double_t& GetEave() const { return fE; }
 
     /** Modifiers **/
     void SetTheta(Double_t theta) { fTheta = theta; };
     void SetZcharge(Double_t z) { fZ = z; };
+    void SetEave(Double_t ene) { fE = ene; };
 
   protected:
-    Double_t fTheta, fZ;
+    Double_t fTheta, fZ, fE;
 
     ClassDef(R3BMusicHitData, 1)
 };

--- a/r3bsource/R3BTrloiiTpatReader.cxx
+++ b/r3bsource/R3BTrloiiTpatReader.cxx
@@ -59,14 +59,17 @@ Bool_t R3BTrloiiTpatReader::Read()
 
     // LOG(info) << "TrloiiTpatReader::Read BEGIN";
 
-    if (fEventHeader) {
-      fEventHeader->SetTpat(0);
-      if (fData->TPAT > 0) {
-        fEventHeader->SetTpat(fData->TPATv[0]);
-        fNEvent = fEventHeader->GetEventno();
-      }
+    if (fEventHeader)
+    {
+        fEventHeader->SetTpat(0);
+        if (fData->TPAT > 0)
+        {
+            fEventHeader->SetTpat(fData->TPATv[0]);
+            fNEvent = fEventHeader->GetEventno();
+        }
     }
-    if (!fEventHeader || fData->TPAT <= 0) fNEvent++;
+    if (!fEventHeader || fData->TPAT <= 0)
+        fNEvent++;
 
     if (0 == (fNEvent % 1000000))
     {
@@ -84,8 +87,6 @@ Bool_t R3BTrloiiTpatReader::Read()
     return kTRUE;
 }
 
-void R3BTrloiiTpatReader::Reset() {
-  fNEvent = 0;
-}
+void R3BTrloiiTpatReader::Reset() { fNEvent = 0; }
 
 ClassImp(R3BTrloiiTpatReader)

--- a/r3bsource/R3BTrloiiTpatReader.cxx
+++ b/r3bsource/R3BTrloiiTpatReader.cxx
@@ -59,16 +59,14 @@ Bool_t R3BTrloiiTpatReader::Read()
 
     // LOG(info) << "TrloiiTpatReader::Read BEGIN";
 
-    if (nullptr != fEventHeader && fData->TPAT != 0)
-    {
+    if (fEventHeader) {
+      fEventHeader->SetTpat(0);
+      if (fData->TPAT > 0) {
         fEventHeader->SetTpat(fData->TPATv[0]);
         fNEvent = fEventHeader->GetEventno();
+      }
     }
-    else
-    {
-        fEventHeader->SetTpat(0);
-        fNEvent++;
-    }
+    if (!fEventHeader || fData->TPAT <= 0) fNEvent++;
 
     if (0 == (fNEvent % 1000000))
     {
@@ -81,8 +79,6 @@ Bool_t R3BTrloiiTpatReader::Read()
     // sprintf(str, "  Trlo II Tpat = 0x%04x.", fData->TPATv[0]);
     // LOG(info) << str;
 
-    // cout<<"TPAT: "<<fData->TPATv[0]<<" "<<fData->TPAT<<endl;
-
     // LOG(info) << "TrloiiTpatReader::Read END";
 
     return kTRUE;
@@ -90,7 +86,6 @@ Bool_t R3BTrloiiTpatReader::Read()
 
 void R3BTrloiiTpatReader::Reset() {
   fNEvent = 0;
-  fEventHeader->SetTpat(0);
 }
 
 ClassImp(R3BTrloiiTpatReader)

--- a/r3bsource/R3BTrloiiTpatReader.cxx
+++ b/r3bsource/R3BTrloiiTpatReader.cxx
@@ -59,13 +59,14 @@ Bool_t R3BTrloiiTpatReader::Read()
 
     // LOG(info) << "TrloiiTpatReader::Read BEGIN";
 
-    if (nullptr != fEventHeader)
+    if (nullptr != fEventHeader && fData->TPAT != 0)
     {
         fEventHeader->SetTpat(fData->TPATv[0]);
         fNEvent = fEventHeader->GetEventno();
     }
     else
     {
+        fEventHeader->SetTpat(0);
         fNEvent++;
     }
 
@@ -80,13 +81,16 @@ Bool_t R3BTrloiiTpatReader::Read()
     // sprintf(str, "  Trlo II Tpat = 0x%04x.", fData->TPATv[0]);
     // LOG(info) << str;
 
-    //  cout<<"TPAT: "<<fData->TPATv[0]<<endl;
+    // cout<<"TPAT: "<<fData->TPATv[0]<<" "<<fData->TPAT<<endl;
 
     // LOG(info) << "TrloiiTpatReader::Read END";
 
     return kTRUE;
 }
 
-void R3BTrloiiTpatReader::Reset() { fNEvent = 0; }
+void R3BTrloiiTpatReader::Reset() {
+  fNEvent = 0;
+  fEventHeader->SetTpat(0);
+}
 
 ClassImp(R3BTrloiiTpatReader)


### PR DESCRIPTION
Due to relatively high-rate events from CALIFA DAQ, there are many events stored with no TPAT value recorded. In the TPAT class, there is a container to store the number of TPAT values in a certain event. If no TPAT value stored, TPAT will be set to 0. This update has been done with Hans and Bastian.

Modification in the classes for R3BMusic. For the dedicated analysis getting rid of the beta dependency, it is necessary to provide averaged energy for outside of the class.
A similar modification has been applied in the TwinMUSIC classes, in the sofia repository.