### PR TITLE
Compatibility with FairRoot 18.4+

### DIFF
--- a/evtvis/R3BCalifaEventDisplay.cxx
+++ b/evtvis/R3BCalifaEventDisplay.cxx
@@ -19,7 +19,6 @@
 
 #include "FairEventManager.h"
 #include "FairLogger.h"
-#include "FairMCTracks.h"
 #include "FairRootManager.h"
 #include "FairRunAna.h"
 #include "FairRuntimeDb.h"

--- a/evtvis/R3BCalifaEventDisplay.h
+++ b/evtvis/R3BCalifaEventDisplay.h
@@ -19,7 +19,6 @@
 #ifndef R3BCALIFAEVENTDISPLAY_H
 #define R3BCALIFAEVENTDISPLAY_H
 
-#include "FairMCTracks.h"
 #include "FairTask.h"
 
 #include "TEveCalo.h"

--- a/evtvis/R3BCalifaHitEventDisplay.cxx
+++ b/evtvis/R3BCalifaHitEventDisplay.cxx
@@ -19,7 +19,6 @@
 
 #include "FairEventManager.h"
 #include "FairLogger.h"
-#include "FairMCTracks.h"
 #include "FairRootManager.h"
 #include "FairRunAna.h"
 #include "FairRuntimeDb.h"

--- a/evtvis/R3BCalifaHitEventDisplay.h
+++ b/evtvis/R3BCalifaHitEventDisplay.h
@@ -19,7 +19,6 @@
 #ifndef R3BCALIFAHITEVENTDISPLAY_H
 #define R3BCALIFAHITEVENTDISPLAY_H
 
-#include "FairMCTracks.h"
 #include "FairTask.h"
 
 #include "TEveCalo.h"

--- a/evtvis/R3BMCTracks.h
+++ b/evtvis/R3BMCTracks.h
@@ -14,19 +14,63 @@
 #ifndef R3BMCTRACKS_H
 #define R3BMCTRACKS_H
 
-#include "FairMCTracks.h"
+#include "FairTask.h" // for FairTask, InitStatus
 
-class R3BMCTracks : public FairMCTracks
+#include <Rtypes.h>              // for Double_t, etc
+#include <TEveTrackPropagator.h> // IWYU pragma: keep needed by cint
+#include <TString.h>             // for TString
+
+class FairEventManager;
+class TClonesArray;
+class TEveTrackList;
+class TObjArray;
+class TParticle;
+
+class R3BMCTracks : public FairTask
 {
-
   public:
+    /** Default constructor **/
     R3BMCTracks();
-    R3BMCTracks(const char* name, Int_t iVerbose = 1);
-    virtual ~R3BMCTracks() { ; }
 
-    virtual InitStatus Init();
+    /** Standard constructor
+     *@param name        Name of task
+     *@param iVerbose    Verbosity level
+     **/
+    R3BMCTracks(const char* name, Int_t iVerbose = 1);
+
+    /** Destructor **/
+    virtual ~R3BMCTracks();
+
+    /** Set verbosity level. For this task and all of the subtasks. **/
+    void SetVerbose(Int_t iVerbose) { fVerbose = iVerbose; }
+    /** Executed task **/
     virtual void Exec(Option_t* option);
+    virtual InitStatus Init();
+    virtual void SetParContainers();
+
+    /** Action after each event**/
+    virtual void Finish();
+    void Reset();
+    TEveTrackList* GetTrGroup(TParticle* P);
+
+  protected:
+    TClonesArray* fTrackList; //!
+    TEveTrackPropagator* fTrPr;
+    FairEventManager* fEventManager; //!
+    TObjArray* fEveTrList;
+    TString fEvent;         //!
+    TEveTrackList* fTrList; //!
+    // TEveElementList *fTrackCont;
+
+    Double_t MinEnergyLimit;
+    Double_t MaxEnergyLimit;
+    Double_t PEnergy;
+
+  private:
+    R3BMCTracks(const R3BMCTracks&);
+    R3BMCTracks& operator=(const R3BMCTracks&);
 
     ClassDef(R3BMCTracks, 1);
 };
+
 #endif

--- a/r3bbase/CMakeLists.txt
+++ b/r3bbase/CMakeLists.txt
@@ -15,11 +15,15 @@
 # the array .
 # The extension is already found.  Any number of sources could be listed here.
 
-Set(SYSTEM_INCLUDE_DIRECTORIES 
+Set(SYSTEM_INCLUDE_DIRECTORIES
 ${SYSTEM_INCLUDE_DIRECTORIES}
 ${BASE_INCLUDE_DIRECTORIES}
 )
 Set(R3BSOF_SOURCE_DIR ${R3BROOT_SOURCE_DIR}/sofia)
+
+if(${FR_MAJOR_VERSION} GREATER_EQUAL 18 AND ${FR_MINOR_VERSION} GREATER_EQUAL 4)
+  add_definitions(-DACTIVATEOBJECTANYIMPLDEFINED)
+endif()
 
 set(INCLUDE_DIRECTORIES
 #put here all directories where header files are located
@@ -59,8 +63,8 @@ include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 link_directories(${FAIRROOT_LIBRARY_DIR} ${ROOT_LIBRARY_DIR})
 
 set(SRCS
-R3BModule.cxx 
-R3BDetector.cxx 
+R3BModule.cxx
+R3BDetector.cxx
 R3BEventHeader.cxx
 R3BEventHeaderCal2Hit.cxx
 R3BWhiterabbitPropagator.cxx

--- a/r3bbase/R3BFileSource.cxx
+++ b/r3bbase/R3BFileSource.cxx
@@ -871,7 +871,7 @@ Bool_t R3BFileSource::ActivateObject(TObject** obj, const char* BrName)
     return kTRUE;
 }
 
-// remove it for new fairroot versions > Jun 2021
+#ifndef ACTIVATEOBJECTANYIMPLDEFINED
 namespace
 {
 
@@ -910,6 +910,7 @@ namespace
     }
 
 } // namespace
+#endif
 
 Bool_t R3BFileSource::ActivateObjectAny(void** obj, const std::type_info& info, const char* BrName)
 {

--- a/r3bbase/R3BFileSource.h
+++ b/r3bbase/R3BFileSource.h
@@ -130,7 +130,11 @@ class R3BFileSource : public FairSource
     void SetInputFileName(TString tstr) { fInputFileName = tstr; }
 
     /**Read one event from source to find out which RunId to use*/
-    Bool_t SpecifyRunId();
+    Bool_t SpecifyRunId()
+    {
+        // FIXME
+        return true;
+    }
 
   private:
     // static pointer to this class

--- a/r3bgen/R3BINCLRootGenerator.cxx
+++ b/r3bgen/R3BINCLRootGenerator.cxx
@@ -17,6 +17,7 @@
 #include "FairPrimaryGenerator.h"
 #include "FairRunSim.h"
 #include "G4NistManager.hh"
+#include "TFile.h"
 #include "TMath.h"
 #include "TRandom.h"
 


### PR DESCRIPTION
- `R3BINCLRootGenerator.cxx`: Added missing include
- `FairMCTracks` has beend removed from FairRoot. Here, remove unused references and roll code into `R3BMCTracks`
- `R3BFileSource.cxx`: Add a define to deal with ActivateObjectAnyImpl, added in FairRoot 18.4
- `R3BFileSource.h`: `SpecifyRunId` is not implemented, which leads to crashes. As it is required by the base class, provide a dummy implementation marked as fixme.

Note: Why does `R3BFileSource` even exist in the first place? It is only used in `R3BEventHeaderCal2Hit` for some Run Id shenanigans. Please solve this in a way that does not create duplication with `FairFileSource`, i.e. by deriving from `FairFileSource` instead of `FairSource`. The naming of `R3BEventHeaderCal2Hit` does not match its function. My guess is that some functionality of FairRoot is misued, misunderstood, or ignored and `R3BEventHeaderCal2Hit` and `R3BFileSource` should be deleted.