### PR TITLE
R3BUcesbSource can now skip events without TPat

### DIFF
--- a/r3bsource/R3BUcesbSource.cxx
+++ b/r3bsource/R3BUcesbSource.cxx
@@ -42,6 +42,7 @@ R3BUcesbSource::R3BUcesbSource(const TString& FileName,
     , fInputFile()
     , fEntryMax(0)
     , fReaders(new TObjArray())
+    , fSkip(0)
 {
 }
 
@@ -205,6 +206,26 @@ Int_t R3BUcesbSource::ReadEvent(UInt_t i)
     LOG(debug1) << "R3BUcesbSource::ReadEvent " << fNEvent;
 
     fNEvent++;
+
+    Int_t tpatbin, fTPat = 0;
+
+    if (fSkip)
+    {
+
+        if (fEventHeader->GetTpat() > 0)
+        {
+
+            FairRunOnline::Instance()->MarkFill(kTRUE);
+        }
+
+        else
+        {
+
+            FairRunOnline::Instance()->MarkFill(kFALSE);
+        }
+    }
+
+
 
     if (fNEvent > fEntryMax && fEntryMax != -1 && fInputFile.is_open())
     {

--- a/r3bsource/R3BUcesbSource.h
+++ b/r3bsource/R3BUcesbSource.h
@@ -28,6 +28,7 @@
 
 #include <fstream>
 #include <list>
+#include "FairRunOnline.h"
 
 /* External data client interface (ucesb) */
 #include "ext_data_clnt.hh"
@@ -75,6 +76,9 @@ class R3BUcesbSource : public FairSource
 
     void SetInputFileName(TString tstr) { fInputFileName = tstr; }
 
+    void SetSkipEvents(Bool_t skip){fSkip=skip;}
+
+
   private:
     /* File descriptor returned from popen() */
     FILE* fFd;
@@ -103,6 +107,7 @@ class R3BUcesbSource : public FairSource
     TString fInputFileName;
     std::ifstream fInputFile;
     Int_t fEntryMax;
+    Bool_t fSkip;
 
   public:
     // Create dictionary


### PR DESCRIPTION
Now it is possible to select only events with an assigned TPat when unpacking.