### PR TITLE
Trloii ScalerReader exclusively for the s467/s444 (2020) setup. In ad…

### DIFF
--- a/r3bdata/trloiiData/R3BTrloiiData.cxx
+++ b/r3bdata/trloiiData/R3BTrloiiData.cxx
@@ -24,7 +24,7 @@ R3BTrloiiData::R3BTrloiiData()
 {
 }
 
-R3BTrloiiData::R3BTrloiiData(UInt_t type, Int_t ch, int32_t counts)
+R3BTrloiiData::R3BTrloiiData(UInt_t type, Int_t ch, uint32_t counts)
     : fType(type)
     , fCh(ch)
     , fCounts(counts)

--- a/r3bdata/trloiiData/R3BTrloiiData.h
+++ b/r3bdata/trloiiData/R3BTrloiiData.h
@@ -32,7 +32,7 @@ class R3BTrloiiData : public TObject
      *@param ch         Scaler channel
      *@param counts     Number of counts
      **/
-    R3BTrloiiData(UInt_t type, Int_t ch, int32_t counts);
+    R3BTrloiiData(UInt_t type, Int_t ch, uint32_t counts);
 
     // Destructor
     virtual ~R3BTrloiiData() {}
@@ -40,12 +40,12 @@ class R3BTrloiiData : public TObject
     // Getters
     inline const UInt_t& GetType() const { return fType; }
     inline const Int_t& GetCh() const { return fCh; }
-    inline const int32_t& GetCounts() const { return fCounts; }
+    inline const uint32_t& GetCounts() const { return fCounts; }
 
   protected:
     UInt_t fType;    // Type of data
     Int_t fCh;       // Scaler channel
-    int32_t fCounts; // Number of counts
+    uint32_t fCounts; // Number of counts
 
   public:
     ClassDef(R3BTrloiiData, 1)

--- a/r3bsource/CMakeLists.txt
+++ b/r3bsource/CMakeLists.txt
@@ -77,6 +77,7 @@ R3BWhiterabbitMusicReader.cxx
 R3BTrloiiTpatReader.cxx
 R3BTrloiiSampReader.cxx
 R3BTrloiiScalerReader.cxx
+R3BTrloiiScalerReader_s467.cxx
 R3BTimestampMasterReader.cxx
 R3BPspxReader.cxx
 R3BBunchedFiberReader.cxx
@@ -132,6 +133,7 @@ ext/ext_h101_wrs8.h
 ext/ext_h101_wrlos.h
 ext/ext_h101_tpat.h
 ext/ext_h101_trlo.h
+ext/ext_h101_trlo_s467.h
 ext/ext_h101_timestamp_master.h
 ext/ext_h101_bmon.h
 ext/ext_h101_fibzero.h

--- a/r3bsource/R3BTrloiiScalerReader_s467.cxx
+++ b/r3bsource/R3BTrloiiScalerReader_s467.cxx
@@ -1,0 +1,101 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "FairLogger.h"
+#include "FairRootManager.h"
+
+#include "R3BTrloiiData.h"
+#include "R3BTrloiiScalerReader_s467.h"
+
+#include "TClonesArray.h"
+#include "ext_data_struct_info.hh"
+
+/**
+ ** ext_h101_trlo.h was created by running
+ ** ./202002_s467 --ntuple=STRUCT_HH,RAW:TRLORAW,RAW:TRLOADT,RAW:TRLOBDT,RAW:TRLOARD,id=h101_TRLO,NOTRIGEVENTNO,ext_h101_trlo_s467.h
+ **/
+
+extern "C"
+{
+#include "ext_data_client.h"
+#include "ext_h101_trlo_s467.h"
+}
+
+R3BTrloiiScalerReader_s467::R3BTrloiiScalerReader_s467(EXT_STR_h101_TRLO_s467_onion* data, size_t offset)
+    : R3BReader("R3BTrloiiScalerReader_s467")
+    , fNEvent(0)
+    , fData(data)
+    , fOffset(offset)
+    , fOnline(kFALSE)
+    , fArray(new TClonesArray("R3BTrloiiData"))
+{
+}
+
+R3BTrloiiScalerReader_s467::~R3BTrloiiScalerReader_s467()
+{
+    if (fArray)
+        delete fArray;
+}
+
+Bool_t R3BTrloiiScalerReader_s467::Init(ext_data_struct_info* a_struct_info)
+{
+    Int_t ok;
+    LOG(INFO) << "R3BTrloiiScalerReader_s467::Init()";
+    EXT_STR_h101_TRLO_s467_ITEMS_INFO(ok, *a_struct_info, fOffset, EXT_STR_h101_TRLO_s467, 0);
+
+    if (!ok)
+    {
+        LOG(ERROR) << "R3BTrloiiScalerReader_s467::Failed to setup structure information.";
+        return kFALSE;
+    }
+
+    // Register output array in tree
+    FairRootManager::Instance()->Register("TrloiiData", "TRLOII_s467 info", fArray, !fOnline);
+    fArray->Clear();
+
+    return kTRUE;
+}
+
+Bool_t R3BTrloiiScalerReader_s467::Read()
+{
+    LOG(DEBUG) << "R3BTrloiiScalerReader_s467::Read() Event data.";
+
+    for (int ch = 0; ch < 16; ++ch)
+    {
+        new ((*fArray)[fArray->GetEntriesFast()]) R3BTrloiiData(1, ch + 1, fData->TRLORAW_MAIN[ch]);
+        new ((*fArray)[fArray->GetEntriesFast()]) R3BTrloiiData(2, ch + 1, fData->TRLOBDT_MAIN[ch]);
+        new ((*fArray)[fArray->GetEntriesFast()]) R3BTrloiiData(3, ch + 1, fData->TRLOADT_MAIN[ch]);
+        new ((*fArray)[fArray->GetEntriesFast()]) R3BTrloiiData(4, ch + 1, fData->TRLOARD_MAIN[ch]);
+
+        new ((*fArray)[fArray->GetEntriesFast()]) R3BTrloiiData(5, ch + 1, fData->TRLORAW_SCITWO[ch]);
+        new ((*fArray)[fArray->GetEntriesFast()]) R3BTrloiiData(6, ch + 1, fData->TRLOBDT_SCITWO[ch]);
+        new ((*fArray)[fArray->GetEntriesFast()]) R3BTrloiiData(7, ch + 1, fData->TRLOADT_SCITWO[ch]);
+        new ((*fArray)[fArray->GetEntriesFast()]) R3BTrloiiData(8, ch + 1, fData->TRLOARD_SCITWO[ch]);
+
+        new ((*fArray)[fArray->GetEntriesFast()]) R3BTrloiiData(9, ch + 1, fData->TRLORAW_SCIEIGHT[ch]);
+        new ((*fArray)[fArray->GetEntriesFast()]) R3BTrloiiData(10, ch + 1, fData->TRLOBDT_SCIEIGHT[ch]);
+        new ((*fArray)[fArray->GetEntriesFast()]) R3BTrloiiData(11, ch + 1, fData->TRLOADT_SCIEIGHT[ch]);
+        new ((*fArray)[fArray->GetEntriesFast()]) R3BTrloiiData(12, ch + 1, fData->TRLOARD_SCIEIGHT[ch]);
+    }
+
+    fNEvent += 1;
+    return kTRUE;
+}
+
+void R3BTrloiiScalerReader_s467::Reset()
+{
+    // Reset the output array
+    fArray->Clear();
+}
+
+ClassImp(R3BTrloiiScalerReader_s467);

--- a/r3bsource/R3BTrloiiScalerReader_s467.h
+++ b/r3bsource/R3BTrloiiScalerReader_s467.h
@@ -1,0 +1,69 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+// ----------------------------------------------------------------------
+// -----                    R3BTrloiiScalerReader_s467              -----
+// -----                Created 16/11/21  by R. Taniuchi            -----
+// ----------------------------------------------------------------------
+
+#ifndef R3BTrloiiScalerReader_s467_H
+#define R3BTrloiiScalerReader_s467_H
+
+#include "R3BReader.h"
+#include <Rtypes.h>
+
+class TClonesArray;
+
+struct EXT_STR_h101_TRLO_s467_t;
+typedef struct EXT_STR_h101_TRLO_s467_t EXT_STR_h101_TRLO_s467;
+typedef struct EXT_STR_h101_TRLO_s467_onion_t EXT_STR_h101_TRLO_s467_onion;
+class ext_data_struct_info;
+
+class R3BTrloiiScalerReader_s467 : public R3BReader
+{
+  public:
+    // Standard constructor
+    R3BTrloiiScalerReader_s467(EXT_STR_h101_TRLO_s467_onion*, size_t);
+
+    // Destructor
+    virtual ~R3BTrloiiScalerReader_s467();
+
+    // Setup structure information
+    virtual Bool_t Init(ext_data_struct_info*) override;
+
+    // Read data from full event structure
+    virtual Bool_t Read() override;
+
+    // Reset
+    virtual void Reset() override;
+
+    // Accessor to select online mode
+    void SetOnline(Bool_t option) { fOnline = option; }
+
+  private:
+    // An event counter
+    unsigned int fNEvent;
+    // Reader specific data structure from ucesb
+    EXT_STR_h101_TRLO_s467_onion* fData;
+    // Data offset
+    size_t fOffset;
+    // Don't store data for online
+    Bool_t fOnline;
+    // Output array
+    TClonesArray* fArray;
+
+  public:
+    ClassDefOverride(R3BTrloiiScalerReader_s467, 0);
+};
+
+#endif /* R3BTrloiiScalerReader_s467_H */

--- a/r3bsource/SourceLinkDef.h
+++ b/r3bsource/SourceLinkDef.h
@@ -36,6 +36,7 @@
 #pragma link C++ class R3BTrloiiTpatReader+;
 #pragma link C++ class R3BTrloiiSampReader+;
 #pragma link C++ class R3BTrloiiScalerReader+;
+#pragma link C++ class R3BTrloiiScalerReader_s467+;
 #pragma link C++ class R3BTimestampMasterReader+;
 #pragma link C++ class R3BBeamMonitorReader+;
 #pragma link C++ class R3BPspxReader+;

--- a/r3bsource/ext/ext_h101_trlo_s467.h
+++ b/r3bsource/ext/ext_h101_trlo_s467.h
@@ -1,0 +1,971 @@
+/********************************************************
+ *
+ * Structure for ext_data_fetch_event() filling.
+ *
+ * Do not edit - automatically generated.
+ */
+
+#ifndef __GUARD_H101_TRLO_S467_EXT_H101_TRLO_S467_H__
+#define __GUARD_H101_TRLO_S467_EXT_H101_TRLO_S467_H__
+
+#ifndef __CINT__
+# include <stdint.h>
+#else
+/* For CINT (old version trouble with stdint.h): */
+# ifndef uint32_t
+typedef unsigned int uint32_t;
+typedef          int  int32_t;
+# endif
+#endif
+#ifndef EXT_STRUCT_CTRL
+# define EXT_STRUCT_CTRL(x)
+#endif
+
+/********************************************************
+ *
+ * Plain structure (layout as ntuple/root file):
+ */
+
+typedef struct EXT_STR_h101_TRLO_s467_t
+{
+  /* RAW */
+  uint32_t TRLORAW_SCITWO1 /* [-1,-1] */;
+  uint32_t TRLORAW_SCITWO2 /* [-1,-1] */;
+  uint32_t TRLORAW_SCITWO3 /* [-1,-1] */;
+  uint32_t TRLORAW_SCITWO4 /* [-1,-1] */;
+  uint32_t TRLORAW_SCITWO5 /* [-1,-1] */;
+  uint32_t TRLORAW_SCITWO6 /* [-1,-1] */;
+  uint32_t TRLORAW_SCITWO7 /* [-1,-1] */;
+  uint32_t TRLORAW_SCITWO8 /* [-1,-1] */;
+  uint32_t TRLORAW_SCITWO9 /* [-1,-1] */;
+  uint32_t TRLORAW_SCITWO10 /* [-1,-1] */;
+  uint32_t TRLORAW_SCITWO11 /* [-1,-1] */;
+  uint32_t TRLORAW_SCITWO12 /* [-1,-1] */;
+  uint32_t TRLORAW_SCITWO13 /* [-1,-1] */;
+  uint32_t TRLORAW_SCITWO14 /* [-1,-1] */;
+  uint32_t TRLORAW_SCITWO15 /* [-1,-1] */;
+  uint32_t TRLORAW_SCITWO16 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT1 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT2 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT3 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT4 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT5 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT6 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT7 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT8 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT9 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT10 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT11 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT12 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT13 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT14 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT15 /* [-1,-1] */;
+  uint32_t TRLORAW_SCIEIGHT16 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN1 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN2 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN3 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN4 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN5 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN6 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN7 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN8 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN9 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN10 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN11 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN12 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN13 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN14 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN15 /* [-1,-1] */;
+  uint32_t TRLORAW_MAIN16 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO1 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO2 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO3 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO4 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO5 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO6 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO7 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO8 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO9 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO10 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO11 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO12 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO13 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO14 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO15 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCITWO16 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT1 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT2 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT3 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT4 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT5 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT6 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT7 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT8 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT9 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT10 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT11 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT12 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT13 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT14 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT15 /* [-1,-1] */;
+  uint32_t TRLOBDT_SCIEIGHT16 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN1 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN2 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN3 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN4 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN5 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN6 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN7 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN8 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN9 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN10 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN11 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN12 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN13 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN14 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN15 /* [-1,-1] */;
+  uint32_t TRLOBDT_MAIN16 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO1 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO2 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO3 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO4 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO5 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO6 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO7 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO8 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO9 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO10 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO11 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO12 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO13 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO14 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO15 /* [-1,-1] */;
+  uint32_t TRLOADT_SCITWO16 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT1 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT2 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT3 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT4 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT5 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT6 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT7 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT8 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT9 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT10 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT11 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT12 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT13 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT14 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT15 /* [-1,-1] */;
+  uint32_t TRLOADT_SCIEIGHT16 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN1 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN2 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN3 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN4 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN5 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN6 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN7 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN8 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN9 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN10 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN11 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN12 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN13 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN14 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN15 /* [-1,-1] */;
+  uint32_t TRLOADT_MAIN16 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO1 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO2 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO3 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO4 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO5 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO6 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO7 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO8 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO9 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO10 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO11 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO12 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO13 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO14 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO15 /* [-1,-1] */;
+  uint32_t TRLOARD_SCITWO16 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT1 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT2 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT3 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT4 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT5 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT6 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT7 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT8 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT9 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT10 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT11 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT12 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT13 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT14 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT15 /* [-1,-1] */;
+  uint32_t TRLOARD_SCIEIGHT16 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN1 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN2 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN3 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN4 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN5 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN6 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN7 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN8 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN9 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN10 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN11 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN12 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN13 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN14 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN15 /* [-1,-1] */;
+  uint32_t TRLOARD_MAIN16 /* [-1,-1] */;
+
+} EXT_STR_h101_TRLO_s467;
+
+/********************************************************
+ *
+ * Structure with multiple levels of arrays (partially)
+ * recovered (recommended):
+ */
+
+typedef struct EXT_STR_h101_TRLO_s467_onion_t
+{
+  /* RAW */
+  uint32_t TRLORAW_SCITWO[16];
+  uint32_t TRLORAW_SCIEIGHT[16];
+  uint32_t TRLORAW_MAIN[16];
+  uint32_t TRLOBDT_SCITWO[16];
+  uint32_t TRLOBDT_SCIEIGHT[16];
+  uint32_t TRLOBDT_MAIN[16];
+  uint32_t TRLOADT_SCITWO[16];
+  uint32_t TRLOADT_SCIEIGHT[16];
+  uint32_t TRLOADT_MAIN[16];
+  uint32_t TRLOARD_SCITWO[16];
+  uint32_t TRLOARD_SCIEIGHT[16];
+  uint32_t TRLOARD_MAIN[16];
+
+} EXT_STR_h101_TRLO_s467_onion;
+
+/*******************************************************/
+
+#define EXT_STR_h101_TRLO_s467_ITEMS_INFO(ok,si,offset,struct_t,printerr) do { \
+  ok = 1; \
+  /* RAW */ \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO1,                 UINT32,\
+                    "TRLORAW_SCITWO1"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO2,                 UINT32,\
+                    "TRLORAW_SCITWO2"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO3,                 UINT32,\
+                    "TRLORAW_SCITWO3"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO4,                 UINT32,\
+                    "TRLORAW_SCITWO4"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO5,                 UINT32,\
+                    "TRLORAW_SCITWO5"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO6,                 UINT32,\
+                    "TRLORAW_SCITWO6"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO7,                 UINT32,\
+                    "TRLORAW_SCITWO7"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO8,                 UINT32,\
+                    "TRLORAW_SCITWO8"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO9,                 UINT32,\
+                    "TRLORAW_SCITWO9"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO10,                UINT32,\
+                    "TRLORAW_SCITWO10"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO11,                UINT32,\
+                    "TRLORAW_SCITWO11"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO12,                UINT32,\
+                    "TRLORAW_SCITWO12"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO13,                UINT32,\
+                    "TRLORAW_SCITWO13"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO14,                UINT32,\
+                    "TRLORAW_SCITWO14"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO15,                UINT32,\
+                    "TRLORAW_SCITWO15"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCITWO16,                UINT32,\
+                    "TRLORAW_SCITWO16"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT1,               UINT32,\
+                    "TRLORAW_SCIEIGHT1"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT2,               UINT32,\
+                    "TRLORAW_SCIEIGHT2"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT3,               UINT32,\
+                    "TRLORAW_SCIEIGHT3"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT4,               UINT32,\
+                    "TRLORAW_SCIEIGHT4"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT5,               UINT32,\
+                    "TRLORAW_SCIEIGHT5"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT6,               UINT32,\
+                    "TRLORAW_SCIEIGHT6"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT7,               UINT32,\
+                    "TRLORAW_SCIEIGHT7"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT8,               UINT32,\
+                    "TRLORAW_SCIEIGHT8"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT9,               UINT32,\
+                    "TRLORAW_SCIEIGHT9"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT10,              UINT32,\
+                    "TRLORAW_SCIEIGHT10"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT11,              UINT32,\
+                    "TRLORAW_SCIEIGHT11"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT12,              UINT32,\
+                    "TRLORAW_SCIEIGHT12"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT13,              UINT32,\
+                    "TRLORAW_SCIEIGHT13"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT14,              UINT32,\
+                    "TRLORAW_SCIEIGHT14"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT15,              UINT32,\
+                    "TRLORAW_SCIEIGHT15"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_SCIEIGHT16,              UINT32,\
+                    "TRLORAW_SCIEIGHT16"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN1,                   UINT32,\
+                    "TRLORAW_MAIN1"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN2,                   UINT32,\
+                    "TRLORAW_MAIN2"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN3,                   UINT32,\
+                    "TRLORAW_MAIN3"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN4,                   UINT32,\
+                    "TRLORAW_MAIN4"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN5,                   UINT32,\
+                    "TRLORAW_MAIN5"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN6,                   UINT32,\
+                    "TRLORAW_MAIN6"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN7,                   UINT32,\
+                    "TRLORAW_MAIN7"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN8,                   UINT32,\
+                    "TRLORAW_MAIN8"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN9,                   UINT32,\
+                    "TRLORAW_MAIN9"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN10,                  UINT32,\
+                    "TRLORAW_MAIN10"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN11,                  UINT32,\
+                    "TRLORAW_MAIN11"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN12,                  UINT32,\
+                    "TRLORAW_MAIN12"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN13,                  UINT32,\
+                    "TRLORAW_MAIN13"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN14,                  UINT32,\
+                    "TRLORAW_MAIN14"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN15,                  UINT32,\
+                    "TRLORAW_MAIN15"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLORAW_MAIN16,                  UINT32,\
+                    "TRLORAW_MAIN16"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO1,                 UINT32,\
+                    "TRLOBDT_SCITWO1"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO2,                 UINT32,\
+                    "TRLOBDT_SCITWO2"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO3,                 UINT32,\
+                    "TRLOBDT_SCITWO3"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO4,                 UINT32,\
+                    "TRLOBDT_SCITWO4"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO5,                 UINT32,\
+                    "TRLOBDT_SCITWO5"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO6,                 UINT32,\
+                    "TRLOBDT_SCITWO6"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO7,                 UINT32,\
+                    "TRLOBDT_SCITWO7"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO8,                 UINT32,\
+                    "TRLOBDT_SCITWO8"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO9,                 UINT32,\
+                    "TRLOBDT_SCITWO9"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO10,                UINT32,\
+                    "TRLOBDT_SCITWO10"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO11,                UINT32,\
+                    "TRLOBDT_SCITWO11"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO12,                UINT32,\
+                    "TRLOBDT_SCITWO12"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO13,                UINT32,\
+                    "TRLOBDT_SCITWO13"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO14,                UINT32,\
+                    "TRLOBDT_SCITWO14"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO15,                UINT32,\
+                    "TRLOBDT_SCITWO15"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCITWO16,                UINT32,\
+                    "TRLOBDT_SCITWO16"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT1,               UINT32,\
+                    "TRLOBDT_SCIEIGHT1"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT2,               UINT32,\
+                    "TRLOBDT_SCIEIGHT2"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT3,               UINT32,\
+                    "TRLOBDT_SCIEIGHT3"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT4,               UINT32,\
+                    "TRLOBDT_SCIEIGHT4"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT5,               UINT32,\
+                    "TRLOBDT_SCIEIGHT5"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT6,               UINT32,\
+                    "TRLOBDT_SCIEIGHT6"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT7,               UINT32,\
+                    "TRLOBDT_SCIEIGHT7"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT8,               UINT32,\
+                    "TRLOBDT_SCIEIGHT8"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT9,               UINT32,\
+                    "TRLOBDT_SCIEIGHT9"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT10,              UINT32,\
+                    "TRLOBDT_SCIEIGHT10"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT11,              UINT32,\
+                    "TRLOBDT_SCIEIGHT11"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT12,              UINT32,\
+                    "TRLOBDT_SCIEIGHT12"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT13,              UINT32,\
+                    "TRLOBDT_SCIEIGHT13"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT14,              UINT32,\
+                    "TRLOBDT_SCIEIGHT14"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT15,              UINT32,\
+                    "TRLOBDT_SCIEIGHT15"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_SCIEIGHT16,              UINT32,\
+                    "TRLOBDT_SCIEIGHT16"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN1,                   UINT32,\
+                    "TRLOBDT_MAIN1"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN2,                   UINT32,\
+                    "TRLOBDT_MAIN2"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN3,                   UINT32,\
+                    "TRLOBDT_MAIN3"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN4,                   UINT32,\
+                    "TRLOBDT_MAIN4"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN5,                   UINT32,\
+                    "TRLOBDT_MAIN5"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN6,                   UINT32,\
+                    "TRLOBDT_MAIN6"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN7,                   UINT32,\
+                    "TRLOBDT_MAIN7"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN8,                   UINT32,\
+                    "TRLOBDT_MAIN8"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN9,                   UINT32,\
+                    "TRLOBDT_MAIN9"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN10,                  UINT32,\
+                    "TRLOBDT_MAIN10"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN11,                  UINT32,\
+                    "TRLOBDT_MAIN11"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN12,                  UINT32,\
+                    "TRLOBDT_MAIN12"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN13,                  UINT32,\
+                    "TRLOBDT_MAIN13"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN14,                  UINT32,\
+                    "TRLOBDT_MAIN14"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN15,                  UINT32,\
+                    "TRLOBDT_MAIN15"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOBDT_MAIN16,                  UINT32,\
+                    "TRLOBDT_MAIN16"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO1,                 UINT32,\
+                    "TRLOADT_SCITWO1"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO2,                 UINT32,\
+                    "TRLOADT_SCITWO2"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO3,                 UINT32,\
+                    "TRLOADT_SCITWO3"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO4,                 UINT32,\
+                    "TRLOADT_SCITWO4"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO5,                 UINT32,\
+                    "TRLOADT_SCITWO5"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO6,                 UINT32,\
+                    "TRLOADT_SCITWO6"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO7,                 UINT32,\
+                    "TRLOADT_SCITWO7"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO8,                 UINT32,\
+                    "TRLOADT_SCITWO8"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO9,                 UINT32,\
+                    "TRLOADT_SCITWO9"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO10,                UINT32,\
+                    "TRLOADT_SCITWO10"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO11,                UINT32,\
+                    "TRLOADT_SCITWO11"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO12,                UINT32,\
+                    "TRLOADT_SCITWO12"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO13,                UINT32,\
+                    "TRLOADT_SCITWO13"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO14,                UINT32,\
+                    "TRLOADT_SCITWO14"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO15,                UINT32,\
+                    "TRLOADT_SCITWO15"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCITWO16,                UINT32,\
+                    "TRLOADT_SCITWO16"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT1,               UINT32,\
+                    "TRLOADT_SCIEIGHT1"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT2,               UINT32,\
+                    "TRLOADT_SCIEIGHT2"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT3,               UINT32,\
+                    "TRLOADT_SCIEIGHT3"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT4,               UINT32,\
+                    "TRLOADT_SCIEIGHT4"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT5,               UINT32,\
+                    "TRLOADT_SCIEIGHT5"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT6,               UINT32,\
+                    "TRLOADT_SCIEIGHT6"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT7,               UINT32,\
+                    "TRLOADT_SCIEIGHT7"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT8,               UINT32,\
+                    "TRLOADT_SCIEIGHT8"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT9,               UINT32,\
+                    "TRLOADT_SCIEIGHT9"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT10,              UINT32,\
+                    "TRLOADT_SCIEIGHT10"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT11,              UINT32,\
+                    "TRLOADT_SCIEIGHT11"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT12,              UINT32,\
+                    "TRLOADT_SCIEIGHT12"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT13,              UINT32,\
+                    "TRLOADT_SCIEIGHT13"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT14,              UINT32,\
+                    "TRLOADT_SCIEIGHT14"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT15,              UINT32,\
+                    "TRLOADT_SCIEIGHT15"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_SCIEIGHT16,              UINT32,\
+                    "TRLOADT_SCIEIGHT16"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN1,                   UINT32,\
+                    "TRLOADT_MAIN1"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN2,                   UINT32,\
+                    "TRLOADT_MAIN2"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN3,                   UINT32,\
+                    "TRLOADT_MAIN3"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN4,                   UINT32,\
+                    "TRLOADT_MAIN4"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN5,                   UINT32,\
+                    "TRLOADT_MAIN5"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN6,                   UINT32,\
+                    "TRLOADT_MAIN6"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN7,                   UINT32,\
+                    "TRLOADT_MAIN7"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN8,                   UINT32,\
+                    "TRLOADT_MAIN8"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN9,                   UINT32,\
+                    "TRLOADT_MAIN9"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN10,                  UINT32,\
+                    "TRLOADT_MAIN10"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN11,                  UINT32,\
+                    "TRLOADT_MAIN11"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN12,                  UINT32,\
+                    "TRLOADT_MAIN12"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN13,                  UINT32,\
+                    "TRLOADT_MAIN13"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN14,                  UINT32,\
+                    "TRLOADT_MAIN14"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN15,                  UINT32,\
+                    "TRLOADT_MAIN15"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOADT_MAIN16,                  UINT32,\
+                    "TRLOADT_MAIN16"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO1,                 UINT32,\
+                    "TRLOARD_SCITWO1"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO2,                 UINT32,\
+                    "TRLOARD_SCITWO2"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO3,                 UINT32,\
+                    "TRLOARD_SCITWO3"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO4,                 UINT32,\
+                    "TRLOARD_SCITWO4"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO5,                 UINT32,\
+                    "TRLOARD_SCITWO5"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO6,                 UINT32,\
+                    "TRLOARD_SCITWO6"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO7,                 UINT32,\
+                    "TRLOARD_SCITWO7"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO8,                 UINT32,\
+                    "TRLOARD_SCITWO8"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO9,                 UINT32,\
+                    "TRLOARD_SCITWO9"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO10,                UINT32,\
+                    "TRLOARD_SCITWO10"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO11,                UINT32,\
+                    "TRLOARD_SCITWO11"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO12,                UINT32,\
+                    "TRLOARD_SCITWO12"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO13,                UINT32,\
+                    "TRLOARD_SCITWO13"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO14,                UINT32,\
+                    "TRLOARD_SCITWO14"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO15,                UINT32,\
+                    "TRLOARD_SCITWO15"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCITWO16,                UINT32,\
+                    "TRLOARD_SCITWO16"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT1,               UINT32,\
+                    "TRLOARD_SCIEIGHT1"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT2,               UINT32,\
+                    "TRLOARD_SCIEIGHT2"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT3,               UINT32,\
+                    "TRLOARD_SCIEIGHT3"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT4,               UINT32,\
+                    "TRLOARD_SCIEIGHT4"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT5,               UINT32,\
+                    "TRLOARD_SCIEIGHT5"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT6,               UINT32,\
+                    "TRLOARD_SCIEIGHT6"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT7,               UINT32,\
+                    "TRLOARD_SCIEIGHT7"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT8,               UINT32,\
+                    "TRLOARD_SCIEIGHT8"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT9,               UINT32,\
+                    "TRLOARD_SCIEIGHT9"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT10,              UINT32,\
+                    "TRLOARD_SCIEIGHT10"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT11,              UINT32,\
+                    "TRLOARD_SCIEIGHT11"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT12,              UINT32,\
+                    "TRLOARD_SCIEIGHT12"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT13,              UINT32,\
+                    "TRLOARD_SCIEIGHT13"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT14,              UINT32,\
+                    "TRLOARD_SCIEIGHT14"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT15,              UINT32,\
+                    "TRLOARD_SCIEIGHT15"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_SCIEIGHT16,              UINT32,\
+                    "TRLOARD_SCIEIGHT16"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN1,                   UINT32,\
+                    "TRLOARD_MAIN1"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN2,                   UINT32,\
+                    "TRLOARD_MAIN2"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN3,                   UINT32,\
+                    "TRLOARD_MAIN3"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN4,                   UINT32,\
+                    "TRLOARD_MAIN4"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN5,                   UINT32,\
+                    "TRLOARD_MAIN5"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN6,                   UINT32,\
+                    "TRLOARD_MAIN6"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN7,                   UINT32,\
+                    "TRLOARD_MAIN7"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN8,                   UINT32,\
+                    "TRLOARD_MAIN8"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN9,                   UINT32,\
+                    "TRLOARD_MAIN9"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN10,                  UINT32,\
+                    "TRLOARD_MAIN10"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN11,                  UINT32,\
+                    "TRLOARD_MAIN11"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN12,                  UINT32,\
+                    "TRLOARD_MAIN12"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN13,                  UINT32,\
+                    "TRLOARD_MAIN13"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN14,                  UINT32,\
+                    "TRLOARD_MAIN14"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN15,                  UINT32,\
+                    "TRLOARD_MAIN15"); \
+  EXT_STR_ITEM_INFO    (ok,si,offset,struct_t,printerr,\
+                     TRLOARD_MAIN16,                  UINT32,\
+                    "TRLOARD_MAIN16"); \
+  \
+} while (0);
+
+/********************************************************
+ *
+ * For internal use by the network data reader:
+ * (version checks, etc)
+ */
+
+typedef struct EXT_STR_h101_TRLO_s467_layout_t
+{
+  uint32_t _magic;
+  uint32_t _size_info;
+  uint32_t _size_struct;
+  uint32_t _size_struct_onion;
+  uint32_t _pack_list_items;
+
+  uint32_t _num_items;
+  struct {
+    uint32_t _offset;
+    uint32_t _size;
+    uint32_t _xor;
+    const char *_name;
+  } _items[1];
+  uint32_t _pack_list[384];
+} EXT_STR_h101_TRLO_s467_layout;
+
+#define EXT_STR_h101_TRLO_s467_LAYOUT_INIT { \
+  0x57e65c96, \
+  sizeof(EXT_STR_h101_TRLO_s467_layout), \
+  sizeof(EXT_STR_h101_TRLO_s467), \
+  sizeof(EXT_STR_h101_TRLO_s467_onion), \
+  384, \
+  1, \
+  { \
+    { 0, sizeof(EXT_STR_h101_TRLO_s467), 0x48e6e281, "h101_TRLO_s467" }, \
+  }, \
+  { \
+   /*    0 */ 0x40a50000, 0x00000000, 0x40a50000, 0x00000004, \
+   /*    4 */ 0x40a50000, 0x00000008, 0x40a50000, 0x0000000c, \
+   /*    8 */ 0x40a50000, 0x00000010, 0x40a50000, 0x00000014, \
+   /*   12 */ 0x40a50000, 0x00000018, 0x40a50000, 0x0000001c, \
+   /*   16 */ 0x40a50000, 0x00000020, 0x40a50000, 0x00000024, \
+   /*   20 */ 0x40a50000, 0x00000028, 0x40a50000, 0x0000002c, \
+   /*   24 */ 0x40a50000, 0x00000030, 0x40a50000, 0x00000034, \
+   /*   28 */ 0x40a50000, 0x00000038, 0x40a50000, 0x0000003c, \
+   /*   32 */ 0x40a50000, 0x00000040, 0x40a50000, 0x00000044, \
+   /*   36 */ 0x40a50000, 0x00000048, 0x40a50000, 0x0000004c, \
+   /*   40 */ 0x40a50000, 0x00000050, 0x40a50000, 0x00000054, \
+   /*   44 */ 0x40a50000, 0x00000058, 0x40a50000, 0x0000005c, \
+   /*   48 */ 0x40a50000, 0x00000060, 0x40a50000, 0x00000064, \
+   /*   52 */ 0x40a50000, 0x00000068, 0x40a50000, 0x0000006c, \
+   /*   56 */ 0x40a50000, 0x00000070, 0x40a50000, 0x00000074, \
+   /*   60 */ 0x40a50000, 0x00000078, 0x40a50000, 0x0000007c, \
+   /*   64 */ 0x40a50000, 0x00000080, 0x40a50000, 0x00000084, \
+   /*   68 */ 0x40a50000, 0x00000088, 0x40a50000, 0x0000008c, \
+   /*   72 */ 0x40a50000, 0x00000090, 0x40a50000, 0x00000094, \
+   /*   76 */ 0x40a50000, 0x00000098, 0x40a50000, 0x0000009c, \
+   /*   80 */ 0x40a50000, 0x000000a0, 0x40a50000, 0x000000a4, \
+   /*   84 */ 0x40a50000, 0x000000a8, 0x40a50000, 0x000000ac, \
+   /*   88 */ 0x40a50000, 0x000000b0, 0x40a50000, 0x000000b4, \
+   /*   92 */ 0x40a50000, 0x000000b8, 0x40a50000, 0x000000bc, \
+   /*   96 */ 0x40a50000, 0x000000c0, 0x40a50000, 0x000000c4, \
+   /*  100 */ 0x40a50000, 0x000000c8, 0x40a50000, 0x000000cc, \
+   /*  104 */ 0x40a50000, 0x000000d0, 0x40a50000, 0x000000d4, \
+   /*  108 */ 0x40a50000, 0x000000d8, 0x40a50000, 0x000000dc, \
+   /*  112 */ 0x40a50000, 0x000000e0, 0x40a50000, 0x000000e4, \
+   /*  116 */ 0x40a50000, 0x000000e8, 0x40a50000, 0x000000ec, \
+   /*  120 */ 0x40a50000, 0x000000f0, 0x40a50000, 0x000000f4, \
+   /*  124 */ 0x40a50000, 0x000000f8, 0x40a50000, 0x000000fc, \
+   /*  128 */ 0x40a50000, 0x00000100, 0x40a50000, 0x00000104, \
+   /*  132 */ 0x40a50000, 0x00000108, 0x40a50000, 0x0000010c, \
+   /*  136 */ 0x40a50000, 0x00000110, 0x40a50000, 0x00000114, \
+   /*  140 */ 0x40a50000, 0x00000118, 0x40a50000, 0x0000011c, \
+   /*  144 */ 0x40a50000, 0x00000120, 0x40a50000, 0x00000124, \
+   /*  148 */ 0x40a50000, 0x00000128, 0x40a50000, 0x0000012c, \
+   /*  152 */ 0x40a50000, 0x00000130, 0x40a50000, 0x00000134, \
+   /*  156 */ 0x40a50000, 0x00000138, 0x40a50000, 0x0000013c, \
+   /*  160 */ 0x40a50000, 0x00000140, 0x40a50000, 0x00000144, \
+   /*  164 */ 0x40a50000, 0x00000148, 0x40a50000, 0x0000014c, \
+   /*  168 */ 0x40a50000, 0x00000150, 0x40a50000, 0x00000154, \
+   /*  172 */ 0x40a50000, 0x00000158, 0x40a50000, 0x0000015c, \
+   /*  176 */ 0x40a50000, 0x00000160, 0x40a50000, 0x00000164, \
+   /*  180 */ 0x40a50000, 0x00000168, 0x40a50000, 0x0000016c, \
+   /*  184 */ 0x40a50000, 0x00000170, 0x40a50000, 0x00000174, \
+   /*  188 */ 0x40a50000, 0x00000178, 0x40a50000, 0x0000017c, \
+   /*  192 */ 0x40a50000, 0x00000180, 0x40a50000, 0x00000184, \
+   /*  196 */ 0x40a50000, 0x00000188, 0x40a50000, 0x0000018c, \
+   /*  200 */ 0x40a50000, 0x00000190, 0x40a50000, 0x00000194, \
+   /*  204 */ 0x40a50000, 0x00000198, 0x40a50000, 0x0000019c, \
+   /*  208 */ 0x40a50000, 0x000001a0, 0x40a50000, 0x000001a4, \
+   /*  212 */ 0x40a50000, 0x000001a8, 0x40a50000, 0x000001ac, \
+   /*  216 */ 0x40a50000, 0x000001b0, 0x40a50000, 0x000001b4, \
+   /*  220 */ 0x40a50000, 0x000001b8, 0x40a50000, 0x000001bc, \
+   /*  224 */ 0x40a50000, 0x000001c0, 0x40a50000, 0x000001c4, \
+   /*  228 */ 0x40a50000, 0x000001c8, 0x40a50000, 0x000001cc, \
+   /*  232 */ 0x40a50000, 0x000001d0, 0x40a50000, 0x000001d4, \
+   /*  236 */ 0x40a50000, 0x000001d8, 0x40a50000, 0x000001dc, \
+   /*  240 */ 0x40a50000, 0x000001e0, 0x40a50000, 0x000001e4, \
+   /*  244 */ 0x40a50000, 0x000001e8, 0x40a50000, 0x000001ec, \
+   /*  248 */ 0x40a50000, 0x000001f0, 0x40a50000, 0x000001f4, \
+   /*  252 */ 0x40a50000, 0x000001f8, 0x40a50000, 0x000001fc, \
+   /*  256 */ 0x40a50000, 0x00000200, 0x40a50000, 0x00000204, \
+   /*  260 */ 0x40a50000, 0x00000208, 0x40a50000, 0x0000020c, \
+   /*  264 */ 0x40a50000, 0x00000210, 0x40a50000, 0x00000214, \
+   /*  268 */ 0x40a50000, 0x00000218, 0x40a50000, 0x0000021c, \
+   /*  272 */ 0x40a50000, 0x00000220, 0x40a50000, 0x00000224, \
+   /*  276 */ 0x40a50000, 0x00000228, 0x40a50000, 0x0000022c, \
+   /*  280 */ 0x40a50000, 0x00000230, 0x40a50000, 0x00000234, \
+   /*  284 */ 0x40a50000, 0x00000238, 0x40a50000, 0x0000023c, \
+   /*  288 */ 0x40a50000, 0x00000240, 0x40a50000, 0x00000244, \
+   /*  292 */ 0x40a50000, 0x00000248, 0x40a50000, 0x0000024c, \
+   /*  296 */ 0x40a50000, 0x00000250, 0x40a50000, 0x00000254, \
+   /*  300 */ 0x40a50000, 0x00000258, 0x40a50000, 0x0000025c, \
+   /*  304 */ 0x40a50000, 0x00000260, 0x40a50000, 0x00000264, \
+   /*  308 */ 0x40a50000, 0x00000268, 0x40a50000, 0x0000026c, \
+   /*  312 */ 0x40a50000, 0x00000270, 0x40a50000, 0x00000274, \
+   /*  316 */ 0x40a50000, 0x00000278, 0x40a50000, 0x0000027c, \
+   /*  320 */ 0x40a50000, 0x00000280, 0x40a50000, 0x00000284, \
+   /*  324 */ 0x40a50000, 0x00000288, 0x40a50000, 0x0000028c, \
+   /*  328 */ 0x40a50000, 0x00000290, 0x40a50000, 0x00000294, \
+   /*  332 */ 0x40a50000, 0x00000298, 0x40a50000, 0x0000029c, \
+   /*  336 */ 0x40a50000, 0x000002a0, 0x40a50000, 0x000002a4, \
+   /*  340 */ 0x40a50000, 0x000002a8, 0x40a50000, 0x000002ac, \
+   /*  344 */ 0x40a50000, 0x000002b0, 0x40a50000, 0x000002b4, \
+   /*  348 */ 0x40a50000, 0x000002b8, 0x40a50000, 0x000002bc, \
+   /*  352 */ 0x40a50000, 0x000002c0, 0x40a50000, 0x000002c4, \
+   /*  356 */ 0x40a50000, 0x000002c8, 0x40a50000, 0x000002cc, \
+   /*  360 */ 0x40a50000, 0x000002d0, 0x40a50000, 0x000002d4, \
+   /*  364 */ 0x40a50000, 0x000002d8, 0x40a50000, 0x000002dc, \
+   /*  368 */ 0x40a50000, 0x000002e0, 0x40a50000, 0x000002e4, \
+   /*  372 */ 0x40a50000, 0x000002e8, 0x40a50000, 0x000002ec, \
+   /*  376 */ 0x40a50000, 0x000002f0, 0x40a50000, 0x000002f4, \
+   /*  380 */ 0x40a50000, 0x000002f8, 0x40a50000, 0x000002fc, \
+  } \
+};
+
+#endif/*__GUARD_H101_TRLO_S467_EXT_H101_TRLO_S467_H__*/
+
+/*******************************************************/


### PR DESCRIPTION
…dition to the MAIN one, the S2 and S8 ones can be read. The R3BTrloiiData class stores values in unsigned int32 to match with the ext file.