### PR TITLE
Add missing #include for newer ROOT / C++

### DIFF
--- a/neuland/calibration/R3BNeulandCal2HitPar.cxx
+++ b/neuland/calibration/R3BNeulandCal2HitPar.cxx
@@ -23,6 +23,7 @@
 #include "FairLogger.h"
 #include "FairRuntimeDb.h"
 
+#include "TROOT.h"
 #include "TCanvas.h"
 #include "TClonesArray.h"
 #include "TH2F.h"

--- a/r3bbase/R3BOnlineSpectraLosStandalone.h
+++ b/r3bbase/R3BOnlineSpectraLosStandalone.h
@@ -29,6 +29,7 @@
 
 #include "TClonesArray.h"
 #include "TMath.h"
+#include "TFolder.h"
 #include <cstdlib>
 
 class TClonesArray;

--- a/r3bbase/R3BOnlineSpectraLosVsSci2.cxx
+++ b/r3bbase/R3BOnlineSpectraLosVsSci2.cxx
@@ -45,6 +45,7 @@
 
 #include "TClonesArray.h"
 #include "TMath.h"
+#include "TFolder.h"
 #include <TRandom3.h>
 #include <TRandomGen.h>
 #include <algorithm>

--- a/r3bbase/R3BOnlineSpectraSfib.h
+++ b/r3bbase/R3BOnlineSpectraSfib.h
@@ -29,6 +29,7 @@
 
 #include "TClonesArray.h"
 #include "TMath.h"
+#include "TF1.h"
 #include <cstdlib>
 
 class TClonesArray;

--- a/sfib/R3BSfibCal2Hit.cxx
+++ b/sfib/R3BSfibCal2Hit.cxx
@@ -11,6 +11,7 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 
+#include <iostream>
 #include <TClonesArray.h>
 #include "FairLogger.h"
 #include "R3BSfibCal2Hit.h"


### PR DESCRIPTION
I was trying to compile with newer versions of ROOT and C++17 (namely: apr21 / Fairroot 18.6).

It looks like some more `#include`s are needed.
Those don't seem to hurt on jun19 / Fairroot 18.2.
So let's do this!