### PR TITLE
Neuland stuff

### DIFF
--- a/neuland/calibration/CMakeLists.txt
+++ b/neuland/calibration/CMakeLists.txt
@@ -46,7 +46,8 @@ set(SRCS
     R3BNeulandCal2Hit.cxx
     R3BNeulandHitModulePar.cxx
     R3BNeulandQCalPar.cxx
-    R3BNeulandQCalFiller.cxx)
+    R3BNeulandQCalFiller.cxx
+    R3BNeulandProvideTStart.cxx)
 change_file_extension(*.cxx *.h HEADERS "${SRCS}")
 
 generate_library()

--- a/neuland/calibration/NeulandCalibrationLinkDef.h
+++ b/neuland/calibration/NeulandCalibrationLinkDef.h
@@ -35,6 +35,7 @@
 #pragma link C++ class R3BNeulandHitModulePar+;
 #pragma link C++ class R3BNeulandQCalPar+;
 #pragma link C++ class R3BNeulandQCalFiller+;
+#pragma link C++ class R3BNeulandProvideTStart+;
 #pragma link C++ class Neuland::Calibration::TSyncer+;
 #pragma link C++ class Neuland::Calibration::HitCalibrationBar+;
 #pragma link C++ class Neuland::Calibration::CosmicTracker+;

--- a/neuland/calibration/R3BNeulandCal2Hit.h
+++ b/neuland/calibration/R3BNeulandCal2Hit.h
@@ -45,6 +45,12 @@ class R3BNeulandCal2Hit : public FairTask
     // Global time offset in ns
     inline void SetGlobalTimeOffset(Double_t t0) { fGlobalTimeOffset = t0; }
 
+    // Energy cutoff in MeV
+    inline void SetEnergyCutoff(Double_t enecut) { fEnergyCutoff = enecut; }
+
+    // Walk correction
+    inline void EnableWalk(Bool_t walk = kFALSE) { fWalkEnabled = walk; }
+
   private:
     void SetParameter();
     Double_t GetUnsaturatedEnergy(const Int_t qdc, const Double_t gain, const Double_t saturation) const;
@@ -63,6 +69,9 @@ class R3BNeulandCal2Hit : public FairTask
     std::vector<Double_t> fAttenuationValues;
     Double_t fGlobalTimeOffset;
     Double_t fEnergyCutoff;
+
+    Bool_t fWalkEnabled;
+    Double_t WalkCorrection(Double_t);
 
     std::map<Int_t, R3BNeulandHitModulePar> fParMap;
 

--- a/neuland/calibration/R3BNeulandHitModulePar.h
+++ b/neuland/calibration/R3BNeulandHitModulePar.h
@@ -77,7 +77,7 @@ class R3BNeulandHitModulePar : public FairParGenericSet
     Double_t GetTimeOffset(const Int_t side) const
     {
         assert(side == 1 || side == 2);
-        return fTSync + (1.5 - side) * fTDiff;
+        return -fTSync + (1.5 - side) * fTDiff;
     }
     Double_t GetEffectiveSpeed() const { return fEffectiveSpeed; }
     Int_t GetPedestal(const Int_t side) const

--- a/neuland/calibration/R3BNeulandHitPar.cxx
+++ b/neuland/calibration/R3BNeulandHitPar.cxx
@@ -20,7 +20,9 @@
 R3BNeulandHitPar::R3BNeulandHitPar(const char* name, const char* title, const char* context, Bool_t own)
     : FairParGenericSet(name, title, context, own)
     , fParams(new TObjArray(Neuland::MaxNumberOfBars))
-    , fGlobalTimeOffset(0.0)
+    , fGlobalTimeOffset(Neuland::NaN)
+    , fDistanceToTarget(Neuland::NaN)
+    , fEnergyCut(0.0)
 {
     fDistancesToFirstPlane.resize(Neuland::MaxNumberOfPlanes, 0);
     for (int p = 1; p < Neuland::MaxNumberOfPlanes; ++p)

--- a/neuland/calibration/R3BNeulandMapped2CalPar.cxx
+++ b/neuland/calibration/R3BNeulandMapped2CalPar.cxx
@@ -108,7 +108,7 @@ void R3BNeulandMapped2CalPar::Exec(Option_t* option)
     if (checkcounts == fNofPMTs)
     {
         std::cout << "done " << std::endl;
-        raise(SIGINT);
+        //    raise(SIGINT);
     }
 
     if (fTrigger >= 0)

--- a/neuland/calibration/R3BNeulandProvideTStart.cxx
+++ b/neuland/calibration/R3BNeulandProvideTStart.cxx
@@ -1,0 +1,84 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "R3BNeulandProvideTStart.h"
+#include "FairRootManager.h"
+#include "R3BEventHeader.h"
+
+R3BNeulandProvideTStart::R3BNeulandProvideTStart()
+    : FairTask("R3BNeulandProvideTStart", 0)
+    , fNeulandCalData("NeulandCalData")
+    , fEventHeader(nullptr)
+{
+}
+
+InitStatus R3BNeulandProvideTStart::Init()
+{
+    fNeulandCalData.Init();
+
+    auto ioman = FairRootManager::Instance();
+    if (ioman == nullptr)
+    {
+        throw std::runtime_error("R3BNeulandProvideTStart: No FairRootManager");
+    }
+
+    fEventHeader = (R3BEventHeader*)ioman->GetObject("R3BEventHeader");
+    if (fEventHeader == nullptr)
+    {
+        throw std::runtime_error("R3BNeulandProvideTStart: No R3BEventHeader");
+    }
+
+    return kSUCCESS;
+}
+
+void R3BNeulandProvideTStart::Exec(Option_t*) { fEventHeader->SetTStart(GetTStart()); }
+
+Double_t R3BNeulandProvideTStart::GetTStart() const
+{
+    const auto calData = fNeulandCalData.Retrieve();
+
+    double tref[2] = { NAN, NAN };
+    double eref[2] = { NAN, NAN };
+    int fref = 0;
+
+    for (const auto& data : calData)
+    {
+        const auto side = data->GetSide() - 1; // [1,2] -> [0,1]
+        const auto bar = data->GetBarId();
+
+        // proton beam 2020, neuland bar 701 used as a start detector
+        if (bar == 701)
+        {
+            tref[side] = data->GetTime();
+            eref[side] = data->GetQdc();
+            fref++;
+        }
+    }
+
+    double pstart = NAN;
+    if (fref == 2)
+    {
+        if (tref[0] - tref[1] < -0.5 * 5. * 2048)
+            tref[1] = tref[1] - 5. * 2048;
+        if (tref[0] - tref[1] > 0.5 * 5. * 2048)
+            tref[0] = tref[0] - 5. * 2048;
+
+        pstart = 0.5 * (tref[0] + tref[1]);
+    }
+
+    return pstart;
+}
+
+bool R3BNeulandProvideTStart::IsBeam() const { return !std::isnan(GetTStart()); }
+
+ClassImp(R3BNeulandProvideTStart)

--- a/neuland/calibration/R3BNeulandProvideTStart.h
+++ b/neuland/calibration/R3BNeulandProvideTStart.h
@@ -1,0 +1,41 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BROOT_R3BNEULANDPROVIDETSTART_H
+#define R3BROOT_R3BNEULANDPROVIDETSTART_H
+
+#include "FairTask.h"
+#include "R3BNeulandCalData.h"
+#include "TCAConnector.h"
+
+class R3BEventHeader;
+
+class R3BNeulandProvideTStart : public FairTask
+{
+  public:
+    R3BNeulandProvideTStart();
+
+    InitStatus Init() override;
+    void Exec(Option_t*) override;
+
+  private:
+    TCAOptionalInputConnector<R3BNeulandCalData> fNeulandCalData;
+    R3BEventHeader* fEventHeader;
+
+    bool IsBeam() const;
+    Double_t GetTStart() const;
+
+    ClassDefOverride(R3BNeulandProvideTStart, 0)
+};
+
+#endif // R3BROOT_R3BNEULANDPROVIDETSTART_H

--- a/neuland/calibration/R3BNeulandTSyncer.cxx
+++ b/neuland/calibration/R3BNeulandTSyncer.cxx
@@ -103,7 +103,14 @@ namespace Neuland
 
                     if ((bar < BarsPerPlane - 1) && (HitMask[plane] & (1UL << (bar + 1))))
                     {
-                        const auto tdiff = EventData[barID + 1] - EventData[barID];
+                        auto tdiff = EventData[barID + 1] - EventData[barID];
+                        if (fabs(tdiff) > 0.5 * MaxCalTime)
+                        {
+                            if (tdiff < 0)
+                                tdiff += MaxCalTime;
+                            else
+                                tdiff -= MaxCalTime;
+                        }
 
                         if (barData.NextBarLog.size() < NextBarLogSize)
                         {
@@ -136,7 +143,14 @@ namespace Neuland
                             continue;
 
                         const auto nextPlaneBarID = nextPlane * BarsPerPlane + barInNextPlane;
-                        const auto tdiff = EventData[nextPlaneBarID] - EventData[barID];
+                        auto tdiff = EventData[nextPlaneBarID] - EventData[barID];
+                        if (fabs(tdiff) > 0.5 * MaxCalTime)
+                        {
+                            if (tdiff < 0)
+                                tdiff += MaxCalTime;
+                            else
+                                tdiff -= MaxCalTime;
+                        }
 
                         if (barData.NextPlaneLog[barInNextPlane].size() < NextPlaneLogSize)
                         {

--- a/neuland/online/R3BNeulandOnlineSpectra.h
+++ b/neuland/online/R3BNeulandOnlineSpectra.h
@@ -40,6 +40,8 @@ class R3BNeulandOnlineSpectra : public FairTask
     void ResetHistosMapped();
     void SetDistanceToTarget(double x) { fDistanceToTarget = x; }
 
+    void SetCosmicTpat(UInt_t CosmicTpat = 0) { fCosmicTpat = CosmicTpat; }
+
   private:
     static const unsigned int fNPlanes = 24;
     static const unsigned int fNBars = fNPlanes * 50;
@@ -54,6 +56,8 @@ class R3BNeulandOnlineSpectra : public FairTask
     TH1D* hNstart;
 
     TH2D* hTestJump;
+    TH2D* hJumpsvsEvnt;
+    TH2D* hJumpsvsEvntzoom;
 
     std::array<TH1D*, 4> ahMappedBar1;
     std::array<TH1D*, 4> ahMappedBar2;
@@ -93,6 +97,8 @@ class R3BNeulandOnlineSpectra : public FairTask
     double fDistanceToTarget;
 
     bool fIsOnline;
+
+    UInt_t fCosmicTpat = 0;
 
   private:
     bool IsBeam() const;


### PR DESCRIPTION
R3BNeulandCal2Hit - fDistanceToTarget, fGlobalTimeOffset, fEnergyCutoff,
                                     fWalkEnabled added and properly initialized
                                  - GetTimeOffset(side) bug fixed in R3BNeulandHitModulePar.h
                                  - the time offset set to 0 in remainder() function for time
                                  - barID from 1 in NeulandHits
                                  - z-coordinate of hit bug fixed

R3BNeulandProvideTStart added for the proton beamtime 2020

R3BNeulandTSyncer - tdiff shift introduced for large time shifts in data

R3BNeulandOnlineSpectra.cxx - some histograms added, bug fixed ...