### PR TITLE
Fix an issue with std::isnan() function when compiling in an old syst…

### DIFF
--- a/neuland/calibration/R3BNeulandCal2HitPar.cxx
+++ b/neuland/calibration/R3BNeulandCal2HitPar.cxx
@@ -29,7 +29,6 @@
 #include "TH2F.h"
 
 using namespace Neuland;
-using std::isnan;
 
 R3BNeulandCal2HitPar::R3BNeulandCal2HitPar(const char* name, const Int_t iVerbose)
     : FairTask(name, iVerbose)

--- a/neuland/calibration/R3BNeulandHitCalibrationBar.cxx
+++ b/neuland/calibration/R3BNeulandHitCalibrationBar.cxx
@@ -28,7 +28,6 @@
 #include <string>
 
 using DPair = std::array<Double_t, 2>;
-using std::isnan;
 
 // FIXME namespace Neuland::Calibration { with c++17
 namespace Neuland
@@ -190,14 +189,14 @@ namespace Neuland
 
         void HitCalibrationBar::Update(const R3BNeulandHitModulePar* par)
         {
-            if (!isnan(par->GetTimeOffset(1)))
+            if (!std::isnan(par->GetTimeOffset(1)))
             {
                 TimeDifference = par->GetTDiff();
                 EffectiveSpeed = par->GetEffectiveSpeed();
                 SetStatus(Validity, PosCalibrationBit);
             }
 
-            if (!isnan(par->GetEnergyGain(1)))
+            if (!std::isnan(par->GetEnergyGain(1)))
             {
                 Gain[0] = par->GetEnergyGain(1);
                 Gain[1] = par->GetEnergyGain(2);
@@ -207,20 +206,20 @@ namespace Neuland
                 SetStatus(Validity, EnergyCalibrationBit);
             }
 
-            if (!isnan(par->GetPMTThreshold(1)))
+            if (!std::isnan(par->GetPMTThreshold(1)))
             {
                 Threshold[0] = par->GetPMTThreshold(1);
                 Threshold[1] = par->GetPMTThreshold(2);
                 SetStatus(Validity, ThresholdCalibrationBit);
             }
 
-            if (!isnan(par->GetPMTSaturation(1)))
+            if (!std::isnan(par->GetPMTSaturation(1)))
             {
                 Saturation[0] = par->GetPMTSaturation(1);
                 Saturation[1] = par->GetPMTSaturation(2);
             }
 
-            if (!isnan(par->GetPedestal(1)))
+            if (!std::isnan(par->GetPedestal(1)))
             {
                 Pedestal[0] = par->GetPedestal(1);
                 Pedestal[1] = par->GetPedestal(2);
@@ -276,7 +275,7 @@ namespace Neuland
         void HitCalibrationBar::SetGlobalTSync(const Double_t value, const Double_t error)
         {
             TimeSync = { value, error };
-            if (isnan(value))
+            if (std::isnan(value))
                 ClearStatus(Validity, TSyncCalibrationBit);
             else
                 SetStatus(Validity, TSyncCalibrationBit);

--- a/neuland/calibration/R3BNeulandTSyncer.cxx
+++ b/neuland/calibration/R3BNeulandTSyncer.cxx
@@ -25,7 +25,6 @@ constexpr auto NextPlaneLogSize = 64;
 constexpr auto NBins = 256;
 
 using namespace Neuland;
-using std::isnan;
 
 namespace Neuland
 {
@@ -176,7 +175,7 @@ namespace Neuland
             UInt_t numberOfEquations = 0;
             for (auto b = 0; b < nBars; ++b)
             {
-                if (!isnan(Data[b].TSyncNextBar.Value))
+                if (!std::isnan(Data[b].TSyncNextBar.Value))
                 {
                     scaleFactors[b] += 1. / Sqr(Data[b].TSyncNextBar.Error);
                     scaleFactors[b + 1] += 1. / Sqr(Data[b].TSyncNextBar.Error);
@@ -189,7 +188,7 @@ namespace Neuland
 
                 for (auto ob = 0; ob < BarsPerPlane; ++ob)
                 {
-                    if (!isnan(Data[b].TSyncNextPlane[ob].Value))
+                    if (!std::isnan(Data[b].TSyncNextPlane[ob].Value))
                     {
                         scaleFactors[b] += 1. / Sqr(Data[b].TSyncNextPlane[ob].Error);
                         scaleFactors[plane * BarsPerPlane + ob] += 1. / Sqr(Data[b].TSyncNextPlane[ob].Error);
@@ -279,7 +278,7 @@ namespace Neuland
             for (UInt_t id = 0; id < Data.size(); ++id)
             {
                 const auto plane = GetPlaneNumber(id);
-                if (!isnan(Data[id].TSyncNextBar.Value))
+                if (!std::isnan(Data[id].TSyncNextBar.Value))
                 {
                     const auto weight = 1. / Data[id].TSyncNextBar.Error;
                     lhs[nEQ] = { { id, id + 1U }, { -weight * scaleFactors[id], weight * scaleFactors[id + 1U] } };
@@ -288,7 +287,7 @@ namespace Neuland
                 }
                 for (UInt_t barInNextPlane = 0; barInNextPlane < BarsPerPlane; ++barInNextPlane)
                 {
-                    if (!isnan(Data[id].TSyncNextPlane[barInNextPlane].Value))
+                    if (!std::isnan(Data[id].TSyncNextPlane[barInNextPlane].Value))
                     {
                         const auto barInNextPlaneID = BarsPerPlane * (plane + 1) + barInNextPlane;
                         const auto weight = 1. / Data[id].TSyncNextPlane[barInNextPlane].Error;


### PR DESCRIPTION
…em such as lx-pool.

When using an old Linux system, I was receiving error messages as:
> error: ‘constexpr bool std::isnan(double)’ conflicts with a previous declaration

Thus it would be better to write explicitly as std::isnan() or TMath::IsNaN() for the compatibility for any systems.