### PR TITLE
Implement a basic skeleton for RPC data structures and reconstructors

### DIFF
--- a/r3bdata/CMakeLists.txt
+++ b/r3bdata/CMakeLists.txt
@@ -54,6 +54,7 @@ ${R3BROOT_SOURCE_DIR}/r3bdata/musicData
 ${R3BROOT_SOURCE_DIR}/r3bdata/sampData
 ${R3BROOT_SOURCE_DIR}/r3bdata/sfibData
 ${R3BROOT_SOURCE_DIR}/r3bdata/frsData
+${R3BROOT_SOURCE_DIR}/r3bdata/rpcData
 )
 
 include_directories(${INCLUDE_DIRECTORIES})
@@ -190,6 +191,10 @@ footData/R3BFootCalData.cxx
 footData/R3BFootHitData.cxx
 alpideData/R3BAlpidePoint.cxx
 alpideData/R3BAlpideMappedData.cxx
+rpcData/R3BRpcCalData.cxx
+rpcData/R3BRpcMappedData.cxx
+rpcData/R3BRpcHitData.cxx
+rpcData/R3BRpcPoint.cxx
 )
 
 # fill list of header files from list of source files by exchanging the file extension

--- a/r3bdata/R3BDataLinkDef.h
+++ b/r3bdata/R3BDataLinkDef.h
@@ -61,6 +61,10 @@
 #pragma link C++ class R3BFootHitData+;
 #pragma link C++ class R3BAlpidePoint+;
 #pragma link C++ class R3BAlpideMappedData+;
+#pragma link C++ class R3BRpcMappedData+;
+#pragma link C++ class R3BRpcCalData+;
+#pragma link C++ class R3BRpcHitData+;
+#pragma link C++ class R3BRpcPoint+;
 
 #pragma link C++ class R3BWRData+;
 #pragma link C++ class R3BTrloiiData+;

--- a/r3bdata/R3BDetectorList.h
+++ b/r3bdata/R3BDetectorList.h
@@ -64,6 +64,7 @@ enum DetectorId
     kSFI,
     kMUSIC,
     kLOS,
+    kRPC,
 #ifdef SOFIA
     kSOFSCI,
     kSOFAT,
@@ -123,7 +124,8 @@ enum fDetectorType
     kFI33Point,
     kSFIPoint,
     kMUSICPoint,
-    kLOSPoint
+    kLOSPoint,
+    kRpcPoint
 #ifdef SOFIA
     ,
     kSOFSCIPoint,

--- a/r3bdata/rpcData/R3BRpcCalData.cxx
+++ b/r3bdata/rpcData/R3BRpcCalData.cxx
@@ -1,5 +1,3 @@
-// clang-format off
-
 /******************************************************************************
  *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
  *   Copyright (C) 2019 Members of R3B Collaboration                          *
@@ -13,27 +11,41 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 
-#ifdef __CINT__
+#include "R3BRpcCalData.h"
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+R3BRpcCalData::R3BRpcCalData()
+    : FairMultiLinkedData()
+    , fChannelId(-1)
+    // MODIFY ME!!!!!!!!!!!!!!!!!
+    , fEnergy(-1.)
+    , fToT_Energy(-1.)
+    , fTime(0)
+{
+}
 
-#pragma link C++ class R3BRpc+;
-#pragma link C++ class R3BRpcContFact;
-#pragma link C++ class R3BRpcDigitizer+;
+R3BRpcCalData::R3BRpcCalData(Int_t ident,
+                             // MODIFY ME!!!!!!!!!!!!!!!!!
 
-#pragma link C++ class R3BRpcMapped2Cal+;
-#pragma link C++ class R3BRpcMapped2CalPar+;
-#pragma link C++ class R3BRpcCalPar+;
+                             Double_t energy,
+                             uint64_t time,
+                             Double_t tot_energy)
+    : FairMultiLinkedData()
+    , fChannelId(ident)
+    // MODIFY ME!!!!!!!!!!!!!!!!!
+    , fEnergy(energy)
+    , fToT_Energy(tot_energy)
+    , fTime(time)
+{
+}
 
-#pragma link C++ class R3BRpcCal2Hit+;
-#pragma link C++ class R3BRpcCal2HitPar+;
-#pragma link C++ class R3BRpcHitPar+;
+R3BRpcCalData::R3BRpcCalData(const R3BRpcCalData& right)
+    : FairMultiLinkedData(right)
+    , fChannelId(right.fChannelId)
+    // MODIFY ME!!!!!!!!!!!!!!!!!
+    , fEnergy(right.fEnergy)
+    , fToT_Energy(right.fToT_Energy)
+    , fTime(right.fTime)
+{
+}
 
-#pragma link C++ class R3BRpcPars4Sim+;
-
-//#pragma link C++ class R3BRpcOnlineSpectra+;
-
-
-#endif
+ClassImp(R3BRpcCalData);

--- a/r3bdata/rpcData/R3BRpcCalData.h
+++ b/r3bdata/rpcData/R3BRpcCalData.h
@@ -1,0 +1,76 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BRPCCALDATA_H
+#define R3BRPCCALDATA_H
+
+#include "FairMultiLinkedData.h"
+#include "TObject.h"
+
+class R3BRpcCalData : public FairMultiLinkedData
+{
+  public:
+    /** Default constructor **/
+    R3BRpcCalData();
+
+    /** Constructor with arguments
+     *@param fChannelId   Channel unique identifier
+     //MODIFY ME!!!!!!!!!!!!!!!!!
+     *@param fEnergy      Total energy deposited ([GeV] in sim)
+     *@param fTime        Time since event start [ns]
+     *@param fToT_Energy  Total energy deposited from ToT ([GeV] in sim)
+     **/
+    R3BRpcCalData(Int_t ident,
+                  // MODIFY ME!!!!!!!!!!!!!!!!!
+                  Double_t energy,
+                  uint64_t time,
+                  Double_t tot_energy = 0);
+
+    /** Copy constructor **/
+    R3BRpcCalData(const R3BRpcCalData&);
+
+    R3BRpcCalData& operator=(const R3BRpcCalData&) { return *this; }
+
+    /** Destructor **/
+    virtual ~R3BRpcCalData() {}
+
+    /** Accessors **/
+    inline const Int_t& GetChannelId() const { return fChannelId; }
+
+    // MODIFY ME!!!!!!!!!!!!!!!!!
+    inline const Double_t& GetEnergy() const { return fEnergy; }
+    inline const Double_t& GetToT_Energy() const { return fToT_Energy; }
+    inline const uint64_t& GetTime() const { return fTime; }
+
+    /** Modifiers **/
+    void SetChannelId(Int_t ident) { fChannelId = ident; }
+
+    // MODIFY ME!!!!!!!!!!!!!!!!!
+    void SetEnergy(Double32_t energy) { fEnergy = energy; }
+    void SetToT_Energy(Double32_t energy) { fToT_Energy = energy; }
+    void SetTime(uint64_t time) { fTime = time; }
+    void AddMoreEnergy(Double32_t moreEnergy) { fEnergy += moreEnergy; }
+
+  protected:
+    Int_t fChannelId; // channel unique identifier
+
+    // MODIFY ME!!!!!!!!!!!!!!!!!
+    Double32_t fEnergy;     // total energy
+    Double32_t fToT_Energy; // total energy from ToT
+    uint64_t fTime;         // time of the interaction
+
+  public:
+    ClassDef(R3BRpcCalData, 1)
+};
+
+#endif

--- a/r3bdata/rpcData/R3BRpcHitData.cxx
+++ b/r3bdata/rpcData/R3BRpcHitData.cxx
@@ -1,5 +1,3 @@
-// clang-format off
-
 /******************************************************************************
  *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
  *   Copyright (C) 2019 Members of R3B Collaboration                          *
@@ -13,27 +11,33 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 
-#ifdef __CINT__
+#include "R3BRpcHitData.h"
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+R3BRpcHitData::R3BRpcHitData()
+    : FairMultiLinkedData()
+    , fChannelId(0)
+    // MODIFY ME!!!!!!!!!!!!!!!!!
+    , fEnergy(NAN)
+    , fTime(NAN)
+{
+}
 
-#pragma link C++ class R3BRpc+;
-#pragma link C++ class R3BRpcContFact;
-#pragma link C++ class R3BRpcDigitizer+;
+R3BRpcHitData::R3BRpcHitData(UInt_t ch, Double_t ene, Double_t tim)
+    : FairMultiLinkedData()
+    , fChannelId(ch)
+    // MODIFY ME!!!!!!!!!!!!!!!!!
+    , fEnergy(ene)
+    , fTime(tim)
+{
+}
 
-#pragma link C++ class R3BRpcMapped2Cal+;
-#pragma link C++ class R3BRpcMapped2CalPar+;
-#pragma link C++ class R3BRpcCalPar+;
+R3BRpcHitData::R3BRpcHitData(const R3BRpcHitData& right)
+    : FairMultiLinkedData(right)
+    , fChannelId(right.fChannelId)
+    // MODIFY ME!!!!!!!!!!!!!!!!!
+    , fEnergy(right.fEnergy)
+    , fTime(right.fTime)
+{
+}
 
-#pragma link C++ class R3BRpcCal2Hit+;
-#pragma link C++ class R3BRpcCal2HitPar+;
-#pragma link C++ class R3BRpcHitPar+;
-
-#pragma link C++ class R3BRpcPars4Sim+;
-
-//#pragma link C++ class R3BRpcOnlineSpectra+;
-
-
-#endif
+ClassImp(R3BRpcHitData);

--- a/r3bdata/rpcData/R3BRpcHitData.h
+++ b/r3bdata/rpcData/R3BRpcHitData.h
@@ -1,0 +1,75 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BRPCHITDATA_H
+#define R3BRPCHITDATA_H
+
+#include "TObject.h"
+
+#include "FairMultiLinkedData.h"
+#include "R3BRpcCalData.h"
+
+class R3BRpcHitData : public FairMultiLinkedData
+{
+
+  public:
+    /** Default constructor **/
+    R3BRpcHitData();
+
+    /** Constructor with arguments
+     *@param fChannelId		Channel unique identifier
+     //MODIFY ME!!!!!!!!!!!!!!!!!
+     *@param fEnergy				Total energy deposited
+     *@param fTime				  Time
+     **/
+    R3BRpcHitData(UInt_t channel, Double_t ene, Double_t time);
+
+    /** Copy constructor **/
+    R3BRpcHitData(const R3BRpcHitData&);
+
+    /** += operator **/
+    R3BRpcHitData& operator+=(R3BRpcCalData& cH)
+    {
+        // MODIFY ME!!!!!!!!!!!!!!!!!
+        this->fEnergy += cH.GetEnergy();
+        return *this;
+    }
+
+    R3BRpcHitData& operator=(const R3BRpcHitData&) { return *this; }
+
+    /** Destructor **/
+    virtual ~R3BRpcHitData() {}
+
+    /** Accessors **/
+    UInt_t GetChannelId() const { return fChannelId; }
+    // MODIFY ME!!!!!!!!!!!!!!!!!
+    Double_t GetEnergy() const { return fEnergy; }
+    Double_t GetTime() const { return fTime; }
+
+    /** Modifiers **/
+    void SetChannelId(UInt_t ch) { fChannelId = ch; }
+    // MODIFY ME!!!!!!!!!!!!!!!!!
+    void SetEnergy(Double_t ene) { fEnergy = ene; }
+    void SetTime(Double_t tim) { fTime = tim; }
+
+  protected:
+    // Basic Hit information
+    UInt_t fChannelId; //
+    // MODIFY ME!!!!!!!!!!!!!!!!!
+    Double_t fEnergy; //
+    Double_t fTime;   //
+
+    ClassDef(R3BRpcHitData, 1)
+};
+
+#endif

--- a/r3bdata/rpcData/R3BRpcMappedData.cxx
+++ b/r3bdata/rpcData/R3BRpcMappedData.cxx
@@ -1,5 +1,3 @@
-// clang-format off
-
 /******************************************************************************
  *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
  *   Copyright (C) 2019 Members of R3B Collaboration                          *
@@ -13,27 +11,22 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 
-#ifdef __CINT__
+#include "R3BRpcMappedData.h"
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+R3BRpcMappedData::R3BRpcMappedData()
+    : fChannelId(0)
+    , fTime(0)
+    , fWrts(0)
+    , fSide(0)
+{
+}
 
-#pragma link C++ class R3BRpc+;
-#pragma link C++ class R3BRpcContFact;
-#pragma link C++ class R3BRpcDigitizer+;
+R3BRpcMappedData::R3BRpcMappedData(UShort_t channelId, uint64_t time, uint64_t wrts, Int_t side)
+    : fChannelId(channelId)
+    , fTime(time)
+    , fWrts(wrts)
+    , fSide(side)
+{
+}
 
-#pragma link C++ class R3BRpcMapped2Cal+;
-#pragma link C++ class R3BRpcMapped2CalPar+;
-#pragma link C++ class R3BRpcCalPar+;
-
-#pragma link C++ class R3BRpcCal2Hit+;
-#pragma link C++ class R3BRpcCal2HitPar+;
-#pragma link C++ class R3BRpcHitPar+;
-
-#pragma link C++ class R3BRpcPars4Sim+;
-
-//#pragma link C++ class R3BRpcOnlineSpectra+;
-
-
-#endif
+ClassImp(R3BRpcMappedData);

--- a/r3bdata/rpcData/R3BRpcMappedData.h
+++ b/r3bdata/rpcData/R3BRpcMappedData.h
@@ -1,0 +1,54 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BRPCMAPPEDDATA_H
+#define R3BRPCMAPPEDDATA_H
+
+#include "TObject.h"
+#include <stdint.h>
+
+class R3BRpcMappedData : public TObject
+{
+
+  public:
+    // Default Constructor
+    R3BRpcMappedData();
+
+    /** Standard Constructor
+     *@param channelId   Channel unique identifier
+     *@param time        Internal time per crystal [ns]
+     *@param wrts        Timestamp or time since event start in simulation [ns]
+     *@param side        Left (0) or right (1)
+     **/
+    R3BRpcMappedData(UShort_t channelId, uint64_t time, uint64_t wrts, Int_t side);
+
+    // Destructor
+    virtual ~R3BRpcMappedData() {}
+
+    // Getters
+    inline const UShort_t& GetChannelId() const { return fChannelId; }
+    inline const uint64_t& GetTime() const { return fTime; }
+    inline const uint64_t& GetWrts() const { return fWrts; }
+    inline const Int_t& GetSide() const { return fSide; }
+
+  protected:
+    UShort_t fChannelId; // Channel unique identifier
+    uint64_t fTime;      // Internal time
+    uint64_t fWrts;      // Timestamp per channel
+    Int_t fSide;         // Left (0) or right (1) or ...
+
+  public:
+    ClassDef(R3BRpcMappedData, 1)
+};
+
+#endif

--- a/r3bdata/rpcData/R3BRpcPoint.cxx
+++ b/r3bdata/rpcData/R3BRpcPoint.cxx
@@ -1,0 +1,59 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "R3BRpcPoint.h"
+
+#include <iostream>
+
+using std::cout;
+using std::endl;
+using std::flush;
+
+R3BRpcPoint::R3BRpcPoint()
+    : FairMCPoint()
+    , fChannelId(-1)
+{
+}
+
+R3BRpcPoint::R3BRpcPoint(Int_t trackID,
+                         Int_t detID,
+                         Int_t ident,
+                         TVector3 posIn,
+                         TVector3 momIn,
+                         Double_t tof,
+                         Double_t length,
+                         Double_t eLoss,
+                         UInt_t EventId)
+    : FairMCPoint(trackID, detID, posIn, momIn, tof, length, eLoss, EventId)
+    , fChannelId(ident)
+{
+}
+
+R3BRpcPoint::R3BRpcPoint(const R3BRpcPoint& right)
+    : FairMCPoint(right)
+    , fChannelId(right.fChannelId)
+{
+}
+
+R3BRpcPoint::~R3BRpcPoint() {}
+
+void R3BRpcPoint::Print(const Option_t* opt) const
+{
+    cout << "-I- R3BRpcPoint: RPC Point for track " << fTrackID << " in channel " << fChannelId << endl;
+    cout << "    Position (" << fX << ", " << fY << ", " << fZ << ") cm" << endl;
+    cout << "    Momentum (" << fPx << ", " << fPy << ", " << fPz << ") GeV" << endl;
+    cout << "    Time " << fTime << " ns,  Length " << fLength << " cm,  Energy loss " << fELoss * 1.0e06 << " keV"
+         << endl;
+}
+
+ClassImp(R3BRpcPoint)

--- a/r3bdata/rpcData/R3BRpcPoint.h
+++ b/r3bdata/rpcData/R3BRpcPoint.h
@@ -1,0 +1,75 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BRPCPOINT_H
+#define R3BRPCPOINT_H
+
+#include "TObject.h"
+#include "TVector3.h"
+
+#include "FairMCPoint.h"
+
+class R3BRpcPoint : public FairMCPoint
+{
+
+  public:
+    /** Default constructor **/
+    R3BRpcPoint();
+
+    /** Constructor with arguments
+     *@param trackID  Index of MCTrack
+     *@param detID    Detector ID
+     *@param ident    channel ID
+     *@param posIn    Ccoordinates at entrance to active volume [cm]
+     *@param momIn    Momentum of track at entrance [GeV]
+     *@param tof      Time since event start [ns]
+     *@param length   Track length since creation [cm]
+     *@param eLoss    Energy deposit [GeV]
+     *@param EventId  Event Identifier
+     **/
+    R3BRpcPoint(Int_t trackID,
+                Int_t detID,
+                Int_t ident,
+                TVector3 posIn,
+                TVector3 momIn,
+                Double_t tof,
+                Double_t length,
+                Double_t eLoss,
+                UInt_t EventId);
+
+    /** Copy constructor **/
+    R3BRpcPoint(const R3BRpcPoint&);
+
+    R3BRpcPoint& operator=(const R3BRpcPoint&) { return *this; }
+
+    /** Destructor **/
+    virtual ~R3BRpcPoint();
+
+    /** Accessors **/
+    Int_t GetChannelId() const { return fChannelId; }
+    Double_t GetXIn() const { return fX; }
+    Double_t GetYIn() const { return fY; }
+    Double_t GetZIn() const { return fZ; }
+    void PositionIn(TVector3& pos) { pos.SetXYZ(fX, fY, fZ); }
+
+    /** Output to screen **/
+    virtual void Print(const Option_t* opt) const;
+
+  protected:
+    Int_t fChannelId; ///< channel index
+    // MODIFY ME!!!!!!!!!!!!!!!!!
+
+    ClassDef(R3BRpcPoint, 1)
+};
+
+#endif

--- a/rpc/CMakeLists.txt
+++ b/rpc/CMakeLists.txt
@@ -13,10 +13,10 @@
 ##############################################################################
 
 # Create a library called "libR3BRpc" which includes the source files given
-# in the array. The extension is already found. Any number of sources could be 
+# in the array. The extension is already found. Any number of sources could be
 # listed here.
 
-Set(SYSTEM_INCLUDE_DIRECTORIES 
+Set(SYSTEM_INCLUDE_DIRECTORIES
 ${SYSTEM_INCLUDE_DIRECTORIES}
 ${BASE_INCLUDE_DIRECTORIES}
 )
@@ -26,6 +26,9 @@ set(INCLUDE_DIRECTORIES
 ${R3BROOT_SOURCE_DIR}/r3bbase
 ${R3BROOT_SOURCE_DIR}/r3bdata
 ${R3BROOT_SOURCE_DIR}/rpc
+${R3BROOT_SOURCE_DIR}/r3bdata
+${R3BROOT_SOURCE_DIR}/r3bdata/rpcData
+${R3BROOT_SOURCE_DIR}/r3bdata/wrData
 )
 
 include_directories( ${INCLUDE_DIRECTORIES})
@@ -34,13 +37,23 @@ include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 set(LINK_DIRECTORIES
 ${ROOT_LIBRARY_DIR}
 ${FAIRROOT_LIBRARY_DIR}
-) 
+)
 
 link_directories( ${LINK_DIRECTORIES})
 
 set(SRCS
 #Put here your sourcefiles
-# R3BRpc.cxx
+R3BRpc.cxx
+R3BRpcContFact.cxx
+R3BRpcDigitizer.cxx
+R3BRpcMapped2Cal.cxx
+R3BRpcMapped2CalPar.cxx
+R3BRpcCalPar.cxx
+R3BRpcCal2Hit.cxx
+R3BRpcCal2HitPar.cxx
+R3BRpcHitPar.cxx
+R3BRpcPars4Sim.cxx
+#R3BRpcOnlineSpectra.cxx
 )
 
 # fill list of header files from list of source files
@@ -49,8 +62,8 @@ CHANGE_FILE_EXTENSION(*.cxx *.h HEADERS "${SRCS}")
 
 set(LINKDEF RpcLinkDef.h)
 set(LIBRARY_NAME R3BRpc)
+
 set(DEPENDENCIES
     R3Bbase R3BData)
 
 GENERATE_LIBRARY()
-

--- a/rpc/R3BRpc.cxx
+++ b/rpc/R3BRpc.cxx
@@ -1,0 +1,207 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "FairLogger.h"
+#include "FairRootManager.h"
+#include "FairVolume.h"
+
+#include "R3BMCStack.h"
+#include "R3BRpc.h"
+#include "R3BRpcPoint.h"
+
+#include "TClonesArray.h"
+#include "TGeoManager.h"
+#include "TGeoNode.h"
+#include "TParticle.h"
+#include "TVirtualMC.h"
+
+#include <iostream>
+#include <stdlib.h>
+
+R3BRpc::R3BRpc()
+    : R3BRpc("")
+{
+}
+
+R3BRpc::R3BRpc(const TString& geoFile, const TGeoTranslation& trans, const TGeoRotation& rot)
+    : R3BRpc(geoFile, { trans, rot })
+{
+}
+
+R3BRpc::R3BRpc(const TString& geoFile, const TGeoCombiTrans& combi)
+    : R3BDetector("R3BRpc", kRPC, geoFile, combi)
+{
+    ResetParameters();
+    fRpcCollection = new TClonesArray("R3BRpcPoint");
+    flGeoPar = new TList();
+    flGeoPar->SetName(GetName());
+}
+
+R3BRpc::~R3BRpc()
+{
+    if (flGeoPar)
+    {
+        delete flGeoPar;
+    }
+    if (fRpcCollection)
+    {
+        fRpcCollection->Delete();
+        delete fRpcCollection;
+    }
+}
+
+void R3BRpc::Initialize()
+{
+    FairDetector::Initialize();
+
+    LOG(INFO) << "R3BRpc::Initialize()";
+    LOG(DEBUG) << "R3BRpc: Vol (McId) def";
+
+    TGeoVolume* vol = gGeoManager->GetVolume("RpcWorld");
+    vol->SetVisibility(kFALSE);
+}
+
+Bool_t R3BRpc::ProcessHits(FairVolume* vol)
+{
+    // HERE YOU GET the CHANNEL FROM THE VOLUME PATH (BY NAME)
+    // Int_t channelId = AFUNCTION OF gMC->CurrentVolPath();
+    // OR ALTERNATIVELY FROM THE POSITION OF THE GEANT4 HIT
+    Int_t channelID = 0;
+
+    if (gMC->IsTrackEntering())
+    {
+        fELoss = 0.;
+        fNSteps = 0; // FIXME
+        fTime = gMC->TrackTime() * 1.0e09;
+        fLength = gMC->TrackLength();
+        gMC->TrackPosition(fPosIn);
+        gMC->TrackMomentum(fMomIn);
+        fEinc = gMC->Etot() - gMC->TrackMass(); // be aware!! Relativistic mass!
+    }
+
+    // Sum energy loss for all steps in the active volume
+    Double_t dE = gMC->Edep() * 1000.;                          // in MeV
+    Double_t post_E = (gMC->Etot() - gMC->TrackMass()) * 1000.; // in MeV
+    TString ptype = gMC->GetStack()->GetCurrentTrack()->GetName();
+
+    fNSteps++;
+
+    // Set additional parameters at exit of active volume. Create R3BRpcPoint.
+    if (gMC->IsTrackExiting() || gMC->IsTrackStop() || gMC->IsTrackDisappeared())
+    {
+        fTrackID = gMC->GetStack()->GetCurrentTrackNumber();
+        fParentTrackID = gMC->GetStack()->GetCurrentParentTrackNumber();
+        fVolumeID = vol->getMCid();
+        fTrackPID = gMC->TrackPid();
+        fUniqueID = gMC->GetStack()->GetCurrentTrack()->GetUniqueID();
+        // updating the value of the track length when exiting or stopping
+        fLength = gMC->TrackLength();
+
+        if (fELoss == 0.)
+            return kFALSE;
+
+        AddPoint(fTrackID,
+                 fVolumeID,
+                 channelID,
+                 TVector3(fPosIn.X(), fPosIn.Y(), fPosIn.Z()),
+                 TVector3(fMomIn.Px(), fMomIn.Py(), fMomIn.Pz()),
+                 fTime,
+                 fLength,
+                 fELoss,
+                 gMC->CurrentEvent());
+
+        // Increment number of RpcPoints for this track
+        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        stack->AddPoint(kRPC);
+        ResetParameters();
+    }
+    return kTRUE;
+}
+
+void R3BRpc::EndOfEvent()
+{
+    // if (fVerboseLevel > 1)
+    Print();
+    fRpcCollection->Clear();
+    ResetParameters();
+}
+
+void R3BRpc::Register() { FairRootManager::Instance()->Register("RPCPoint", GetName(), fRpcCollection, kTRUE); }
+
+TClonesArray* R3BRpc::GetCollection(Int_t iColl) const
+{
+    if (iColl == 0)
+    {
+        return fRpcCollection;
+    }
+    else
+        return NULL;
+}
+
+void R3BRpc::Print(Option_t* option) const
+{
+    Int_t nPoints = fRpcCollection->GetEntriesFast();
+    LOG(INFO) << "R3BRpc: " << nPoints << " points registered in this event";
+}
+
+void R3BRpc::Reset()
+{
+    fRpcCollection->Clear();
+    ResetParameters();
+}
+
+void R3BRpc::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
+{
+    Int_t nEntries = cl1->GetEntriesFast();
+    LOG(INFO) << "R3BRpc: " << nEntries << " entries to add";
+    TClonesArray& clref = *cl2;
+    R3BRpcPoint* oldpoint = NULL;
+    for (Int_t i = 0; i < nEntries; i++)
+    {
+        oldpoint = (R3BRpcPoint*)cl1->At(i);
+        Int_t index = oldpoint->GetTrackID() + offset;
+        oldpoint->SetTrackID(index);
+        new (clref[fPosIndex]) R3BRpcPoint(*oldpoint);
+        fPosIndex++;
+    }
+    LOG(INFO) << "R3BRpc: " << cl2->GetEntriesFast() << " merged entries";
+}
+
+R3BRpcPoint* R3BRpc::AddPoint(Int_t trackID,
+                              Int_t detID,
+                              Int_t ident,
+                              TVector3 posIn,
+                              TVector3 momIn,
+                              Double_t time,
+                              Double_t length,
+                              Double_t eLoss,
+                              UInt_t EventId)
+{
+    TClonesArray& clref = *fRpcCollection;
+    Int_t size = clref.GetEntriesFast();
+    if (fVerboseLevel > 1)
+        LOG(INFO) << "R3BRpc: Adding Point at (" << posIn.X() << ", " << posIn.Y() << ", " << posIn.Z()
+                  << ") cm,  detector " << detID << ", track " << trackID << ", energy loss " << eLoss * 1e06 << " keV";
+    return new (clref[size]) R3BRpcPoint(trackID, detID, ident, posIn, momIn, time, length, eLoss, EventId);
+}
+
+Bool_t R3BRpc::CheckIfSensitive(std::string name)
+{
+    if (TString(name).Contains("RPC_"))
+    {
+        return kTRUE;
+    }
+    return kFALSE;
+}
+
+ClassImp(R3BRpc);

--- a/rpc/R3BRpc.h
+++ b/rpc/R3BRpc.h
@@ -1,0 +1,153 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BRPC_H
+#define R3BRPC_H
+
+#include "R3BDetector.h"
+#include "Rtypes.h"
+#include "TLorentzVector.h"
+#include <map>
+
+class TClonesArray;
+class R3BRpcPoint;
+class FairVolume;
+class TGeoRotation;
+
+class R3BRpc : public R3BDetector
+{
+  public:
+    /** Default constructor */
+    R3BRpc();
+
+    /** Standard constructor.
+     *@param geoFile name of the ROOT geometry file
+     *@param trans   position
+     *@param rot     rotation
+     */
+    R3BRpc(const TString& geoFile, const TGeoTranslation& trans, const TGeoRotation& rot = TGeoRotation());
+
+    /** Standard constructor.
+     *@param geoFile name of the ROOT geometry file
+     *@param combi   position + rotation
+     */
+    R3BRpc(const TString& geoFile, const TGeoCombiTrans& combi = TGeoCombiTrans());
+
+    /** Destructor **/
+    virtual ~R3BRpc();
+
+    /** Virtual method ProcessHits
+     **
+     ** Defines the action to be taken when a step is inside the active
+     ** volume. Creates a R3BRpcPoint and adds it to the collection.
+     *@param vol  Pointer to the active volume
+     **/
+    virtual Bool_t ProcessHits(FairVolume* vol = 0);
+
+    /** Virtual method EndOfEvent
+     **
+     ** If verbosity level is set, print hit collection at the
+     ** end of the event and resets it afterwards.
+     **/
+    virtual void EndOfEvent();
+
+    /** Virtual method Register
+     **
+     ** Registers the hit collection in the ROOT manager.
+     **/
+    virtual void Register();
+
+    /** Accessor to the hit collection **/
+    virtual TClonesArray* GetCollection(Int_t iColl) const;
+
+    /** Virtual method Print
+     **
+     ** Screen output of hit collection.
+     **/
+    virtual void Print(Option_t* option = "") const;
+
+    /** Virtual method Reset
+     **
+     ** Clears the hit collection
+     **/
+    virtual void Reset();
+
+    /** Virtual method CopyClones
+     **
+     ** Copies the hit collection with a given track index offset
+     *@param cl1     Origin
+     *@param cl2     Target
+     *@param offset  Index offset
+     **/
+    virtual void CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset);
+
+    virtual Bool_t CheckIfSensitive(std::string name);
+
+    virtual void Initialize();
+    virtual void SetSpecialPhysicsCuts() {}
+
+  private:
+    /** Track information to be stored until the track leaves the
+    active volume. **/
+    Int_t fTrackID;        //!  track index
+    Int_t fTrackPID;       //!  particle identification
+    Int_t fVolumeID;       //!  volume id
+    Int_t fParentTrackID;  //!  parent track index
+    Int_t fUniqueID;       //!  particle unique id (e.g. if Delta electron, fUniqueID=9)
+    TLorentzVector fPosIn; //!  position
+    TLorentzVector fMomIn; //!  momentum
+    Double32_t fTime;      //!  time
+    Double32_t fLength;    //!  length
+    Double32_t fELoss;     //!  energy loss
+    Int_t fPosIndex;       //!
+    Int_t fNSteps;         //!  Number of steps in the active volume
+    Double32_t fEinc;      //!  Total incident energy
+    TList* flGeoPar;       //!
+
+    TClonesArray* fRpcCollection; //!  The point collection
+
+    /** Private method AddPoint
+     **
+     ** Adds a RpcPoint to the HitCollection
+     **/
+    R3BRpcPoint* AddPoint(Int_t trackID,
+                          Int_t detID,
+                          Int_t ident,
+                          TVector3 posIn,
+                          TVector3 momIn,
+                          Double_t time,
+                          Double_t length,
+                          Double_t eLoss,
+                          UInt_t EventId);
+
+    /** Private method ResetParameters
+     **
+     ** Resets the private members for the track parameters
+     **/
+    void ResetParameters();
+
+  public:
+    ClassDef(R3BRpc, 1);
+};
+
+inline void R3BRpc::ResetParameters()
+{
+    fTrackID = fVolumeID = fParentTrackID = fTrackPID = fUniqueID = 0;
+    fPosIn.SetXYZM(0.0, 0.0, 0.0, 0.0);
+    fMomIn.SetXYZM(0.0, 0.0, 0.0, 0.0);
+    fTime = fLength = fELoss = fEinc = 0;
+    fPosIndex = 0;
+    fNSteps = 0;
+};
+
+#endif /* R3BRPC_H */

--- a/rpc/R3BRpcCal2Hit.cxx
+++ b/rpc/R3BRpcCal2Hit.cxx
@@ -1,0 +1,138 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "R3BRpcCal2Hit.h"
+#include "TClonesArray.h"
+#include "TMath.h"
+#include "TObjArray.h"
+#include "TRandom.h"
+#include "TVector3.h"
+
+#include "FairLogger.h"
+#include "FairRootManager.h"
+#include "FairRunAna.h"
+#include "FairRuntimeDb.h"
+
+#include "TGeoManager.h"
+#include "TGeoMatrix.h"
+
+#include "R3BRpcCalData.h"
+#include <list>
+#include <vector>
+
+R3BRpcCal2Hit::R3BRpcCal2Hit()
+    : FairTask("R3B RPC Cal to Hit")
+    , fCalDataCA(NULL)
+    , fHitDataCA(NULL)
+    , fOnline(kFALSE)
+{
+}
+
+R3BRpcCal2Hit::~R3BRpcCal2Hit()
+{
+    LOG(INFO) << "R3BRpcCal2Hit: Delete instance";
+    if (fHitDataCA)
+        delete fHitDataCA;
+}
+
+void R3BRpcCal2Hit::SetParContainers()
+{
+    // Parameter Container
+    // Reading RPCHitPar from FairRuntimeDb
+    FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+    if (!rtdb)
+    {
+        LOG(ERROR) << "R3BRpcCal2Hit:: FairRuntimeDb not opened";
+    }
+
+    fHitPar = (R3BRpcHitPar*)rtdb->getContainer("RPCHitPar");
+    if (!fHitPar)
+    {
+        LOG(ERROR) << "R3BRpcCal2Hit::Init() Couldn't get handle on RPCHitPar container";
+    }
+    else
+    {
+        LOG(INFO) << "R3BRpcCal2Hit:: RPCHitPar container open";
+    }
+}
+
+InitStatus R3BRpcCal2Hit::Init()
+{
+    LOG(INFO) << "R3BRpcCal2Hit::Init()";
+    assert(!fHitDataCA); // in case someone calls Init() twice.
+    FairRootManager* ioManager = FairRootManager::Instance();
+    if (!ioManager)
+        LOG(fatal) << "R3BRpcCal2Hit::Init() FairRootManager not found";
+
+    fCalDataCA = (TClonesArray*)ioManager->GetObject("RPCCalData");
+
+    // Register output array
+    fHitDataCA = new TClonesArray("R3BRPCHitData");
+    ioManager->Register("RPCHitData", "RPC Hit", fHitDataCA, !fOnline);
+
+    return kSUCCESS;
+}
+
+InitStatus R3BRpcCal2Hit::ReInit()
+{
+    SetParContainers();
+    return kSUCCESS;
+}
+
+void R3BRpcCal2Hit::Exec(Option_t* opt)
+{
+    Reset(); // Reset entries in output arrays, local arrays
+
+    if (!fHitPar)
+    {
+        LOG(WARNING) << "R3BRpcCal2Hit::Parameter container not found";
+    }
+
+    // Reading the Input -- Cal Data --
+    Int_t nHits = fCalDataCA->GetEntries();
+    if (!nHits)
+        return;
+
+    R3BRpcCalData** calData;
+    calData = new R3BRpcCalData*[nHits];
+
+    for (Int_t i = 0; i < nHits; i++)
+    {
+        calData[i] = (R3BRpcCalData*)(fCalDataCA->At(i));
+        Int_t channelId = 0; // DUMMY FILLING---> CALL HERE YOUR CALIB
+        Double_t energy = 0;
+        uint64_t time = 0;
+        AddHit(channelId, energy, time);
+    }
+
+    if (calData)
+        delete[] calData; // FTFY
+    return;
+}
+
+void R3BRpcCal2Hit::Reset()
+{
+    // Clear the CA structure
+    LOG(DEBUG) << "Clearing RPCHitData Structure";
+    if (fHitDataCA)
+        fHitDataCA->Clear();
+}
+
+R3BRpcHitData* R3BRpcCal2Hit::AddHit(UInt_t channel, Double_t ene, ULong64_t time)
+{
+    TClonesArray& clref = *fHitDataCA;
+    Int_t size = clref.GetEntriesFast();
+    return new (clref[size]) R3BRpcHitData(channel, ene, time);
+}
+
+ClassImp(R3BRpcCal2Hit);

--- a/rpc/R3BRpcCal2Hit.h
+++ b/rpc/R3BRpcCal2Hit.h
@@ -1,0 +1,75 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BRPCCAL2HIT_H
+#define R3BRPCCAL2HIT_H
+
+#include "FairTask.h"
+#include "R3BRpcHitData.h"
+#include "R3BRpcHitPar.h"
+#include "Rtypes.h"
+
+#include <TVector3.h>
+
+class TClonesArray;
+class R3BTGeoPar;
+
+class R3BRpcCal2Hit : public FairTask
+{
+
+  public:
+    /** Default constructor
+     **/
+    R3BRpcCal2Hit();
+
+    /** Destructor **/
+    virtual ~R3BRpcCal2Hit();
+
+    /** Virtual method Exec **/
+    virtual void Exec(Option_t* opt);
+
+    /** Virtual method Reset **/
+    virtual void Reset();
+
+    /** Virtual method SetParContainers **/
+    virtual void SetParContainers();
+
+    /** Virtual method Finish **/
+    // virtual void Finish();
+
+    /** Accessor to select online mode **/
+    void SetOnline(Bool_t option) { fOnline = option; }
+
+    /** Virtual method Init **/
+    virtual InitStatus Init();
+
+    /** Virtual method ReInit **/
+    virtual InitStatus ReInit();
+
+  private:
+    TClonesArray* fCalDataCA;
+    TClonesArray* fHitDataCA;
+
+    Bool_t fOnline; // Selector for online data storage
+    // Parameter class
+    R3BRpcHitPar* fHitPar;
+
+    /** Private method AddHit
+     ** Adds a RpcHit to the HitCollection
+     **/
+    R3BRpcHitData* AddHit(UInt_t channel, Double_t ene, ULong64_t time);
+
+    ClassDef(R3BRpcCal2Hit, 1);
+};
+
+#endif /* R3BRPCCAL2HIT_H */

--- a/rpc/R3BRpcCal2HitPar.cxx
+++ b/rpc/R3BRpcCal2HitPar.cxx
@@ -1,0 +1,137 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "TClonesArray.h"
+#include "TMath.h"
+#include "TObjArray.h"
+#include "TVector3.h"
+
+#include "FairLogger.h"
+#include "FairRootManager.h"
+#include "FairRunAna.h"
+#include "FairRuntimeDb.h"
+
+#include "R3BRpcCal2HitPar.h"
+#include "R3BRpcCalData.h"
+#include "R3BRpcHitPar.h"
+
+#include <iostream>
+#include <stdlib.h>
+
+R3BRpcCal2HitPar::R3BRpcCal2HitPar()
+    : R3BRpcCal2HitPar("R3B CALIFA Tot Calibration Parameters Finder ", 1)
+{
+}
+
+R3BRpcCal2HitPar::R3BRpcCal2HitPar(const char* name, Int_t iVerbose)
+    : FairTask(name, iVerbose)
+    , fHitPar(NULL)
+    , fCalDataCA(NULL)
+    , fNumChannels(64)
+    , fDebugMode(false)
+{
+}
+
+R3BRpcCal2HitPar::~R3BRpcCal2HitPar()
+{
+    LOG(INFO) << "R3BRpcCal2HitPar: Delete instance";
+    if (fCalDataCA)
+        delete fCalDataCA;
+}
+
+void R3BRpcCal2HitPar::SetParContainers()
+{
+    // Parameter Container
+    // Reading califaMappingPar from FairRuntimeDb
+    FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+    if (!rtdb)
+    {
+        LOG(ERROR) << "FairRuntimeDb not opened!";
+    }
+}
+
+void R3BRpcCal2HitPar::SetParameter() {}
+
+InitStatus R3BRpcCal2HitPar::Init()
+{
+    LOG(INFO) << "R3BRpcCal2HitPar::Init()";
+
+    FairRootManager* rootManager = FairRootManager::Instance();
+    if (!rootManager)
+    {
+        LOG(ERROR) << "R3BRpcCal2HitPar::Init() FairRootManager not found";
+        return kFATAL;
+    }
+
+    fCalDataCA = (TClonesArray*)rootManager->GetObject("RPCCalData");
+    if (!fCalDataCA)
+    {
+        LOG(ERROR) << "R3BRpcCal2HitPar::Init() RPCCalData not found";
+        return kFATAL;
+    }
+
+    FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+    if (!rtdb)
+    {
+        LOG(ERROR) << "R3BRpcCal2HitPar::Init() FairRuntimeDb not found";
+        return kFATAL;
+    }
+
+    fHitPar = (R3BRpcHitPar*)rtdb->getContainer("RPCHitPar");
+    if (!fHitPar)
+
+    {
+        LOG(ERROR) << "R3BRpcCal2HitPar::Init() Couldn't get handle on RPCHitPar container";
+        return kFATAL;
+    }
+
+    // Set container with mapping parameters
+    SetParameter();
+
+    return kSUCCESS;
+}
+
+InitStatus R3BRpcCal2HitPar::ReInit()
+{
+    SetParContainers();
+    SetParameter();
+    return kSUCCESS;
+}
+
+void R3BRpcCal2HitPar::Reset() {}
+
+void R3BRpcCal2HitPar::FinishEvent() {}
+
+void R3BRpcCal2HitPar::FinishTask() {}
+
+void R3BRpcCal2HitPar::Exec(Option_t* opt)
+{
+    Int_t nHits = fCalDataCA->GetEntries();
+    if (!nHits)
+        return;
+
+    R3BRpcCalData** CalHit = new R3BRpcCalData*[nHits];
+    Int_t crystalId = 0;
+
+    for (Int_t i = 0; i < nHits; i++)
+    {
+        CalHit[i] = (R3BRpcCalData*)(fCalDataCA->At(i));
+        // DO THE WORK
+    }
+
+    if (CalHit)
+        delete[] CalHit;
+    return;
+}
+
+ClassImp(R3BRpcCal2HitPar)

--- a/rpc/R3BRpcCal2HitPar.h
+++ b/rpc/R3BRpcCal2HitPar.h
@@ -1,0 +1,78 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BRPCCAL2HITPAR_H
+#define R3BRPCCAL2HITPAR_H
+
+#include "FairTask.h"
+#include "R3BRpcHitPar.h"
+#include "TGraph.h"
+#include "TH1F.h"
+
+class TClonesArray;
+class R3BEventHeader;
+
+class R3BRpcCal2HitPar : public FairTask
+{
+
+  public:
+    /** Default constructor **/
+    R3BRpcCal2HitPar();
+
+    /** Standard constructor **/
+    R3BRpcCal2HitPar(const char* name, Int_t iVerbose = 1);
+
+    /** Destructor **/
+    virtual ~R3BRpcCal2HitPar();
+
+    /** Virtual method Init **/
+    virtual InitStatus Init();
+
+    /** Virtual method Exec **/
+    virtual void Exec(Option_t* opt);
+
+    /** Virtual method FinishEvent **/
+    virtual void FinishEvent();
+
+    /** Virtual method FinishTask **/
+    virtual void FinishTask();
+
+    /** Virtual method Reset **/
+    virtual void Reset();
+
+    /** Virtual method ReInit **/
+    virtual InitStatus ReInit();
+
+    /** Virtual method SetParContainers **/
+    virtual void SetParContainers();
+
+    /** Accessor functions **/
+    const Int_t GetNumChannels() { return fNumChannels; }
+
+    void SetNumChannels(Int_t numberCha) { fNumChannels = numberCha; }
+
+    void SetDebugMode(Bool_t debug) { fDebugMode = debug; }
+
+  private:
+    void SetParameter();
+    Bool_t fDebugMode;
+    Int_t fNumChannels;
+
+    R3BRpcHitPar* fHitPar;    /**< Container for Hit parameters. >*/
+    TClonesArray* fCalDataCA; /**< Array with Cal RPC - input data. >*/
+
+  public:
+    ClassDef(R3BRpcCal2HitPar, 1);
+};
+
+#endif

--- a/rpc/R3BRpcCalPar.cxx
+++ b/rpc/R3BRpcCalPar.cxx
@@ -1,0 +1,107 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "R3BRpcCalPar.h"
+
+#include "FairLogger.h"
+#include "FairParamList.h"
+
+#include "TMath.h"
+#include "TString.h"
+
+#include <iostream>
+
+// ---- Standard Constructor ---------------------------------------------------
+R3BRpcCalPar::R3BRpcCalPar(const char* name, const char* title, const char* context)
+    : FairParGenericSet(name, title, context)
+    , fNumChannels(64)
+{
+}
+
+// ----  Destructor ------------------------------------------------------------
+R3BRpcCalPar::~R3BRpcCalPar()
+{
+    clear();
+    if (fCalParams)
+        delete fCalParams;
+}
+
+// ----  Method clear ----------------------------------------------------------
+void R3BRpcCalPar::clear()
+{
+    status = kFALSE;
+    resetInputVersions();
+}
+
+// ----  Method putParams ------------------------------------------------------
+void R3BRpcCalPar::putParams(FairParamList* list)
+{
+    LOG(INFO) << "R3BRpcCalPar::putParams() called";
+    if (!list)
+    {
+        return;
+    }
+
+    Int_t array_size = fNumChannels;
+    LOG(INFO) << "Array Size: " << array_size;
+
+    fCalParams->Set(array_size);
+
+    list->add("RPCCalPar", *fCalParams);
+    list->add("RPCChannelsNumberPar", fNumChannels);
+}
+
+// ----  Method getParams ------------------------------------------------------
+Bool_t R3BRpcCalPar::getParams(FairParamList* list)
+{
+    LOG(INFO) << "R3BRpcCalPar::getParams() called";
+    if (!list)
+    {
+        return kFALSE;
+    }
+
+    if (!list->fill("RPCChannelsNumberPar", &fNumChannels))
+    {
+        return kFALSE;
+    }
+
+    Int_t array_size = fNumChannels;
+    LOG(INFO) << "Nb_channels: " << array_size;
+    fCalParams->Set(array_size);
+
+    if (!(list->fill("RPCCalPar", fCalParams)))
+    {
+        LOG(INFO) << "---Could not initialize RPCCalPar";
+        return kFALSE;
+    }
+
+    return kTRUE;
+}
+
+// ----  Method print ----------------------------------------------------------
+void R3BRpcCalPar::print() { printParams(); }
+
+// ----  Method printParams ----------------------------------------------------
+void R3BRpcCalPar::printParams()
+{
+    LOG(INFO) << "R3BRpcCalPar::RPC Calibration Parameters: ";
+    Int_t array_size = fNumChannels;
+
+    for (Int_t i = 0; i < fNumChannels; i++)
+    {
+        LOG(INFO) << "Channel number: " << i + 1;
+        LOG(INFO) << "Param= " << fCalParams->GetAt(i);
+    }
+}
+
+ClassImp(R3BRpcCalPar)

--- a/rpc/R3BRpcCalPar.h
+++ b/rpc/R3BRpcCalPar.h
@@ -1,0 +1,70 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BRPCCALPAR_H
+#define R3BRPCCALPAR_H
+
+#include "FairParGenericSet.h"
+#include "TObject.h"
+
+#include "TArrayF.h"
+#include "TObjArray.h"
+#include <TObjString.h>
+
+class FairParamList;
+
+class R3BRpcCalPar : public FairParGenericSet
+{
+
+  public:
+    /** Standard constructor **/
+    R3BRpcCalPar(const char* name = "RPCCalPar",
+                 const char* title = "RPC Cal Parameters",
+                 const char* context = "RPCCalParContext");
+
+    /** Destructor **/
+    virtual ~R3BRpcCalPar();
+
+    /** Method to reset all parameters **/
+    virtual void clear();
+
+    /** Method to store all parameters using FairRuntimeDB **/
+    virtual void putParams(FairParamList* list);
+
+    /** Method to retrieve all parameters using FairRuntimeDB**/
+    Bool_t getParams(FairParamList* list);
+
+    /** Method to print values of parameters to the standard output **/
+    virtual void print();
+    void printParams();
+
+    /** Accessor functions **/
+    const Double_t GetNumChannels() { return fNumChannels; }
+    TArrayF* GetCalParams() { return fCalParams; }
+
+    void SetNumChannels(Int_t numberCha) { fNumChannels = numberCha; }
+    void SetCalParams(Float_t cc, Int_t ii) { fCalParams->AddAt(cc, ii); }
+
+    /** Create more Methods if you need them! **/
+
+  private:
+    TArrayF* fCalParams; /*< Calibration Parameters of Channels>*/
+    Int_t fNumChannels;  /*< number of channels>*/
+
+    const R3BRpcCalPar& operator=(const R3BRpcCalPar&);
+    R3BRpcCalPar(const R3BRpcCalPar&);
+
+    ClassDef(R3BRpcCalPar, 1);
+};
+
+#endif /* R3BRPCCALPAR_H */

--- a/rpc/R3BRpcContFact.cxx
+++ b/rpc/R3BRpcContFact.cxx
@@ -1,0 +1,80 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "R3BRpcContFact.h"
+
+#include "FairLogger.h"
+#include "FairParAsciiFileIo.h"
+#include "FairParRootFileIo.h"
+#include "FairRuntimeDb.h"
+
+#include "R3BRpcCalPar.h"
+#include "R3BRpcHitPar.h"
+#include "R3BRpcPars4Sim.h"
+#include "TClass.h"
+
+static R3BRpcContFact gR3BRpcContFact;
+
+R3BRpcContFact::R3BRpcContFact()
+{
+    // Constructor (called when the library is loaded)
+    fName = "R3BRpcContFact";
+    fTitle = "Factory for parameter containers in libR3BRpc";
+    setAllContainers();
+    FairRuntimeDb::instance()->addContFactory(this);
+}
+
+void R3BRpcContFact::setAllContainers()
+{
+    // Creates the Container objects with all accepted contexts and adds them
+    // to the list of containers for the RPC library.
+
+    FairContainer* p1 = new FairContainer("RPCCalPar", "RPC Calibration Parameters", "RPCCalParContext");
+    p1->addContext("RPCCalParContext");
+    containers->Add(p1);
+
+    FairContainer* p2 = new FairContainer("RPCHitPar", "RPC Hit Parameters", "RPCHitParContext");
+    p2->addContext("RPCHitParContext");
+    containers->Add(p2);
+
+    FairContainer* p3 = new FairContainer("RPCPars4Sim", "RPC Parameters for Sim", "RPCSimParContext");
+    p3->addContext("RPCSimParContext");
+    containers->Add(p3);
+}
+
+FairParSet* R3BRpcContFact::createContainer(FairContainer* c)
+{
+    /** Calls the constructor of the corresponding parameter container.
+     * For an actual context, which is not an empty string and not the default context
+     * of this container, the name is concatinated with the context.
+     */
+
+    const char* name = c->GetName();
+    LOG(INFO) << "R3BRpcContFact: Create container name: " << name;
+    FairParSet* p = 0;
+    if (strcmp(name, "RPCCalPar") == 0)
+    {
+        p = new R3BRpcCalPar(c->getConcatName().Data(), c->GetTitle(), c->getContext());
+    }
+    else if (strcmp(name, "RPCHitPar") == 0)
+    {
+        p = new R3BRpcHitPar(c->getConcatName().Data(), c->GetTitle(), c->getContext());
+    }
+    else if (strcmp(name, "RPCPars4Sim") == 0)
+    {
+        p = new R3BRpcPars4Sim(c->getConcatName().Data(), c->GetTitle(), c->getContext());
+    }
+    return p;
+}
+
+ClassImp(R3BRpcContFact);

--- a/rpc/R3BRpcContFact.h
+++ b/rpc/R3BRpcContFact.h
@@ -1,5 +1,3 @@
-// clang-format off
-
 /******************************************************************************
  *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
  *   Copyright (C) 2019 Members of R3B Collaboration                          *
@@ -13,27 +11,23 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 
-#ifdef __CINT__
+#ifndef R3BRPCCONTFACT_H
+#define R3BRPCCONTFACT_H
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+#include "FairContFact.h"
 
-#pragma link C++ class R3BRpc+;
-#pragma link C++ class R3BRpcContFact;
-#pragma link C++ class R3BRpcDigitizer+;
+class FairContainer;
 
-#pragma link C++ class R3BRpcMapped2Cal+;
-#pragma link C++ class R3BRpcMapped2CalPar+;
-#pragma link C++ class R3BRpcCalPar+;
+class R3BRpcContFact : public FairContFact
+{
+  private:
+    void setAllContainers();
 
-#pragma link C++ class R3BRpcCal2Hit+;
-#pragma link C++ class R3BRpcCal2HitPar+;
-#pragma link C++ class R3BRpcHitPar+;
+  public:
+    R3BRpcContFact();
+    ~R3BRpcContFact() {}
+    FairParSet* createContainer(FairContainer*);
+    ClassDef(R3BRpcContFact, 0) // Factory for all RPC parameter containers
+};
 
-#pragma link C++ class R3BRpcPars4Sim+;
-
-//#pragma link C++ class R3BRpcOnlineSpectra+;
-
-
-#endif
+#endif /* !R3BRPCCONTFACT_H */

--- a/rpc/R3BRpcDigitizer.cxx
+++ b/rpc/R3BRpcDigitizer.cxx
@@ -1,0 +1,179 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "R3BRpcDigitizer.h"
+#include "FairRootManager.h"
+#include "R3BRpc.h"
+#include "R3BRpcCalData.h"
+#include "R3BRpcPoint.h"
+#include "TArrayD.h"
+#include "TClonesArray.h"
+#include "TMath.h"
+#include "TRandom.h"
+#include "TVector3.h"
+#include <iostream>
+#include <stdlib.h>
+
+R3BRpcDigitizer::R3BRpcDigitizer()
+    : FairTask("R3B RPC Digitizer")
+    , fRpcPointDataCA(NULL)
+    , fRpcCalDataCA(NULL)
+{
+}
+
+R3BRpcDigitizer::~R3BRpcDigitizer()
+{
+    LOG(INFO) << "R3BRpcDigitizer: Delete instance";
+
+    if (fRpcPointDataCA)
+    {
+        fRpcPointDataCA->Delete();
+        delete fRpcPointDataCA;
+    }
+    if (fRpcCalDataCA)
+    {
+        fRpcCalDataCA->Delete();
+        delete fRpcCalDataCA;
+    }
+}
+
+void R3BRpcDigitizer::SetParContainers()
+{
+    FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+    LOG_IF(ERROR, !rtdb) << "R3BRpcDigitizer::FairRuntimeDb not opened!";
+
+    fSim_Par = (R3BRpcPars4Sim*)rtdb->getContainer("rpcPars4Sim");
+    if (!fSim_Par)
+    {
+        LOG(ERROR) << "R3BRpcDigitizer::Init() Couldn't get handle on "
+                      "rpcPars4Sim container";
+    }
+    else
+    {
+        LOG(INFO) << "R3BRpcDigitizer:: rpcPars4Sim container opened";
+    }
+}
+
+void R3BRpcDigitizer::SetParameter()
+{
+    //--- Parameter Container ---
+    fNumberOfChannels = fSim_Par->GetNumChannels(); // Number of Channels (example!)
+
+    fSim_Par->printParams();
+
+    LOG(INFO) << "R3BRpcDigitizer:: max channel ID " << fNumberOfChannels;
+}
+
+InitStatus R3BRpcDigitizer::Init()
+{
+    LOG(INFO) << "R3BRpcDigitizer::Init ";
+
+    FairRootManager* rootManager = FairRootManager::Instance();
+    if (!rootManager)
+        LOG(fatal) << "Init: No FairRootManager";
+
+    fRpcPointDataCA = (TClonesArray*)rootManager->GetObject("RPCPoint");
+    if (!fRpcPointDataCA)
+    {
+        LOG(fatal) << "Init: No RpcPoint CA";
+        return kFATAL;
+    }
+
+    fRpcCalDataCA = new TClonesArray("R3BRpcCalData", 10);
+    rootManager->Register("RpcCalData", "RPC Cal", fRpcCalDataCA, kTRUE);
+
+    SetParameter();
+    return kSUCCESS;
+}
+
+void R3BRpcDigitizer::Exec(Option_t* option)
+{
+    // Reset entries in output arrays, local arrays
+    Reset();
+
+    // Reading the Input -- Point data --
+    Int_t nHits = fRpcPointDataCA->GetEntries();
+    if (!nHits)
+        return;
+
+    R3BRpcPoint** pointData = NULL;
+    pointData = new R3BRpcPoint*[nHits];
+    for (Int_t i = 0; i < nHits; i++)
+        pointData[i] = (R3BRpcPoint*)(fRpcPointDataCA->At(i));
+
+    Int_t channelId;
+    Double_t time;
+    Double_t energy;
+
+    for (Int_t i = 0; i < nHits; i++)
+    {
+        channelId = pointData[i]->GetChannelId();
+        time = pointData[i]->GetTime();
+        energy = pointData[i]->GetEnergyLoss();
+
+        Int_t nCals = fRpcCalDataCA->GetEntriesFast();
+        Bool_t existHit = 0;
+        if (nCals == 0)
+            AddCal(channelId, energy, time, 0);
+        else
+        {
+            for (Int_t j = 0; j < nCals; j++)
+            {
+                if (((R3BRpcCalData*)(fRpcCalDataCA->At(j)))->GetChannelId() == channelId)
+                {
+                    ((R3BRpcCalData*)(fRpcCalDataCA->At(j)))->AddMoreEnergy(energy);
+                    if (((R3BRpcCalData*)(fRpcCalDataCA->At(j)))->GetTime() > time)
+                    {
+                        ((R3BRpcCalData*)(fRpcCalDataCA->At(j)))->SetTime(time);
+                    }
+                    existHit = 1; // to avoid the creation of a new Hit
+                    break;
+                }
+            }
+            if (!existHit)
+                AddCal(channelId, energy, time, 0);
+        }
+        existHit = 0;
+    }
+
+    if (pointData)
+        delete[] pointData;
+
+    Int_t nCals = fRpcCalDataCA->GetEntriesFast();
+    if (nCals == 0)
+        return;
+}
+
+void R3BRpcDigitizer::Reset()
+{
+    // Clear the CA structure
+    LOG(DEBUG) << "Clearing RpcCalData Structure";
+    if (fRpcCalDataCA)
+        fRpcCalDataCA->Clear();
+
+    ResetParameters();
+}
+
+R3BRpcCalData* R3BRpcDigitizer::AddCal(Int_t ident, Double_t energy, ULong64_t time, Double_t tot_energy)
+{
+    TClonesArray& clref = *fRpcCalDataCA;
+    Int_t size = clref.GetEntriesFast();
+    if (fVerbose > 1)
+        LOG(INFO) << "-I- R3BRpcDigitizer: Adding RpcCalData "
+                  << " with unique identifier " << ident << " entering with " << energy * 1e06 << " keV  Time=" << time
+                  << " tot_energy=" << tot_energy;
+
+    return new (clref[size]) R3BRpcCalData(ident, energy, time, tot_energy);
+}
+
+ClassImp(R3BRpcDigitizer);

--- a/rpc/R3BRpcDigitizer.h
+++ b/rpc/R3BRpcDigitizer.h
@@ -1,0 +1,68 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BRPCDIGITIZER_H
+#define R3BRPCDIGITIZER_H
+
+#include "FairTask.h"
+#include "R3BRpc.h"
+#include "R3BRpcCalData.h"
+#include "R3BRpcPars4Sim.h"
+#include "R3BRpcPoint.h"
+#include "Rtypes.h"
+
+class TClonesArray;
+
+class R3BRpcDigitizer : public FairTask
+{
+  public:
+    /** Standard contructor **/
+    R3BRpcDigitizer();
+
+    /** Destructor **/
+    virtual ~R3BRpcDigitizer();
+
+    /** Virtual method Init **/
+    virtual InitStatus Init();
+
+    /** Virtual method Exec **/
+    virtual void Exec(Option_t* opt);
+
+    /** Virtual method Reset **/
+    virtual void Reset();
+
+    virtual void SetParContainers();
+
+  private:
+    void SetParameter();
+
+    TClonesArray* fRpcPointDataCA; //!  The RPC hit collection
+    TClonesArray* fRpcCalDataCA;   /**< Array with RPC Cal- output data. >*/
+
+    R3BRpcPars4Sim* fSim_Par; // Parameter Container for a Realistic Simulation
+
+    UInt_t fNumberOfChannels;
+
+    /** Private method AddCal
+     **
+     ** Adds a RpcCal data
+     **/
+    R3BRpcCalData* AddCal(Int_t ident, Double_t energy, ULong64_t time, Double_t tot_energy = 0.);
+
+    inline void ResetParameters(){};
+
+  public:
+    ClassDef(R3BRpcDigitizer, 1);
+};
+
+#endif /* R3BRPCDIGITIZER_H */

--- a/rpc/R3BRpcHitPar.cxx
+++ b/rpc/R3BRpcHitPar.cxx
@@ -1,5 +1,3 @@
-// clang-format off
-
 /******************************************************************************
  *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
  *   Copyright (C) 2019 Members of R3B Collaboration                          *
@@ -13,27 +11,42 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 
-#ifdef __CINT__
+#include "R3BRpcHitPar.h"
+#include "TMath.h"
+#include <iostream>
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+R3BRpcHitPar::R3BRpcHitPar(const char* name, const char* title, const char* context)
+    : FairParGenericSet(name, title, context)
+{
+    clear();
+}
 
-#pragma link C++ class R3BRpc+;
-#pragma link C++ class R3BRpcContFact;
-#pragma link C++ class R3BRpcDigitizer+;
+void R3BRpcHitPar::putParams(FairParamList* list)
+{
+    std::cout << "-I- R3BRpcHitPar::putParams() called" << std::endl;
 
-#pragma link C++ class R3BRpcMapped2Cal+;
-#pragma link C++ class R3BRpcMapped2CalPar+;
-#pragma link C++ class R3BRpcCalPar+;
+    if (!list)
+        return;
+    list->add("fExample", (Double_t)fExample);
+}
 
-#pragma link C++ class R3BRpcCal2Hit+;
-#pragma link C++ class R3BRpcCal2HitPar+;
-#pragma link C++ class R3BRpcHitPar+;
+Bool_t R3BRpcHitPar::getParams(FairParamList* list)
+{
+    std::cout << "-I- R3BRpcHitPar::getParams() called" << std::endl;
+    if (!list)
+        return kFALSE;
+    std::cout << "-I- R3BRpcHitPar::getParams() 1 ";
 
-#pragma link C++ class R3BRpcPars4Sim+;
+    if (!list->fill("fExample", &fExample, 1))
+        return kFALSE;
 
-//#pragma link C++ class R3BRpcOnlineSpectra+;
+    return kTRUE;
+}
 
+void R3BRpcHitPar::Print(Option_t* option) const
+{
+    std::cout << "-I- CALIFA HitFinder Parameters:" << std::endl;
+    std::cout << "fExample " << fExample << std::endl;
+}
 
-#endif
+ClassImp(R3BRpcHitPar);

--- a/rpc/R3BRpcHitPar.h
+++ b/rpc/R3BRpcHitPar.h
@@ -1,5 +1,3 @@
-// clang-format off
-
 /******************************************************************************
  *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
  *   Copyright (C) 2019 Members of R3B Collaboration                          *
@@ -13,27 +11,37 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 
-#ifdef __CINT__
+#ifndef R3BRPCHITPAR_H
+#define R3BRPCHITPAR_H
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+#include <TObjString.h>
+#include <TVector3.h>
 
-#pragma link C++ class R3BRpc+;
-#pragma link C++ class R3BRpcContFact;
-#pragma link C++ class R3BRpcDigitizer+;
+#include "FairParGenericSet.h"
+#include "FairParamList.h"
 
-#pragma link C++ class R3BRpcMapped2Cal+;
-#pragma link C++ class R3BRpcMapped2CalPar+;
-#pragma link C++ class R3BRpcCalPar+;
+class R3BRpcHitPar : public FairParGenericSet
+{
+  public:
+    R3BRpcHitPar(const char* name = "R3BRpcHitPar",
+                 const char* title = "RPC Hit Finder Parameters",
+                 const char* context = "TestDefaultContext");
+    ~R3BRpcHitPar(void){};
+    void clear(void){};
+    void putParams(FairParamList* list);
+    Bool_t getParams(FairParamList* list);
 
-#pragma link C++ class R3BRpcCal2Hit+;
-#pragma link C++ class R3BRpcCal2HitPar+;
-#pragma link C++ class R3BRpcHitPar+;
+    void Print(Option_t* option = "") const;
+    /** Accessor functions **/
+    const Double_t GetExample() { return fExample; }
 
-#pragma link C++ class R3BRpcPars4Sim+;
+    void SetExample(Double_t value) { fExample = value; }
 
-//#pragma link C++ class R3BRpcOnlineSpectra+;
+  private:
+    // Whatever
+    Double_t fExample;
 
+    ClassDef(R3BRpcHitPar, 1); //
+};
 
-#endif
+#endif /* !R3BRPCHITPAR_H*/

--- a/rpc/R3BRpcMapped2Cal.cxx
+++ b/rpc/R3BRpcMapped2Cal.cxx
@@ -1,0 +1,195 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "TClonesArray.h"
+#include "TMath.h"
+#include "TRandom.h"
+
+#include "FairLogger.h"
+#include "FairRootManager.h"
+#include "FairRunAna.h"
+#include "FairRuntimeDb.h"
+
+#include <iomanip>
+
+#include "R3BRpc.h"
+#include "R3BRpcCalData.h"
+#include "R3BRpcCalPar.h"
+#include "R3BRpcMapped2Cal.h"
+#include "R3BRpcMappedData.h"
+
+// R3BRpcMapped2Cal: Constructor
+R3BRpcMapped2Cal::R3BRpcMapped2Cal()
+    : FairTask("R3B RPC Calibrator")
+    , fNumChannels(0)
+    , fCalParams(NULL)
+    , fCal_Par(NULL)
+    , fOnline(kFALSE)
+    , fRpcMappedDataCA(NULL)
+    , fRpcCalDataCA(NULL)
+{
+}
+
+R3BRpcMapped2Cal::~R3BRpcMapped2Cal()
+{
+    LOG(INFO) << "R3BRpcMapped2Cal: Delete instance";
+
+    /*
+     * Note to whomever felt in neccessary to add: "delete fRpcMappedDataCA;"
+     * This will cause a double free because  R3BRpcFebexReader (reasonably)
+     * considers itself the owner of that object.
+     * Short version: if your class did not allocate the object with new,
+     * it also (typically) may not delete it. -- pklenze
+     */
+    if (fRpcCalDataCA)
+        delete fRpcCalDataCA;
+}
+
+void R3BRpcMapped2Cal::SetParContainers()
+{
+    // Parameter Container
+    // Reading RPCCalPar from FairRuntimeDb
+    FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+    if (!rtdb)
+    {
+        LOG(ERROR) << "R3BRpcMapped2Cal:: FairRuntimeDb not opened";
+    }
+
+    fCal_Par = (R3BRpcCalPar*)rtdb->getContainer("RPCCalPar");
+    if (!fCal_Par)
+    {
+        LOG(ERROR) << "R3BRpcMapped2Cal::Init() Couldn't get handle on RPCCalPar container";
+    }
+    else
+    {
+        LOG(INFO) << "R3BRpcMapped2Cal:: RPCCalPar container open";
+    }
+}
+
+void R3BRpcMapped2Cal::SetParameter()
+{
+    // NB: the handling of calibration parameters should be redone from the scratch.
+    // The par-file format  is not really human-readable (the root file even is worse).
+    // Luckily, this does not matter because the choice to store the values in the
+    // class using two one-dimensional array precludes any possibility of humans groking
+    // it.
+    // A sensible reimplementation might store the calibration in csv lines (with the crID
+    // coming first) or go down the json rabbit hole.
+    // For using the calibration here,  an std::vector of some struct {m, c, totAmp, totTime}
+    // would be convenient. Nobody wants higher order polynomials for calibration.
+    // Also, if you insist on crIDs starting from one (that ship has long sailed), then
+    // please just leave the first array entry undefined and use params(id) == a[id], instead
+    // of bothering with params(id)==a[id-1].
+    // See also: https://github.com/R3BRootGroup/R3BRoot/issues/473
+    // Just my 2 cents. -- pklenze
+
+    //--- Parameter Container ---
+    fNumChannels = fCal_Par->GetNumChannels(); // Number of Channels
+
+    fCalParams = fCal_Par->GetCalParams(); // Array with the Cal parameters
+
+    LOG(INFO) << "R3BRpcMapped2Cal:: Max Channel ID " << fNumChannels;
+}
+
+InitStatus R3BRpcMapped2Cal::Init()
+{
+    LOG(INFO) << "R3BRpcMapped2Cal::Init()";
+
+    // INPUT DATA
+    FairRootManager* rootManager = FairRootManager::Instance();
+    if (!rootManager)
+    {
+        LOG(FATAL) << "R3BRpcMapped2Cal::FairRootManager not found";
+        return kFATAL;
+    }
+
+    fRpcMappedDataCA = (TClonesArray*)rootManager->GetObject("RPCMappedData");
+    if (!fRpcMappedDataCA)
+    {
+        LOG(FATAL) << "R3BRpcMapped2Cal::RpcMappedData not found";
+        return kFATAL;
+    }
+
+    // OUTPUT DATA
+    // Calibrated data
+    fRpcCalDataCA = new TClonesArray("R3BRpcCalData", 50);
+
+    rootManager->Register("RPCCalData", "RPC Cal", fRpcCalDataCA, !fOnline);
+
+    SetParameter();
+    return kSUCCESS;
+}
+
+InitStatus R3BRpcMapped2Cal::ReInit()
+{
+    SetParContainers();
+    SetParameter();
+    return kSUCCESS;
+}
+
+void R3BRpcMapped2Cal::Exec(Option_t* option)
+{
+    // Reset entries in output arrays, local arrays
+    Reset();
+
+    if (!fCal_Par)
+    {
+        LOG(WARNING) << "R3BRpcMapped2Cal::Parameter container not found";
+    }
+
+    // Reading the Input -- Mapped Data --
+    Int_t nHits = fRpcMappedDataCA->GetEntries();
+    if (!nHits)
+        return;
+
+    R3BRpcMappedData** mappedData;
+    mappedData = new R3BRpcMappedData*[nHits];
+
+    for (Int_t i = 0; i < nHits; i++)
+    {
+        mappedData[i] = (R3BRpcMappedData*)(fRpcMappedDataCA->At(i));
+        Int_t channelId = mappedData[i]->GetChannelId();
+        uint64_t time = mappedData[i]->GetTime();
+        uint64_t wrts = mappedData[i]->GetWrts();
+        Int_t side = mappedData[i]->GetSide();
+
+        // DUMMY FILLING---> CALL HERE YOUR CALIB
+        Double32_t energy = 0.;
+        Double32_t TotCal = 0.;
+
+        AddCalData(channelId, energy, wrts, TotCal);
+    }
+
+    if (mappedData)
+        delete[] mappedData; // FTFY
+    return;
+}
+
+void R3BRpcMapped2Cal::Finish() {}
+
+void R3BRpcMapped2Cal::Reset()
+{
+    LOG(DEBUG) << "Clearing RPCCalData Structure";
+    if (fRpcCalDataCA)
+        fRpcCalDataCA->Clear();
+}
+
+R3BRpcCalData* R3BRpcMapped2Cal::AddCalData(Int_t id, Double_t energy, uint64_t wrts, Double_t tot_energy = 0)
+{
+    // It fills the R3BRpcCalData
+    TClonesArray& clref = *fRpcCalDataCA;
+    Int_t size = clref.GetEntriesFast();
+    return new (clref[size]) R3BRpcCalData(id, energy, wrts, tot_energy);
+}
+
+ClassImp(R3BRpcMapped2Cal)

--- a/rpc/R3BRpcMapped2Cal.h
+++ b/rpc/R3BRpcMapped2Cal.h
@@ -1,0 +1,85 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+// -----------------------------------------------------------------------------
+// -----                                                                   -----
+// -----                     R3BRpcMapped2Cal                              -----
+// -----                Created 17/01/2021 by H. Alvarez-Pol               -----
+// -----------------------------------------------------------------------------
+
+#ifndef R3BRPCMAPPED2CAL_H
+#define R3BRPCMAPPED2CAL_H
+
+#include "FairTask.h"
+#include "R3BRpc.h"
+#include "R3BRpcCalData.h"
+#include "R3BRpcMapped2CalPar.h"
+#include "R3BRpcMappedData.h"
+#include <TRandom.h>
+
+class TClonesArray;
+class R3BRpcCalPar;
+
+class R3BRpcMapped2Cal : public FairTask
+{
+
+  public:
+    /** Default constructor **/
+    R3BRpcMapped2Cal();
+
+    /** Destructor **/
+    virtual ~R3BRpcMapped2Cal();
+
+    /** Virtual method Exec **/
+    virtual void Exec(Option_t* option);
+
+    /** Virtual method Reset **/
+    virtual void Reset();
+
+    virtual void SetParContainers();
+
+    // Fair specific
+    /** Virtual method Init **/
+    virtual InitStatus Init();
+
+    /** Virtual method ReInit **/
+    virtual InitStatus ReInit();
+
+    /** Virtual method Finish **/
+    virtual void Finish();
+
+    /** Accessor to select online mode **/
+    void SetOnline(Bool_t option) { fOnline = option; }
+
+  private:
+    void SetParameter();
+
+    Int_t fNumChannels;
+    TArrayF* fCalParams;
+    // Don't store data for online
+    Bool_t fOnline;
+
+    R3BRpcCalPar* fCal_Par;         /**< Parameter container. >*/
+    TClonesArray* fRpcMappedDataCA; /**< Array with RPC Mapped- input data. >*/
+    TClonesArray* fRpcCalDataCA;    /**< Array with RPC Cal- output data. >*/
+
+    /** Private method AddCalData **/
+    //** Adds a RpcCalData to the RpcCalCollection
+    R3BRpcCalData* AddCalData(Int_t id, Double_t energy, uint64_t wrts, Double_t tot_energy);
+
+  public:
+    // Class definition
+    ClassDef(R3BRpcMapped2Cal, 1)
+};
+
+#endif

--- a/rpc/R3BRpcMapped2CalPar.cxx
+++ b/rpc/R3BRpcMapped2CalPar.cxx
@@ -1,0 +1,133 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "TClonesArray.h"
+#include "TObjArray.h"
+#include "TVector3.h"
+
+#include "FairLogger.h"
+#include "FairRootManager.h"
+#include "FairRunAna.h"
+#include "FairRuntimeDb.h"
+
+#include "R3BRpcCalPar.h"
+#include "R3BRpcMapped2CalPar.h"
+#include "R3BRpcMappedData.h"
+
+#include <iostream>
+#include <stdlib.h>
+
+R3BRpcMapped2CalPar::R3BRpcMapped2CalPar()
+    : R3BRpcMapped2CalPar("R3B RPC Calibration Parameters Finder ", 1)
+{
+}
+
+R3BRpcMapped2CalPar::R3BRpcMapped2CalPar(const char* name, Int_t iVerbose)
+    : FairTask(name, iVerbose)
+    , fCalPar(NULL)
+    , fMappedDataCA(NULL)
+    , fNumChannels(64)
+    , fDebugMode(0)
+{
+}
+
+R3BRpcMapped2CalPar::~R3BRpcMapped2CalPar()
+{
+    LOG(INFO) << "R3BRpcMapped2CalPar: Delete instance";
+    if (fMappedDataCA)
+        delete fMappedDataCA;
+}
+
+void R3BRpcMapped2CalPar::SetParContainers()
+{
+    // Parameter Container
+    FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+    if (!rtdb)
+    {
+        LOG(ERROR) << "FairRuntimeDb not opened!";
+    }
+}
+
+void R3BRpcMapped2CalPar::SetParameter() {}
+
+InitStatus R3BRpcMapped2CalPar::Init()
+{
+    LOG(INFO) << "R3BRpcMapped2CalPar::Init()";
+
+    FairRootManager* rootManager = FairRootManager::Instance();
+    if (!rootManager)
+    {
+        LOG(ERROR) << "R3BRpcMapped2CalPar::Init() FairRootManager not found";
+        return kFATAL;
+    }
+
+    fMappedDataCA = (TClonesArray*)rootManager->GetObject("RPCMappedData");
+    if (!fMappedDataCA)
+    {
+        LOG(ERROR) << "R3BRpcMapped2CalPar::Init() RpcMappedDataCA not found";
+        return kFATAL;
+    }
+
+    FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+    if (!rtdb)
+    {
+        LOG(ERROR) << "R3BRpcMapped2CalPar::Init() FairRuntimeDb not found";
+        return kFATAL;
+    }
+
+    fCalPar = (R3BRpcCalPar*)rtdb->getContainer("RPCCalPar");
+    if (!fCalPar)
+    {
+        LOG(ERROR) << "R3BRpcMapped2CalPar::Init() Couldn't get handle on RPCCalPar container";
+        return kFATAL;
+    }
+
+    // Set container with mapping parameters
+    SetParameter();
+
+    return kSUCCESS;
+}
+
+InitStatus R3BRpcMapped2CalPar::ReInit()
+{
+    SetParContainers();
+    SetParameter();
+    return kSUCCESS;
+}
+
+void R3BRpcMapped2CalPar::Exec(Option_t* opt)
+{
+    Int_t nHits = fMappedDataCA->GetEntries();
+    if (!nHits)
+        return;
+
+    R3BRpcMappedData** map = new R3BRpcMappedData*[nHits];
+    Int_t channelId = 0;
+
+    for (Int_t i = 0; i < nHits; i++)
+    {
+        map[i] = (R3BRpcMappedData*)(fMappedDataCA->At(i));
+        // DO THE WORK HERE!!!
+    }
+    if (map)
+        delete[] map;
+    return;
+}
+
+void R3BRpcMapped2CalPar::Reset() {}
+
+void R3BRpcMapped2CalPar::FinishEvent() {}
+
+void R3BRpcMapped2CalPar::FinishTask() {}
+
+ClassImp(R3BRpcMapped2CalPar)

--- a/rpc/R3BRpcMapped2CalPar.h
+++ b/rpc/R3BRpcMapped2CalPar.h
@@ -1,0 +1,77 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BRPCMAPPED2CALPAR_H
+#define R3BRPCMAPPED2CALPAR_H
+
+#include "FairTask.h"
+#include "TH1F.h"
+
+class TClonesArray;
+class R3BRpcCalPar;
+class R3BEventHeader;
+
+class R3BRpcMapped2CalPar : public FairTask
+{
+
+  public:
+    /** Default constructor **/
+    R3BRpcMapped2CalPar();
+
+    /** Standard constructor **/
+    R3BRpcMapped2CalPar(const char* name, Int_t iVerbose = 1);
+
+    /** Destructor **/
+    virtual ~R3BRpcMapped2CalPar();
+
+    /** Virtual method Init **/
+    virtual InitStatus Init();
+
+    /** Virtual method Exec **/
+    virtual void Exec(Option_t* opt);
+
+    /** Virtual method FinishEvent **/
+    virtual void FinishEvent();
+
+    /** Virtual method FinishTask **/
+    virtual void FinishTask();
+
+    /** Virtual method Reset **/
+    virtual void Reset();
+
+    /** Virtual method ReInit **/
+    virtual InitStatus ReInit();
+
+    /** Virtual method SetParContainers **/
+    virtual void SetParContainers();
+
+    /** Accessor functions **/
+    const Int_t GetNumChannels() { return fNumChannels; }
+
+    void SetNumChannels(Int_t numberCha) { fNumChannels = numberCha; }
+
+    void SetDebugMode(Bool_t debug) { fDebugMode = debug; }
+
+  private:
+    void SetParameter();
+    Bool_t fDebugMode;
+    Int_t fNumChannels;
+
+    R3BRpcCalPar* fCalPar;       /**< Container for Cal parameters. >*/
+    TClonesArray* fMappedDataCA; /**< Array with RPC Mapped-input data. >*/
+
+  public:
+    ClassDef(R3BRpcMapped2CalPar, 1);
+};
+
+#endif

--- a/rpc/R3BRpcOnlineSpectra.cxx
+++ b/rpc/R3BRpcOnlineSpectra.cxx
@@ -1,0 +1,1441 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "R3BRpcMappedData.h"
+#include "R3BRpcCalData.h"
+#include "R3BRpcHitData.h"
+#include "R3BRpcOnlineSpectra.h"
+#include "R3BEventHeader.h"
+#include "R3BWRData.h"
+#include "THttpServer.h"
+
+#include "FairLogger.h"
+#include "FairRootManager.h"
+#include "FairRunAna.h"
+#include "FairRunOnline.h"
+#include "FairRuntimeDb.h"
+#include "TCanvas.h"
+#include "TFolder.h"
+#include "TH1F.h"
+#include "TH1I.h"
+#include "TH2F.h"
+#include "TVector3.h"
+
+#include "TClonesArray.h"
+#include "TMath.h"
+#include "TRandom.h"
+#include <array>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+using namespace std;
+
+R3BRpcOnlineSpectra::R3BRpcOnlineSpectra()
+    : FairTask("RPCOnlineSpectra", 1)
+    , fMappedItems(NULL)
+    , fCalItems(NULL)
+    , fHitItems(NULL)
+    , fNEvents(0)
+    , fNumSides(Nb_Sides)
+    , fNumChannels(Nb_Channels)
+    , fMapHistos_bins(500)
+    , fMapHistos_max(4000)
+    , fLogScale(kTRUE)
+    , fTotHist(kFALSE)
+{
+}
+
+R3BRpcOnlineSpectra::R3BRpcOnlineSpectra(const TString& name, Int_t iVerbose)
+    : FairTask(name, iVerbose)
+    , fMappedItems(NULL)
+    , fCalItems(NULL)
+    , fHitItems(NULL)
+    , fNEvents(0)
+    , fNumSides(Nb_Sides)
+    , fNumChannels(Nb_Channels)
+    , fMapHistos_bins(500)
+    , fMapHistos_max(4000)
+    , fLogScale(kTRUE)
+    , fTotHist(kFALSE)
+{
+}
+
+R3BRpcOnlineSpectra::~R3BRpcOnlineSpectra()
+{
+    LOG(INFO) << "R3BRpcOnlineSpectra: Delete instance";
+    if (fMappedItems)
+        delete fMappedItems;
+    if (fCalItems)
+        delete fCalItems;
+    if (fHitItems)
+        delete fHitItems;
+}
+
+void R3BRpcOnlineSpectra::SetParContainers()
+{
+    // Parameter Container
+    // Reading from FairRuntimeDb
+    FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+    if (!rtdb)
+    {
+        LOG(ERROR) << "FairRuntimeDb not opened!";
+    }
+}
+
+void R3BRpcOnlineSpectra::SetParameter() {}
+
+InitStatus R3BRpcOnlineSpectra::Init()
+{
+    LOG(INFO) << "R3BRpcOnlineSpectra::Init()";
+
+    // try to get a handle on the EventHeader. EventHeader may not be
+    // present though and hence may be null. Take care when using.
+
+    FairRootManager* mgr = FairRootManager::Instance();
+    if (NULL == mgr)
+        LOG(FATAL) << "R3BRpcOnlineSpectra::Init FairRootManager not found";
+
+    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    FairRunOnline* run = FairRunOnline::Instance();
+    run->GetHttpServer()->Register("", this);
+
+    // get access to Mapped data
+    fMappedItems = (TClonesArray*)mgr->GetObject("RPCMappedData");
+    if (!fMappedItems)
+    {
+        LOG(ERROR) << "R3BRpcOnlineSpectra::RPCMappedData not found";
+        return kFATAL;
+    }
+
+    // get access to Cal data
+    fCalItems = (TClonesArray*)mgr->GetObject("RPCCalData");
+    if (!fCalItems)
+    {
+        LOG(WARNING) << "R3BRpcOnlineSpectra::RPCCalData not found";
+    }
+
+    // get access to Hit data
+    fHitItems = (TClonesArray*)mgr->GetObject("RPCHitData");
+    if (!fHitItems)
+    {
+        LOG(WARNING) << "R3BRpcOnlineSpectra::RPCHitData not found";
+    }
+
+    SetParameter();
+
+    // Create histograms for detectors
+    char Name1[255];
+    char Name2[255];
+    char Name3[255];
+    TString Xaxis;
+    Double_t bins = fMapHistos_bins;
+    Double_t maxE = fMapHistos_max;
+    Double_t minE = 0.;
+
+    // CANVAS Crystal_ID vs energy
+    cRpc_cry_energy = new TCanvas("Rpc_Map_cryID_energy", "Rpc_Map energy vs cryID", 10, 10, 500, 500);
+    fh2_Rpc_cryId_energy = new TH2F("fh2_Rpc_Map_cryID_energy",
+                                       "Rpc: CryID vs energy",
+                                       fMap_Par->GetNumCrystals(),
+                                       0.5,
+                                       fMap_Par->GetNumCrystals() + 0.5,
+                                       fBinsChannelFebex,
+                                       0.0,
+                                       fMaxBinChannelFebex);
+    fh2_Rpc_cryId_energy->GetXaxis()->SetTitle("Crystal ID");
+    fh2_Rpc_cryId_energy->GetYaxis()->SetTitle("Energy [Channels]");
+    fh2_Rpc_cryId_energy->GetYaxis()->SetTitleOffset(1.4);
+    fh2_Rpc_cryId_energy->GetXaxis()->CenterTitle(true);
+    fh2_Rpc_cryId_energy->GetYaxis()->CenterTitle(true);
+    gPad->SetLogz();
+    fh2_Rpc_cryId_energy->Draw("COLZ");
+
+    // CANVAS Crystal_ID vs energy
+    cRpc_cry_energy_cal = new TCanvas("Rpc_Cal_cryID_energy", "Rpc_Cal energy vs cryID", 10, 10, 500, 500);
+    fh2_Rpc_cryId_energy_cal = new TH2F("fh2_Rpc_Cal_cryID_energy",
+                                           "Rpc: CryID vs calibrated energy",
+                                           fMap_Par->GetNumCrystals(),
+                                           0.5,
+                                           fMap_Par->GetNumCrystals() + 0.5,
+                                           bins,
+                                           minE,
+                                           maxE);
+    fh2_Rpc_cryId_energy_cal->GetXaxis()->SetTitle("Crystal ID");
+    fh2_Rpc_cryId_energy_cal->GetYaxis()->SetTitle("Energy [keV]");
+    fh2_Rpc_cryId_energy_cal->GetYaxis()->SetTitleOffset(1.4);
+    fh2_Rpc_cryId_energy_cal->GetXaxis()->CenterTitle(true);
+    fh2_Rpc_cryId_energy_cal->GetYaxis()->CenterTitle(true);
+    gPad->SetLogz();
+    fh2_Rpc_cryId_energy_cal->Draw("COLZ");
+
+    cRpc_NsNf = new TCanvas("Rpc_Cal_NsNf", "Rpc_Cal Ns vs Nf", 10, 10, 500, 500);
+    fh2_Rpc_NsNf =
+        new TH2F("fh2_Rpc_Cal_NsNf", "Rpc PID: Ns vs Nf energies", bins, minE, maxE, bins, minE, maxE);
+    fh2_Rpc_NsNf->GetXaxis()->SetTitle("Nf Energy [keV]");
+    fh2_Rpc_NsNf->GetYaxis()->SetTitle("Ns Energy [keV]");
+    fh2_Rpc_NsNf->GetYaxis()->SetTitleOffset(1.4);
+    fh2_Rpc_NsNf->GetXaxis()->CenterTitle(true);
+    fh2_Rpc_NsNf->GetYaxis()->CenterTitle(true);
+    gPad->SetLogz();
+    fh2_Rpc_NsNf->Draw("COLZ");
+
+    // Map data
+    for (Int_t i = 0; i < fNumRings; i++)
+    {
+        // Left side
+        sprintf(Name1, "Ring_%d_Left", i + 1);
+        cMap_RingL[i] = new TCanvas(Name1, Name1, 10, 10, 800, 700);
+
+        sprintf(Name1, "fh2_Ring_%d_Left", i + 1);
+        sprintf(Name2, "Ring %d left: Preamp number vs channel number", i + 1);
+        fh2_Preamp_vs_ch_L[i] = new TH2F(
+            Name1, Name2, fNumPreamps, 0.5, fNumPreamps + 0.5, fNumCrystalPreamp, 0.5, fNumCrystalPreamp + 0.5);
+        sprintf(Name3, "Channel number [1-%d]", fNumCrystalPreamp);
+        fh2_Preamp_vs_ch_L[i]->GetXaxis()->SetTitle("Preamp number [1-16]");
+        fh2_Preamp_vs_ch_L[i]->GetYaxis()->SetTitle(Name3);
+        fh2_Preamp_vs_ch_L[i]->GetYaxis()->SetTitleOffset(1.2);
+        fh2_Preamp_vs_ch_L[i]->GetXaxis()->CenterTitle(true);
+        fh2_Preamp_vs_ch_L[i]->GetYaxis()->CenterTitle(true);
+        fh2_Preamp_vs_ch_L[i]->Draw("colz");
+
+        // Right side
+        sprintf(Name1, "Ring_%d_Right", i + 1);
+        cMap_RingR[i] = new TCanvas(Name1, Name1, 10, 10, 800, 700);
+
+        sprintf(Name1, "fh2_Ring_%d_Right", i + 1);
+        sprintf(Name2, "Ring %d right: Preamp number vs channel number", i + 1);
+        fh2_Preamp_vs_ch_R[i] = new TH2F(
+            Name1, Name2, fNumPreamps, 0.5, fNumPreamps + 0.5, fNumCrystalPreamp, 0.5, fNumCrystalPreamp + 0.5);
+        fh2_Preamp_vs_ch_R[i]->GetXaxis()->SetTitle("Preamp number [1-16]");
+        fh2_Preamp_vs_ch_R[i]->GetYaxis()->SetTitle(Name3);
+        fh2_Preamp_vs_ch_R[i]->GetYaxis()->SetTitleOffset(1.2);
+        fh2_Preamp_vs_ch_R[i]->GetXaxis()->CenterTitle(true);
+        fh2_Preamp_vs_ch_R[i]->GetYaxis()->CenterTitle(true);
+        fh2_Preamp_vs_ch_R[i]->Draw("colz");
+    }
+
+    char Side[50];
+    for (Int_t s = 0; s < fNumSides; s++) // Side
+    {
+        if (s == 1)
+            sprintf(Side, "Left");
+        else
+            sprintf(Side, "Right");
+        for (Int_t r = 0; r < fNumRings; r++)       // Ring
+            for (Int_t p = 0; p < fNumPreamps; p++) // Preamp
+            {
+                if (fFebexInfo[s][r][p][0] != -1)
+                {
+                    sprintf(Name1, "Ring_%d_%s_Preamp_%d", r + 1, Side, p + 1);
+                    sprintf(Name2, "Ring %d, %s side, Preamp %d", r + 1, Side, p + 1);
+                    cMapCry[s][r][p] = new TCanvas(Name1, Name2, 10, 10, 500, 500);
+                    cMapCry[s][r][p]->Divide(4, 4);
+                    // for TOT correlations
+                    sprintf(Name1, "Ring_%d_%s_Preamp_%d_tot", r + 1, Side, p + 1);
+                    sprintf(Name2, "Ring %d, %s side, Preamp %d", r + 1, Side, p + 1);
+                    cMapCryTot[s][r][p] = new TCanvas(Name1, Name2, 10, 10, 500, 500);
+                    cMapCryTot[s][r][p]->Divide(4, 4);
+                }
+                if (fFebexInfo[s][r][p][2] != -1)
+                {
+                    sprintf(Name1, "Ring_%d_%s_Preamp_%d_pr", r + 1, Side, p + 1);
+                    sprintf(Name2, "Ring %d, %s side, Preamp %d for PR", r + 1, Side, p + 1);
+                    cMapCryP[s][r][p] = new TCanvas(Name1, Name2, 10, 10, 500, 500);
+                    cMapCryP[s][r][p]->Divide(4, 4);
+                    // for TOT correlations
+                    sprintf(Name1, "Ring_%d_%s_Preamp_%d_tot_pr", r + 1, Side, p + 1);
+                    sprintf(Name2, "Ring %d, %s side, Preamp %d for PR", r + 1, Side, p + 1);
+                    cMapCryPTot[s][r][p] = new TCanvas(Name1, Name2, 10, 10, 500, 500);
+                    cMapCryPTot[s][r][p]->Divide(4, 4);
+                }
+                for (Int_t j = 0; j < fNumCrystalPreamp; j++)
+                { // Channel
+                    Xaxis = "Energy [channels]";
+
+                    if (fFebexInfo[s][r][p][0] != -1)
+                    {
+                        sprintf(Name1, "fh1_Map_Side_%s_Ring_%d_Preamp_%d_Ch_%d_energy", Side, r + 1, p + 1, j + 1);
+                        sprintf(Name2, "Map level, Side %s, Ring %d, Preamp %d, ch. %d", Side, r + 1, p + 1, j + 1);
+
+                        fh1_crystals[s][r][p][j] = new TH1F(Name1, Name2, fBinsChannelFebex, 0, fMaxBinChannelFebex);
+                        fh1_crystals[s][r][p][j]->SetTitleSize(1.6, "t");
+                        fh1_crystals[s][r][p][j]->GetXaxis()->SetTitle(Xaxis);
+                        fh1_crystals[s][r][p][j]->GetXaxis()->SetLabelSize(0.06);
+                        fh1_crystals[s][r][p][j]->GetYaxis()->SetLabelSize(0.07);
+                        fh1_crystals[s][r][p][j]->GetXaxis()->SetTitleSize(0.05);
+                        fh1_crystals[s][r][p][j]->GetXaxis()->CenterTitle(true);
+                        fh1_crystals[s][r][p][j]->GetYaxis()->CenterTitle(true);
+                        fh1_crystals[s][r][p][j]->GetXaxis()->SetTitleOffset(1.);
+                        fh1_crystals[s][r][p][j]->SetFillColor(45);
+                        cMapCry[s][r][p]->cd(j + 1);
+                        gPad->SetLogy();
+                        fh1_crystals[s][r][p][j]->Draw();
+
+                        // for TOT correlations
+                        sprintf(Name1, "fh2_Map_Side_%s_Ring_%d_Preamp_%d_Ch_%d_evstot", Side, r + 1, p + 1, j + 1);
+                        sprintf(Name2, "Map level, Side %s, Ring %d, Preamp %d, ch. %d", Side, r + 1, p + 1, j + 1);
+
+                        fh2_crystalsETot[s][r][p][j] = new TH2F(Name1,
+                                                                Name2,
+                                                                fBinsChannelFebex,
+                                                                0,
+                                                                fMaxBinChannelFebex,
+                                                                fBinsChannelFebex,
+                                                                0,
+                                                                fMaxBinChannelFebex);
+                        fh2_crystalsETot[s][r][p][j]->SetTitleSize(1.6, "t");
+                        fh2_crystalsETot[s][r][p][j]->GetXaxis()->SetTitle(Xaxis);
+                        fh2_crystalsETot[s][r][p][j]->GetYaxis()->SetTitle("Tot");
+                        fh2_crystalsETot[s][r][p][j]->GetXaxis()->SetLabelSize(0.06);
+                        fh2_crystalsETot[s][r][p][j]->GetYaxis()->SetLabelSize(0.06);
+                        fh2_crystalsETot[s][r][p][j]->GetXaxis()->SetTitleSize(0.05);
+                        fh2_crystalsETot[s][r][p][j]->GetXaxis()->CenterTitle(true);
+                        fh2_crystalsETot[s][r][p][j]->GetYaxis()->CenterTitle(true);
+                        fh2_crystalsETot[s][r][p][j]->GetXaxis()->SetTitleOffset(1.);
+                        cMapCryTot[s][r][p]->cd(j + 1);
+                        fh2_crystalsETot[s][r][p][j]->Draw();
+                    }
+                    if (fFebexInfo[s][r][p][2] != -1)
+                    {
+                        // histograms for proton range
+                        sprintf(Name1, "fh1_Map_Side_%s_Ring_%d_Preamp_%d_Ch_%d_energy_pr", Side, r + 1, p + 1, j + 1);
+                        sprintf(
+                            Name2, "Map level (PR), Side %s, Ring %d, Preamp %d, ch. %d", Side, r + 1, p + 1, j + 1);
+                        fh1_crystals_p[s][r][p][j] = new TH1F(Name1, Name2, fBinsChannelFebex, 0, fMaxBinChannelFebex);
+                        fh1_crystals_p[s][r][p][j]->SetTitleSize(1.6, "t");
+                        fh1_crystals_p[s][r][p][j]->GetXaxis()->SetTitle(Xaxis);
+                        fh1_crystals_p[s][r][p][j]->GetXaxis()->SetLabelSize(0.06);
+                        fh1_crystals_p[s][r][p][j]->GetYaxis()->SetLabelSize(0.07);
+                        fh1_crystals_p[s][r][p][j]->GetXaxis()->SetTitleSize(0.05);
+                        fh1_crystals_p[s][r][p][j]->GetXaxis()->CenterTitle(true);
+                        fh1_crystals_p[s][r][p][j]->GetYaxis()->CenterTitle(true);
+                        fh1_crystals_p[s][r][p][j]->GetXaxis()->SetTitleOffset(1.);
+                        fh1_crystals_p[s][r][p][j]->SetFillColor(45);
+                        cMapCryP[s][r][p]->cd(j + 1);
+                        gPad->SetLogy();
+                        fh1_crystals_p[s][r][p][j]->Draw();
+
+                        // for TOT correlations
+                        sprintf(Name1, "fh2_Map_Side_%s_Ring_%d_Preamp_%d_Ch_%d_pr_evstot", Side, r + 1, p + 1, j + 1);
+                        sprintf(
+                            Name2, "Map level (PR), Side %s, Ring %d, Preamp %d, ch. %d", Side, r + 1, p + 1, j + 1);
+                        fh2_crystalsETot_p[s][r][p][j] = new TH2F(Name1,
+                                                                  Name2,
+                                                                  fBinsChannelFebex,
+                                                                  0,
+                                                                  fMaxBinChannelFebex,
+                                                                  fBinsChannelFebex,
+                                                                  0,
+                                                                  fMaxBinChannelFebex);
+                        fh2_crystalsETot_p[s][r][p][j]->SetTitleSize(1.6, "t");
+                        fh2_crystalsETot_p[s][r][p][j]->GetXaxis()->SetTitle(Xaxis);
+                        fh2_crystalsETot_p[s][r][p][j]->GetYaxis()->SetTitle("Tot");
+                        fh2_crystalsETot_p[s][r][p][j]->GetXaxis()->SetLabelSize(0.06);
+                        fh2_crystalsETot_p[s][r][p][j]->GetYaxis()->SetLabelSize(0.06);
+                        fh2_crystalsETot_p[s][r][p][j]->GetXaxis()->SetTitleSize(0.05);
+                        fh2_crystalsETot_p[s][r][p][j]->GetXaxis()->CenterTitle(true);
+                        fh2_crystalsETot_p[s][r][p][j]->GetYaxis()->CenterTitle(true);
+                        fh2_crystalsETot_p[s][r][p][j]->GetXaxis()->SetTitleOffset(1.);
+                        cMapCryPTot[s][r][p]->cd(j + 1);
+                        fh2_crystalsETot_p[s][r][p][j]->Draw();
+                    }
+                }
+            }
+    }
+
+    // Cal data
+    for (Int_t s = 0; s < fNumSides; s++) // Side
+    {
+        if (s == 1)
+            sprintf(Side, "Left");
+        else
+            sprintf(Side, "Right");
+        for (Int_t r = 0; r < fNumRings; r++) // Ring
+
+            for (Int_t p = 0; p < fNumPreamps; p++) // Preamp
+            {
+                if (fFebexInfo[s][r][p][0] != -1)
+                {
+                    sprintf(Name1, "Ring_%d_%s_Preamp_%d_cal", r + 1, Side, p + 1);
+                    sprintf(Name2, "Ring %d, %s side, Preamp %d Cal", r + 1, Side, p + 1);
+                    cMapCryCal[s][r][p] = new TCanvas(Name1, Name2, 10, 10, 500, 500);
+                    cMapCryCal[s][r][p]->Divide(4, 4);
+                }
+                if (fFebexInfo[s][r][p][2] != -1)
+                {
+                    sprintf(Name1, "Ring_%d_%s_Preamp_%d_calpr", r + 1, Side, p + 1);
+                    sprintf(Name2, "Ring %d, %s side, Preamp %d for PR Cal", r + 1, Side, p + 1);
+                    cMapCryPCal[s][r][p] = new TCanvas(Name1, Name2, 10, 10, 500, 500);
+                    cMapCryPCal[s][r][p]->Divide(4, 4);
+                }
+                for (Int_t j = 0; j < fNumCrystalPreamp; j++)
+                { // Channel
+                    Xaxis = "Energy [keV]";
+
+                    if (fFebexInfo[s][r][p][0] != -1)
+                    {
+                        sprintf(Name1, "fh1_Cal_Side_%s_Ring_%d_Preamp_%d_Ch_%d_energy", Side, r + 1, p + 1, j + 1);
+                        sprintf(Name2, "Cal level, Side %s, Ring %d, Preamp %d, ch. %d", Side, r + 1, p + 1, j + 1);
+
+                        fh1_crystals_cal[s][r][p][j] =
+                            new TH1F(Name1, Name2, arry_bins[s][r][p][j], arry_minE[s][r][p][j], arry_maxE[s][r][p][j]);
+                        fh1_crystals_cal[s][r][p][j]->SetTitleSize(1.6, "t");
+                        fh1_crystals_cal[s][r][p][j]->GetXaxis()->SetTitle(Xaxis);
+                        fh1_crystals_cal[s][r][p][j]->GetXaxis()->SetLabelSize(0.06);
+                        fh1_crystals_cal[s][r][p][j]->GetYaxis()->SetLabelSize(0.07);
+                        fh1_crystals_cal[s][r][p][j]->GetXaxis()->SetTitleSize(0.05);
+                        fh1_crystals_cal[s][r][p][j]->GetXaxis()->CenterTitle(true);
+                        fh1_crystals_cal[s][r][p][j]->GetYaxis()->CenterTitle(true);
+                        fh1_crystals_cal[s][r][p][j]->GetXaxis()->SetTitleOffset(1.);
+                        fh1_crystals_cal[s][r][p][j]->SetFillColor(45);
+                        cMapCryCal[s][r][p]->cd(j + 1);
+                        gPad->SetLogy();
+                        fh1_crystals_cal[s][r][p][j]->Draw();
+                    }
+                    if (fFebexInfo[s][r][p][2] != -1)
+                    { // histograms for proton range
+                        sprintf(Name1, "fh1_Cal_Side_%s_Ring_%d_Preamp_%d_Ch_%d_energy_pr", Side, r + 1, p + 1, j + 1);
+                        sprintf(
+                            Name2, "Cal level (PR), Side %s, Ring %d, Preamp %d, ch. %d", Side, r + 1, p + 1, j + 1);
+                        fh1_crystals_p_cal[s][r][p][j] =
+                            new TH1F(Name1, Name2, arry_bins[s][r][p][j], arry_minE[s][r][p][j], arry_maxE[s][r][p][j]);
+                        fh1_crystals_p_cal[s][r][p][j]->SetTitleSize(1.6, "t");
+                        fh1_crystals_p_cal[s][r][p][j]->GetXaxis()->SetTitle(Xaxis);
+                        fh1_crystals_p_cal[s][r][p][j]->GetXaxis()->SetLabelSize(0.06);
+                        fh1_crystals_p_cal[s][r][p][j]->GetYaxis()->SetLabelSize(0.07);
+                        fh1_crystals_p_cal[s][r][p][j]->GetXaxis()->SetTitleSize(0.05);
+                        fh1_crystals_p_cal[s][r][p][j]->GetXaxis()->CenterTitle(true);
+                        fh1_crystals_p_cal[s][r][p][j]->GetYaxis()->CenterTitle(true);
+                        fh1_crystals_p_cal[s][r][p][j]->GetXaxis()->SetTitleOffset(1.);
+                        fh1_crystals_p_cal[s][r][p][j]->SetFillColor(45);
+                        cMapCryPCal[s][r][p]->cd(j + 1);
+                        gPad->SetLogy();
+                        fh1_crystals_p_cal[s][r][p][j]->Draw();
+                    }
+                }
+            }
+    }
+
+    // CANVAS Multiplicity
+    cPRCMult = new TCanvas("RPC_Multiplicity", "RPC_Multiplicity", 10, 10, 500, 500);
+    fh1_Rpc_Mult = new TH1F("fh1_Rpc_Mult", "RPC multiplicity", 141, -0.5, 140.5);
+    fh1_Rpc_MultHit = new TH1F("fh1_Rpc_MultHit", "Rpc multiplicity", 141, -0.5, 140.5);
+    fh1_Rpc_Mult->GetXaxis()->SetTitle("Multiplicity");
+    fh1_Rpc_Mult->GetXaxis()->CenterTitle(true);
+    fh1_Rpc_Mult->GetYaxis()->CenterTitle(true);
+    fh1_Rpc_Mult->GetYaxis()->SetTitleOffset(1.2);
+    fh1_Rpc_Mult->GetXaxis()->SetTitleOffset(1.1);
+    gPad->SetLogy();
+    fh1_Rpc_Mult->Draw();
+    fh1_Rpc_MultHit->SetLineColor(kRed);
+    fh1_Rpc_MultHit->Draw("SAME");
+
+    // CANVAS Energy correlations between hits
+    cRpcCoinE = new TCanvas("Rpc_energy_correlation_hits", "Energy correlations, hit level", 10, 10, 500, 500);
+
+    fh2_Rpc_coinE =
+        new TH2F("fh2_Rpc_energy_correlations", "Rpc energy correlations", bins, minE, maxE, bins, minE, maxE);
+    fh2_Rpc_coinE->GetXaxis()->SetTitle("Energy (keV)");
+    fh2_Rpc_coinE->GetYaxis()->SetTitle("Energy (keV)");
+    fh2_Rpc_coinE->GetYaxis()->SetTitleOffset(1.2);
+    fh2_Rpc_coinE->GetXaxis()->CenterTitle(true);
+    fh2_Rpc_coinE->GetYaxis()->CenterTitle(true);
+    fh2_Rpc_coinE->Draw("COLZ");
+
+    // CANVAS Theta correlations between hits
+    cRpcCoinTheta = new TCanvas("Rpc_theta_correlation_hits", "Theta correlations, hit level", 10, 10, 500, 500);
+
+    fh2_Rpc_coinTheta =
+        new TH2F("fh2_Rpc_theta_correlations", "Rpc theta correlations", 50, 0, 100, 50, 0, 100);
+    fh2_Rpc_coinTheta->GetXaxis()->SetTitle("Theta [degrees]");
+    fh2_Rpc_coinTheta->GetYaxis()->SetTitle("Theta [degrees]");
+    fh2_Rpc_coinTheta->GetYaxis()->SetTitleOffset(1.2);
+    fh2_Rpc_coinTheta->GetXaxis()->CenterTitle(true);
+    fh2_Rpc_coinTheta->GetYaxis()->CenterTitle(true);
+    fh2_Rpc_coinTheta->Draw("COLZ");
+
+    // CANVAS Phi correlations between hits
+    cRpcCoinPhi = new TCanvas("Rpc_phi_correlation_hits", "Phi correlations, hit level", 10, 10, 500, 500);
+
+    fh2_Rpc_coinPhi =
+        new TH2F("fh2_Rpc_phi_correlations", "Rpc phi correlations", 90, -180, 180, 90, -180, 180);
+    fh2_Rpc_coinPhi->GetXaxis()->SetTitle("Phi [degrees]");
+    fh2_Rpc_coinPhi->GetYaxis()->SetTitle("Phi [degrees]");
+    fh2_Rpc_coinPhi->GetYaxis()->SetTitleOffset(1.2);
+    fh2_Rpc_coinPhi->GetXaxis()->CenterTitle(true);
+    fh2_Rpc_coinPhi->GetYaxis()->CenterTitle(true);
+    fh2_Rpc_coinPhi->Draw("COLZ");
+
+    // CANVAS Theta vs Phi
+    cRpc_angles = new TCanvas("Rpc_Theta_vs_Phi", "Theta vs Phi", 10, 10, 500, 500);
+    fh2_Rpc_theta_phi = new TH2F("fh2_Rpc_theta_vs_phi", "Rpc theta vs phi", 50, 0, 90, 180, -180, 180);
+    fh2_Rpc_theta_phi->GetXaxis()->SetTitle("Theta [degrees]");
+    fh2_Rpc_theta_phi->GetYaxis()->SetTitle("Phi [degrees]");
+    fh2_Rpc_theta_phi->GetYaxis()->SetTitleOffset(1.2);
+    fh2_Rpc_theta_phi->GetXaxis()->CenterTitle(true);
+    fh2_Rpc_theta_phi->GetYaxis()->CenterTitle(true);
+    fh2_Rpc_theta_phi->Draw("COLZ");
+
+    // CANVAS Theta vs energy
+    sprintf(Name1, "Rpc_calorimeter_theta_vs_energy");
+    sprintf(Name2, "fh_Rpc_theta_vs_total_energy");
+    sprintf(Name3, "Rpc theta vs energy for full calorimeter");
+    cRpc_theta_energy = new TCanvas(Name1, Name1, 10, 10, 500, 500);
+    fh2_Rpc_theta_energy = new TH2F(Name2, Name3, 360, 0, 90, bins, minE, maxE);
+    fh2_Rpc_theta_energy->GetXaxis()->SetTitle("Theta [degrees]");
+    fh2_Rpc_theta_energy->GetYaxis()->SetTitle("Energy [keV]");
+    fh2_Rpc_theta_energy->GetYaxis()->SetTitleOffset(1.4);
+    fh2_Rpc_theta_energy->GetXaxis()->CenterTitle(true);
+    fh2_Rpc_theta_energy->GetYaxis()->CenterTitle(true);
+    fh2_Rpc_theta_energy->Draw("COLZ");
+
+    // CANVAS Total energy
+    sprintf(Name1, "Rpc_calorimeter_total_energy_per_hit");
+    sprintf(Name2, "fh_Rpc_total_energy");
+    sprintf(Name3, "Rpc total energy per hit for the full calorimeter");
+    cRpc_hitenergy = new TCanvas(Name1, Name1, 10, 10, 500, 500);
+    fh1_Rpc_total_energy = new TH1F(Name2, Name3, bins, minE, maxE);
+    fh1_Rpc_total_energy->GetXaxis()->SetTitle("Energy [keV]");
+    fh1_Rpc_total_energy->GetYaxis()->SetTitle("Counts");
+    fh1_Rpc_total_energy->GetYaxis()->SetTitleOffset(1.4);
+    fh1_Rpc_total_energy->GetXaxis()->CenterTitle(true);
+    fh1_Rpc_total_energy->GetYaxis()->CenterTitle(true);
+    fh1_Rpc_total_energy->SetFillColor(29);
+    fh1_Rpc_total_energy->SetLineColor(1);
+    fh1_Rpc_total_energy->SetLineWidth(2);
+    fh1_Rpc_total_energy->Draw("");
+    gPad->SetLogy();
+
+    // CANVAS opening angle
+    sprintf(Name1, "Rpc_opening_angle_hit");
+    sprintf(Name2, "fh1_Rpc_opening");
+    sprintf(Name3, "Rpc opening angle");
+    cRpc_opening = new TCanvas(Name1, Name1, 10, 10, 500, 500);
+    fh1_openangle = new TH1F(Name2, Name3, 160, 10, 170);
+    fh1_openangle->GetXaxis()->SetTitle("Opening angle [degrees]");
+    fh1_openangle->GetYaxis()->SetTitle("Counts");
+    fh1_openangle->GetXaxis()->CenterTitle(true);
+    fh1_openangle->GetYaxis()->CenterTitle(true);
+    fh1_openangle->GetYaxis()->SetTitleOffset(1.2);
+    fh1_openangle->GetXaxis()->SetTitleOffset(1.2);
+    fh1_openangle->SetFillColor(8);
+    fh1_openangle->SetLineColor(1);
+    fh1_openangle->SetLineWidth(2);
+    fh1_openangle->Draw("");
+
+    // Difference between Rpc WRs
+    sprintf(Name1, "WR_Rpc");
+    sprintf(Name2, "fh1_WR_Rpc");
+    sprintf(Name3, "WR-Wixhausen - WR-Messel");
+    cRpc_wr = new TCanvas(Name1, Name1, 10, 10, 500, 500);
+    fh1_Rpc_wr = new TH1I(Name2, Name3, 4000, -4000, 4000);
+    fh1_Rpc_wr->GetXaxis()->SetTitle("Difference of Rpc WRs");
+    fh1_Rpc_wr->GetYaxis()->SetTitle("Counts");
+    fh1_Rpc_wr->GetYaxis()->SetTitleOffset(1.3);
+    fh1_Rpc_wr->GetXaxis()->CenterTitle(true);
+    fh1_Rpc_wr->GetYaxis()->CenterTitle(true);
+    fh1_Rpc_wr->SetFillColor(29);
+    fh1_Rpc_wr->SetLineColor(1);
+    fh1_Rpc_wr->SetLineWidth(2);
+    fh1_Rpc_wr->Draw("");
+
+    // Difference between Rpc-Master WRs
+    sprintf(Name1, "WR_Master_Rpc");
+    cWrs = new TCanvas(Name1, Name1, 10, 10, 500, 500);
+    sprintf(Name2, "fh1_WR_Master_Rpc");
+    sprintf(Name3, "WR-Master - WR-Rpc: Messel (blue), Wixhausen (red) - WR-Master");
+    fh1_wrs[0] = new TH1I(Name2, Name3, 4000, -4000, 4000);
+    fh1_wrs[0]->SetStats(1);
+    fh1_wrs[0]->GetXaxis()->SetTitle("WRTs difference");
+    fh1_wrs[0]->GetYaxis()->SetTitle("Counts");
+    fh1_wrs[0]->GetYaxis()->SetTitleOffset(1.3);
+    fh1_wrs[0]->GetXaxis()->CenterTitle(true);
+    fh1_wrs[0]->GetYaxis()->CenterTitle(true);
+    fh1_wrs[0]->SetLineColor(2);
+    fh1_wrs[0]->SetLineWidth(3);
+    fh1_wrs[0]->Draw("");
+    fh1_wrs[1] = new TH1I("fh1_WR_Master_Rpc_Messel", "", 4000, -4000, 4000);
+    fh1_wrs[1]->SetLineColor(4);
+    fh1_wrs[1]->SetLineWidth(3);
+    fh1_wrs[1]->Draw("same");
+
+    // CANVAS energy vs wrs
+    sprintf(Name1, "Rpc_wr_vs_energy");
+    sprintf(Name2, "fh2_wr_vs_energy_left");
+    sprintf(Name3, "Rpc WR vs hit-energy left side");
+    cRpc_wr_energy = new TCanvas(Name1, Name1, 10, 10, 500, 500);
+    cRpc_wr_energy->Divide(1, 2);
+    fh2_Cal_wr_energy_l = new TH2F(Name2, Name3, 700, -4000, 4000, bins, minE, maxE);
+    fh2_Cal_wr_energy_l->GetXaxis()->SetTitle("WR difference (Master-Rpc)");
+    fh2_Cal_wr_energy_l->GetYaxis()->SetTitle("Energy [keV]");
+    fh2_Cal_wr_energy_l->GetYaxis()->SetTitleOffset(1.4);
+    fh2_Cal_wr_energy_l->GetXaxis()->CenterTitle(true);
+    fh2_Cal_wr_energy_l->GetYaxis()->CenterTitle(true);
+    cRpc_wr_energy->cd(1);
+    fh2_Cal_wr_energy_l->Draw("COLZ");
+    sprintf(Name2, "fh2_wr_vs_energy_right");
+    sprintf(Name3, "Rpc WR vs hit-energy right side");
+    fh2_Cal_wr_energy_r = new TH2F(Name2, Name3, 700, -4000, 4000, bins, minE, maxE);
+    fh2_Cal_wr_energy_r->GetXaxis()->SetTitle("WR difference (Master-Rpc)");
+    fh2_Cal_wr_energy_r->GetYaxis()->SetTitle("Energy [keV]");
+    fh2_Cal_wr_energy_r->GetYaxis()->SetTitleOffset(1.4);
+    fh2_Cal_wr_energy_r->GetXaxis()->CenterTitle(true);
+    fh2_Cal_wr_energy_r->GetYaxis()->CenterTitle(true);
+    cRpc_wr_energy->cd(2);
+    fh2_Cal_wr_energy_r->Draw("COLZ");
+
+    // FOLDERS for Rpc
+    TFolder* folder_sta = new TFolder("Statistics_per_ring", "Statistics info");
+    for (Int_t i = 2; i < fNumRings; i++)
+    { // FIXME in the future
+        folder_sta->Add(cMap_RingR[i]);
+        folder_sta->Add(cMap_RingL[i]);
+    }
+
+    TFolder* folder_el = new TFolder("Energy_Map_per_crystal_Left", "Energy per crystal, left side info");
+    for (Int_t r = 0; r < fNumRings; r++)
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            if (fFebexInfo[1][r][p][0] != -1)
+                folder_el->Add(cMapCry[1][r][p]);
+
+    TFolder* folder_etotl = new TFolder("Energy_Tot_per_crystal_Left", "Energy vs Tot per crystal, left side info");
+    for (Int_t r = 0; r < fNumRings; r++)
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            if (fFebexInfo[1][r][p][0] != -1)
+                folder_etotl->Add(cMapCryTot[1][r][p]);
+
+    TFolder* folder_eprl = new TFolder("Energy_Map_per_crystal_Left_PR", "Energy per crystal, left side info for PR");
+    for (Int_t r = 0; r < fNumRings; r++)
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            if (fFebexInfo[1][r][p][2] != -1)
+                folder_eprl->Add(cMapCryP[1][r][p]);
+
+    TFolder* folder_eprtotl =
+        new TFolder("Energy_Tot_per_crystal_Left_PR", "Energy vs Tot per crystal, left side info for PR");
+    for (Int_t r = 0; r < fNumRings; r++)
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            if (fFebexInfo[1][r][p][2] != -1)
+                folder_eprtotl->Add(cMapCryPTot[1][r][p]);
+
+    TFolder* folder_er = new TFolder("Energy_Map_per_crystal_Right", "Energy per crystal, right side info");
+    for (Int_t r = 0; r < fNumRings; r++)
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            if (fFebexInfo[0][r][p][0] != -1)
+                folder_er->Add(cMapCry[0][r][p]);
+
+    TFolder* folder_etotr = new TFolder("Energy_Tot_per_crystal_Right", "Energy vs Tot per crystal, right side info");
+    for (Int_t r = 0; r < fNumRings; r++)
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            if (fFebexInfo[0][r][p][0] != -1)
+                folder_etotr->Add(cMapCryTot[0][r][p]);
+
+    TFolder* folder_eprr = new TFolder("Energy_Map_per_crystal_Right_PR", "Energy per crystal, right side info for PR");
+    for (Int_t r = 0; r < fNumRings; r++)
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            if (fFebexInfo[0][r][p][2] != -1)
+                folder_eprr->Add(cMapCryP[0][r][p]);
+
+    TFolder* folder_eprtotr =
+        new TFolder("Energy_Tot_per_crystal_Right_PR", "Energy vs Tot per crystal, right side info for PR");
+    for (Int_t r = 0; r < fNumRings; r++)
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            if (fFebexInfo[0][r][p][2] != -1)
+                folder_eprtotr->Add(cMapCryPTot[0][r][p]);
+
+    TFolder* folder_ecall = new TFolder("Energy_Cal_per_crystal_Left", "Energy Cal per crystal, left side info");
+    for (Int_t r = 0; r < fNumRings; r++)
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            if (fFebexInfo[1][r][p][0] != -1)
+                folder_ecall->Add(cMapCryCal[1][r][p]);
+
+    TFolder* folder_eprcall =
+        new TFolder("Energy_Cal_per_crystal_Left_PR", "Energy Cal per crystal, left side info for PR");
+    for (Int_t r = 0; r < fNumRings; r++)
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            if (fFebexInfo[1][r][p][2] != -1)
+                folder_eprcall->Add(cMapCryPCal[1][r][p]);
+
+    TFolder* folder_ecalr = new TFolder("Energy_Cal_per_crystal_Right", "Energy Cal per crystal, right side info");
+    for (Int_t r = 0; r < fNumRings; r++)
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            if (fFebexInfo[0][r][p][0] != -1)
+                folder_ecalr->Add(cMapCryCal[0][r][p]);
+
+    TFolder* folder_eprcalr =
+        new TFolder("Energy_Cal_per_crystal_Right_PR", "Energy Cal per crystal, right side info for PR");
+    for (Int_t r = 0; r < fNumRings; r++)
+        for (Int_t p = 0; p < fNumPreamps; p++)
+            if (fFebexInfo[0][r][p][2] != -1)
+                folder_eprcalr->Add(cMapCryPCal[0][r][p]);
+
+    // MAIN FOLDER-Rpc
+    TFolder* mainfolRpc = new TFolder("Rpc", "Rpc info");
+    mainfolRpc->Add(cRpcMult);
+    mainfolRpc->Add(cRpc_cry_energy);
+
+    TFolder* folder_wrs = new TFolder("WRs", "Rpc white-rabbit info");
+
+    if (fWRItemsRpc && fWRItemsMaster)
+        folder_wrs->Add(cWrs);
+    if (fWRItemsRpc)
+    {
+        folder_wrs->Add(cRpc_wr);
+        folder_wrs->Add(cRpc_sync);
+    }
+    if (fWRItemsRpc)
+        mainfolRpc->Add(folder_wrs);
+
+    mainfolRpc->Add(folder_sta);
+    mainfolRpc->Add(folder_el);
+    mainfolRpc->Add(folder_eprl);
+    mainfolRpc->Add(folder_er);
+    mainfolRpc->Add(folder_eprr);
+
+    if (fTotHist)
+    {
+        mainfolRpc->Add(folder_etotl);
+        mainfolRpc->Add(folder_eprtotl);
+        mainfolRpc->Add(folder_etotr);
+        mainfolRpc->Add(folder_eprtotr);
+    }
+
+    if (fCalItemsRpc)
+    {
+        mainfolRpc->Add(cRpc_cry_energy_cal);
+        mainfolRpc->Add(cRpc_NsNf);
+        mainfolRpc->Add(folder_ecall);
+        mainfolRpc->Add(folder_eprcall);
+        mainfolRpc->Add(folder_ecalr);
+        mainfolRpc->Add(folder_eprcalr);
+    }
+    if (fHitItemsRpc)
+    {
+        mainfolRpc->Add(cRpcCoinE);
+        mainfolRpc->Add(cRpcCoinTheta);
+        mainfolRpc->Add(cRpcCoinPhi);
+        mainfolRpc->Add(cRpc_angles);
+        mainfolRpc->Add(cRpc_opening);
+        mainfolRpc->Add(cRpc_theta_energy);
+        mainfolRpc->Add(cRpc_hitenergy);
+        if (fWRItemsRpc && fWRItemsMaster)
+            mainfolRpc->Add(cRpc_wr_energy);
+    }
+    run->AddObject(mainfolRpc);
+
+    // Register command to reset histograms
+    run->GetHttpServer()->RegisterCommand("Reset_Rpc", Form("/Objects/%s/->Reset_Rpc_Histo()", GetName()));
+    // Register command for moving between Febex and Preamp channels
+    run->GetHttpServer()->RegisterCommand("Febex2Preamp_Rpc",
+                                          Form("/Objects/%s/->Febex2Preamp_Rpc_Histo()", GetName()));
+    // Register command to change the histogram scales (Log/Lineal)
+    run->GetHttpServer()->RegisterCommand("Log_Rpc", Form("/Objects/%s/->Log_Rpc_Histo()", GetName()));
+
+    return kSUCCESS;
+}
+
+// -----   Public method ReInit   ----------------------------------------------
+InitStatus R3BRpcOnlineSpectra::ReInit()
+{
+    SetParContainers();
+    SetParameter();
+    return kSUCCESS;
+}
+
+void R3BRpcOnlineSpectra::Reset_Rpc_Histo()
+{
+    LOG(INFO) << "R3BRpcOnlineSpectra::Reset_Rpc_Histo";
+
+    if (fWRItemsRpc)
+        fh1_Rpc_wr->Reset();
+
+    if (fWRItemsRpc && fWRItemsMaster)
+    {
+        fh1_wrs[0]->Reset();
+        fh1_wrs[1]->Reset();
+        if (fHitItemsRpc)
+        {
+            fh2_Cal_wr_energy_r->Reset();
+            fh2_Cal_wr_energy_l->Reset();
+        }
+    }
+
+    if (fMappedItemsRpc)
+    {
+        fh1_Rpc_Mult->Reset();
+        for (Int_t s = 0; s < 3; s++)
+            fh1_Rpc_sync[s]->Reset();
+        fh2_Rpc_cryId_energy->Reset();
+        for (Int_t i = 0; i < fNumRings; i++)
+        {
+            fh2_Preamp_vs_ch_R[i]->Reset();
+            fh2_Preamp_vs_ch_L[i]->Reset();
+        }
+        for (Int_t s = 0; s < fNumSides; s++)
+            for (Int_t r = 0; r < fNumRings; r++)
+                for (Int_t p = 0; p < fNumPreamps; p++)
+                    for (Int_t ch = 0; ch < fNumCrystalPreamp; ch++)
+                    {
+                        if (fFebexInfo[s][r][p][0] != -1)
+                        {
+                            fh1_crystals[s][r][p][ch]->Reset();
+                            fh2_crystalsETot[s][r][p][ch]->Reset();
+                        }
+                        if (fFebexInfo[s][r][p][2] != -1)
+                        {
+                            fh1_crystals_p[s][r][p][ch]->Reset();
+                            fh2_crystalsETot_p[s][r][p][ch]->Reset();
+                        }
+                    }
+    }
+
+    if (fCalItemsRpc)
+    {
+        fh2_Rpc_cryId_energy_cal->Reset();
+        fh2_Rpc_NsNf->Reset();
+        for (Int_t s = 0; s < fNumSides; s++)
+            for (Int_t r = 0; r < fNumRings; r++)
+                for (Int_t p = 0; p < fNumPreamps; p++)
+                    for (Int_t ch = 0; ch < fNumCrystalPreamp; ch++)
+                    {
+                        if (fFebexInfo[s][r][p][0] != -1)
+                            fh1_crystals_cal[s][r][p][ch]->Reset();
+                        if (fFebexInfo[s][r][p][2] != -1)
+                            fh1_crystals_p_cal[s][r][p][ch]->Reset();
+                    }
+    }
+
+    if (fHitItemsRpc)
+    {
+        fh1_Rpc_MultHit->Reset();
+        fh2_Rpc_coinE->Reset();
+        fh2_Rpc_coinTheta->Reset();
+        fh2_Rpc_coinPhi->Reset();
+        fh2_Rpc_theta_phi->Reset();
+        fh2_Rpc_theta_energy->Reset();
+        fh1_Rpc_total_energy->Reset();
+        fh1_openangle->Reset();
+    }
+}
+
+void R3BRpcOnlineSpectra::Log_Rpc_Histo()
+{
+
+    LOG(INFO) << "R3BRpcOnlineSpectra::Log_Rpc_Histo";
+
+    cRpc_cry_energy->cd();
+    if (fLogScale)
+    {
+        gPad->SetLogz(0);
+    }
+    else
+    {
+        gPad->SetLogz(1);
+    }
+
+    cRpcMult->cd();
+    if (fLogScale)
+    {
+        gPad->SetLogy(0);
+    }
+    else
+    {
+        gPad->SetLogy(1);
+    }
+
+    for (Int_t s = 0; s < fNumSides; s++)
+    {
+        for (Int_t r = 0; r < fNumRings; r++)
+        {
+            for (Int_t p = 0; p < fNumPreamps; p++)
+            {
+
+                for (Int_t j = 0; j < fNumCrystalPreamp; j++)
+                {
+                    if (fFebexInfo[s][r][p][0] != -1)
+                    {
+                        cMapCry[s][r][p]->cd(j + 1);
+                        if (fLogScale)
+                        {
+                            gPad->SetLogy(0);
+                        }
+                        else
+                        {
+                            gPad->SetLogy(1);
+                        }
+                    }
+                    if (fFebexInfo[s][r][p][2] != -1)
+                    { // histograms for proton range
+                        cMapCryP[s][r][p]->cd(j + 1);
+                        if (fLogScale)
+                        {
+                            gPad->SetLogy(0);
+                        }
+                        else
+                        {
+                            gPad->SetLogy(1);
+                        }
+                    }
+                    if (fCalItemsRpc)
+                    {
+                        if (fFebexInfo[s][r][p][0] != -1)
+                        {
+                            cMapCryCal[s][r][p]->cd(p + 1);
+                            if (fLogScale)
+                            {
+                                gPad->SetLogy(0);
+                            }
+                            else
+                            {
+                                gPad->SetLogy(1);
+                            }
+                        }
+                        if (fFebexInfo[s][r][p][2] != -1)
+                        { // histograms for proton range
+                            cMapCryPCal[s][r][p]->cd(j + 1);
+                            if (fLogScale)
+                            {
+                                gPad->SetLogy(0);
+                            }
+                            else
+                            {
+                                gPad->SetLogy(1);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (fCalItemsRpc)
+    {
+        cRpc_cry_energy_cal->cd();
+        if (fLogScale)
+        {
+            gPad->SetLogz(0);
+        }
+        else
+        {
+            gPad->SetLogz(1);
+        }
+    }
+
+    if (fHitItemsRpc)
+    {
+        cRpc_hitenergy->cd();
+        if (fLogScale)
+        {
+            gPad->SetLogy(0);
+        }
+        else
+        {
+            gPad->SetLogy(1);
+        }
+    }
+
+    if (fLogScale)
+        fLogScale = kFALSE;
+    else
+        fLogScale = kTRUE;
+}
+
+void R3BRpcOnlineSpectra::Febex2Preamp_Rpc_Histo()
+{
+    LOG(INFO) << "R3BRpcOnlineSpectra::Febex2Preamp_Rpc_Histo";
+
+    char Name[255];
+    char Side[50];
+
+    if (fFebex2Preamp)
+    { // Preamp to Febex sequence
+        for (Int_t s = 0; s < fNumSides; s++)
+        {
+            if (s == 1)
+                sprintf(Side, "Left");
+            else
+                sprintf(Side, "Right");
+            for (Int_t r = 0; r < fNumRings; r++)
+            {
+                for (Int_t p = 0; p < fNumPreamps; p++)
+                {
+                    for (Int_t j = 0; j < fNumCrystalPreamp; j++)
+                    {
+                        if (fFebexInfo[s][r][p][0] != -1)
+                        {
+                            cMapCry[s][r][p]->cd(fOrderFebexPreamp[j] + 1);
+                            fh1_crystals[s][r][p][j]->SetFillColor(kGreen);
+                            sprintf(Name,
+                                    "Map level, Side %s, Ring %d, Slot %d, Febex %d, ch. %d",
+                                    Side,
+                                    r + 1,
+                                    fFebexInfo[s][r][p][0],
+                                    fFebexInfo[s][r][p][1],
+                                    fOrderFebexPreamp[j]);
+                            fh1_crystals[s][r][p][j]->SetTitle(Name);
+                            fh1_crystals[s][r][p][j]->Draw();
+
+                            cMapCryTot[s][r][p]->cd(fOrderFebexPreamp[j] + 1);
+                            sprintf(Name,
+                                    "Map level, Side %s, Ring %d, Slot %d, Febex %d, ch. %d",
+                                    Side,
+                                    r + 1,
+                                    fFebexInfo[s][r][p][0],
+                                    fFebexInfo[s][r][p][1],
+                                    fOrderFebexPreamp[j]);
+                            fh2_crystalsETot[s][r][p][j]->SetTitle(Name);
+                            fh2_crystalsETot[s][r][p][j]->Draw();
+                        }
+                        if (fFebexInfo[s][r][p][2] != -1)
+                        {
+                            cMapCryP[s][r][p]->cd(fOrderFebexPreamp[j] + 1);
+                            fh1_crystals_p[s][r][p][j]->SetFillColor(kGreen);
+                            sprintf(Name,
+                                    "Map level (PR), Side %s, Ring %d, Slot %d, Febex %d, ch. %d",
+                                    Side,
+                                    r + 1,
+                                    fFebexInfo[s][r][p][2],
+                                    fFebexInfo[s][r][p][3],
+                                    fOrderFebexPreamp[j]);
+                            fh1_crystals_p[s][r][p][j]->SetTitle(Name);
+                            fh1_crystals_p[s][r][p][j]->Draw();
+
+                            cMapCryPTot[s][r][p]->cd(fOrderFebexPreamp[j] + 1);
+                            sprintf(Name,
+                                    "Map level (PR), Side %s, Ring %d, Slot %d, Febex %d, ch. %d",
+                                    Side,
+                                    r + 1,
+                                    fFebexInfo[s][r][p][2],
+                                    fFebexInfo[s][r][p][3],
+                                    fOrderFebexPreamp[j]);
+                            fh2_crystalsETot_p[s][r][p][j]->SetTitle(Name);
+                            fh2_crystalsETot_p[s][r][p][j]->Draw();
+                        }
+
+                        if (fCalItemsRpc)
+                        {
+                            if (fFebexInfo[s][r][p][0] != -1)
+                            {
+                                cMapCryCal[s][r][p]->cd(fOrderFebexPreamp[j] + 1);
+                                fh1_crystals_cal[s][r][p][j]->SetFillColor(kGreen);
+                                sprintf(Name,
+                                        "Cal level, Side %s, Ring %d, Slot %d, Febex %d, ch. %d",
+                                        Side,
+                                        r + 1,
+                                        fFebexInfo[s][r][p][0],
+                                        fFebexInfo[s][r][p][1],
+                                        fOrderFebexPreamp[j]);
+                                fh1_crystals_cal[s][r][p][j]->SetTitle(Name);
+                                fh1_crystals_cal[s][r][p][j]->Draw();
+                            }
+                            if (fFebexInfo[s][r][p][2] != -1)
+                            {
+                                cMapCryPCal[s][r][p]->cd(fOrderFebexPreamp[j] + 1);
+                                fh1_crystals_p_cal[s][r][p][j]->SetFillColor(kGreen);
+                                sprintf(Name,
+                                        "Cal level (PR), Side %s, Ring %d, Slot %d, Febex %d, ch. %d",
+                                        Side,
+                                        r + 1,
+                                        fFebexInfo[s][r][p][2],
+                                        fFebexInfo[s][r][p][3],
+                                        fOrderFebexPreamp[j]);
+                                fh1_crystals_p_cal[s][r][p][j]->SetTitle(Name);
+                                fh1_crystals_p_cal[s][r][p][j]->Draw();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        fFebex2Preamp = kFALSE;
+    }
+    else
+    { // Febex to Preamp sequence
+        for (Int_t s = 0; s < fNumSides; s++)
+        {
+            if (s == 1)
+                sprintf(Side, "Left");
+            else
+                sprintf(Side, "Right");
+            for (Int_t r = 0; r < fNumRings; r++)
+            {
+                for (Int_t p = 0; p < fNumPreamps; p++)
+                {
+                    for (Int_t j = 0; j < fNumCrystalPreamp; j++)
+                    {
+                        if (fFebexInfo[s][r][p][0] != -1)
+                        {
+                            cMapCry[s][r][p]->cd(j + 1);
+                            fh1_crystals[s][r][p][j]->SetFillColor(45);
+                            sprintf(Name, "Map level, Side %s, Ring %d, Preamp %d, ch. %d", Side, r + 1, p + 1, j + 1);
+                            fh1_crystals[s][r][p][j]->SetTitle(Name);
+                            fh1_crystals[s][r][p][j]->Draw();
+
+                            cMapCryTot[s][r][p]->cd(j + 1);
+                            sprintf(Name, "Map level, Side %s, Ring %d, Preamp %d, ch. %d", Side, r + 1, p + 1, j + 1);
+                            fh2_crystalsETot[s][r][p][j]->SetTitle(Name);
+                            fh2_crystalsETot[s][r][p][j]->Draw();
+                        }
+                        if (fFebexInfo[s][r][p][2] != -1)
+                        {
+                            cMapCryP[s][r][p]->cd(j + 1);
+                            fh1_crystals_p[s][r][p][j]->SetFillColor(45);
+                            sprintf(
+                                Name, "Map level (PR), Side %s, Ring %d, Preamp %d, ch. %d", Side, r + 1, p + 1, j + 1);
+                            fh1_crystals_p[s][r][p][j]->SetTitle(Name);
+                            fh1_crystals_p[s][r][p][j]->Draw();
+
+                            cMapCryPTot[s][r][p]->cd(j + 1);
+                            sprintf(
+                                Name, "Map level (PR), Side %s, Ring %d, Preamp %d, ch. %d", Side, r + 1, p + 1, j + 1);
+                            fh2_crystalsETot_p[s][r][p][j]->SetTitle(Name);
+                            fh2_crystalsETot_p[s][r][p][j]->Draw();
+                        }
+
+                        if (fCalItemsRpc)
+                        {
+                            if (fFebexInfo[s][r][p][0] != -1)
+                            {
+                                cMapCryCal[s][r][p]->cd(j + 1);
+                                fh1_crystals_cal[s][r][p][j]->SetFillColor(45);
+                                sprintf(
+                                    Name, "Cal level, Side %s, Ring %d, Preamp %d, ch. %d", Side, r + 1, p + 1, j + 1);
+                                fh1_crystals_cal[s][r][p][j]->SetTitle(Name);
+                                fh1_crystals_cal[s][r][p][j]->Draw();
+                            }
+
+                            if (fFebexInfo[s][r][p][2] != -1)
+                            {
+                                cMapCryPCal[s][r][p]->cd(j + 1);
+                                fh1_crystals_p_cal[s][r][p][j]->SetFillColor(45);
+                                sprintf(Name,
+                                        "Cal level (PR), Side %s, Ring %d, Preamp %d, ch. %d",
+                                        Side,
+                                        r + 1,
+                                        p + 1,
+                                        j + 1);
+                                fh1_crystals_p_cal[s][r][p][j]->SetTitle(Name);
+                                fh1_crystals_p_cal[s][r][p][j]->Draw();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        fFebex2Preamp = kTRUE;
+    }
+}
+
+void R3BRpcOnlineSpectra::Exec(Option_t* option)
+{
+    FairRootManager* mgr = FairRootManager::Instance();
+    if (NULL == mgr)
+        LOG(FATAL) << "R3BRpcOnlineSpectra::Exec FairRootManager not found";
+
+    // int64_t wrdif[fNumSides];
+    // Int_t wrdifinUse = 0;
+    int64_t wr[2];
+    int64_t wrm = 0.0;
+    for (int i = 0; i < 2; i++)
+        wr[i] = 0;
+    // WR data
+    if (fWRItemsRpc && fWRItemsRpc->GetEntriesFast() > 0)
+    {
+        // Rpc
+        Int_t nHits = fWRItemsRpc->GetEntriesFast();
+        for (Int_t ihit = 0; ihit < nHits; ihit++)
+        {
+            R3BWRData* hit = (R3BWRData*)fWRItemsRpc->At(ihit);
+            if (!hit)
+                continue;
+            wr[ihit] = hit->GetTimeStamp();
+        }
+        if (nHits == 2)
+            fh1_Rpc_wr->Fill(wr[1] - wr[0]);
+
+        // Master Ref. (exp. 2020)
+        if (fWRItemsMaster && fWRItemsMaster->GetEntriesFast() > 0)
+        {
+            nHits = fWRItemsMaster->GetEntriesFast();
+            for (Int_t ihit = 0; ihit < nHits; ihit++)
+            {
+                R3BWRData* hit = (R3BWRData*)fWRItemsMaster->At(ihit);
+                if (!hit)
+                    continue;
+                wrm = hit->GetTimeStamp();
+            }
+            // fh1_wrs[0]->Fill(wrm - wr[0]); // messel
+            // fh1_wrs[1]->Fill(wrm - wr[1]); // wixhausen
+            // wrdif[0] = wrm - wr[0];
+            // wrdif[1] = wrm - wr[1];
+            // wrdifinUse = 1;
+        }
+    }
+
+    // Mapped data
+    if (fMappedItemsRpc && fMappedItemsRpc->GetEntriesFast() > 0)
+    {
+        Int_t nHits = fMappedItemsRpc->GetEntriesFast();
+        Int_t Crymult = 0;
+        for (Int_t ihit = 0; ihit < nHits; ihit++)
+        {
+            R3BRpcMappedData* hit = (R3BRpcMappedData*)fMappedItemsRpc->At(ihit);
+            if (!hit)
+                continue;
+
+            Int_t cryId = hit->GetCrystalId();
+
+            // compensate slave exploder delays:
+            int64_t wrc = hit->GetWrts() + 245 * (fMap_Par->GetPreamp(cryId) > 8);
+            if (wrm > 0.)
+            {
+                bool side = !(fMap_Par->GetHalf(cryId) % 2);
+                fh1_wrs[side]->Fill(wrc - wrm);
+            }
+
+            if ((fMap_Par->GetInUse(cryId) == 1 && cryId <= fNbRpcCrystals / 2) ||
+                (cryId > fNbRpcCrystals / 2 &&
+                 fMap_Par->GetInUse(cryId) != fMap_Par->GetInUse(cryId - fNbRpcCrystals / 2)))
+                Crymult++;
+
+            fh2_Rpc_cryId_energy->Fill(cryId, hit->GetEnergy());
+
+            if (fMap_Par->GetHalf(cryId) == 2)
+                fh2_Preamp_vs_ch_L[fMap_Par->GetRing(cryId) - 1]->Fill(fMap_Par->GetPreamp(cryId),
+                                                                       fMap_Par->GetChannel(cryId));
+            if (fMap_Par->GetHalf(cryId) == 1)
+                fh2_Preamp_vs_ch_R[fMap_Par->GetRing(cryId) - 1]->Fill(fMap_Par->GetPreamp(cryId),
+                                                                       fMap_Par->GetChannel(cryId));
+
+            if (fMap_Par->GetInUse(cryId) == 1 && cryId <= fNbRpcCrystals / 2)
+            {
+                fh1_crystals[fMap_Par->GetHalf(cryId) - 1][fMap_Par->GetRing(cryId) - 1][fMap_Par->GetPreamp(cryId) - 1]
+                            [fMap_Par->GetChannel(cryId) - 1]
+                                ->Fill(hit->GetEnergy());
+                fh2_crystalsETot[fMap_Par->GetHalf(cryId) - 1][fMap_Par->GetRing(cryId) - 1]
+                                [fMap_Par->GetPreamp(cryId) - 1][fMap_Par->GetChannel(cryId) - 1]
+                                    ->Fill(hit->GetEnergy(), hit->GetTot());
+            }
+
+            else if (fMap_Par->GetInUse(cryId) == 1 && cryId > fNbRpcCrystals / 2)
+            {
+                fh1_crystals_p[fMap_Par->GetHalf(cryId) - 1][fMap_Par->GetRing(cryId) - 1]
+                              [fMap_Par->GetPreamp(cryId) - 1][fMap_Par->GetChannel(cryId) - 1]
+                                  ->Fill(hit->GetEnergy());
+                fh2_crystalsETot_p[fMap_Par->GetHalf(cryId) - 1][fMap_Par->GetRing(cryId) - 1]
+                                  [fMap_Par->GetPreamp(cryId) - 1][fMap_Par->GetChannel(cryId) - 1]
+                                      ->Fill(hit->GetEnergy(), hit->GetTot());
+            }
+        }
+        fh1_Rpc_Mult->Fill(Crymult);
+    }
+
+    // Cal data
+    if (fCalItemsRpc && fCalItemsRpc->GetEntriesFast() > 0)
+    {
+        Int_t nHits = fCalItemsRpc->GetEntriesFast();
+
+        for (Int_t ihit = 0; ihit < nHits; ihit++)
+        {
+            R3BRpcCrystalCalData* hit = (R3BRpcCrystalCalData*)fCalItemsRpc->At(ihit);
+            if (!hit)
+                continue;
+
+            Int_t cryId = hit->GetCrystalId();
+
+            fh2_Rpc_cryId_energy_cal->Fill(cryId, hit->GetEnergy());
+
+            fh2_Rpc_NsNf->Fill(hit->GetNf(), hit->GetNs());
+
+            if (fMap_Par->GetInUse(cryId) == 1 && cryId <= fNbRpcCrystals / 2)
+                fh1_crystals_cal[fMap_Par->GetHalf(cryId) - 1][fMap_Par->GetRing(cryId) - 1]
+                                [fMap_Par->GetPreamp(cryId) - 1][fMap_Par->GetChannel(cryId) - 1]
+                                    ->Fill(hit->GetEnergy());
+            else if (fMap_Par->GetInUse(cryId) == 1 && cryId > fNbRpcCrystals / 2)
+                fh1_crystals_p_cal[fMap_Par->GetHalf(cryId) - 1][fMap_Par->GetRing(cryId) - 1]
+                                  [fMap_Par->GetPreamp(cryId) - 1][fMap_Par->GetChannel(cryId) - 1]
+                                      ->Fill(hit->GetEnergy());
+        }
+    }
+
+    // Hit data
+    if (fHitItemsRpc && fHitItemsRpc->GetEntriesFast() > 0)
+    {
+        Int_t nHits = fHitItemsRpc->GetEntriesFast();
+        fh1_Rpc_MultHit->Fill(nHits);
+
+        Double_t theta = 0., phi = 0.;
+        Double_t Rpc_theta[nHits];
+        Double_t Rpc_phi[nHits];
+        Double_t Rpc_e[nHits];
+        for (Int_t ihit = 0; ihit < nHits; ihit++)
+        {
+            R3BRpcHitData* hit = (R3BRpcHitData*)fHitItemsRpc->At(ihit);
+            if (!hit)
+                continue;
+            theta = hit->GetTheta() * TMath::RadToDeg();
+            phi = hit->GetPhi() * TMath::RadToDeg();
+            Rpc_theta[ihit] = theta;
+            Rpc_phi[ihit] = phi;
+            Rpc_e[ihit] = hit->GetEnergy();
+            fh2_Rpc_theta_phi->Fill(theta, phi);
+            fh2_Rpc_theta_energy->Fill(theta + gRandom->Uniform(-1.5, 1.5), hit->GetEnergy());
+            fh1_Rpc_total_energy->Fill(hit->GetEnergy());
+        }
+
+        TVector3 master[2];
+        Double_t maxEL = 0., maxER = 0.;
+        for (Int_t i1 = 0; i1 < nHits; i1++)
+        {
+
+            if (Rpc_e[i1] > maxER && TMath::Abs(Rpc_phi[i1]) > 150.) // wixhausen
+            {
+                master[0].SetMagThetaPhi(1., Rpc_theta[i1] * TMath::DegToRad(), Rpc_phi[i1] * TMath::DegToRad());
+                maxER = Rpc_e[i1];
+            }
+            if (Rpc_e[i1] > maxEL && TMath::Abs(Rpc_phi[i1]) < 60.)
+            { // messel
+                master[1].SetMagThetaPhi(1., Rpc_theta[i1] * TMath::DegToRad(), Rpc_phi[i1] * TMath::DegToRad());
+                maxEL = Rpc_e[i1];
+            }
+        }
+        if (maxEL > fMinProtonE && maxER > fMinProtonE)
+        {
+            fh1_openangle->Fill(master[0].Angle(master[1]) * TMath::RadToDeg());
+        }
+
+        // Comparison of hits to get energy, theta and phi correlations between them
+        for (Int_t i1 = 0; i1 < nHits; i1++)
+        {
+            /*if (wrdifinUse == 1)
+            {
+                if (TMath::Abs(Rpc_phi[i1]) > 90.)
+                    fh2_Cal_wr_energy_r->Fill(wrdif[1], Rpc_e[i1]); // wixhausen
+                else
+                    fh2_Cal_wr_energy_l->Fill(wrdif[0], Rpc_e[i1]); // messel
+            }*/
+            for (Int_t i2 = i1 + 1; i2 < nHits; i2++)
+            {
+                if (gRandom->Uniform(0., 1.) < 0.5)
+                {
+                    fh2_Rpc_coinE->Fill(Rpc_e[i1], Rpc_e[i2]);
+                    fh2_Rpc_coinTheta->Fill(Rpc_theta[i1], Rpc_theta[i2]);
+                    fh2_Rpc_coinPhi->Fill(Rpc_phi[i1], Rpc_phi[i2]);
+                }
+                else
+                {
+                    fh2_Rpc_coinE->Fill(Rpc_e[i2], Rpc_e[i1]);
+                    fh2_Rpc_coinTheta->Fill(Rpc_theta[i2], Rpc_theta[i1]);
+                    fh2_Rpc_coinPhi->Fill(Rpc_phi[i2], Rpc_phi[i1]);
+                }
+            }
+        }
+    }
+
+    fNEvents += 1;
+}
+
+void R3BRpcOnlineSpectra::FinishEvent()
+{
+    if (fMappedItemsRpc)
+    {
+        fMappedItemsRpc->Clear();
+    }
+    if (fCalItemsRpc)
+    {
+        fCalItemsRpc->Clear();
+    }
+    if (fHitItemsRpc)
+    {
+        fHitItemsRpc->Clear();
+    }
+    if (fWRItemsRpc)
+    {
+        fWRItemsRpc->Clear();
+    }
+    if (fWRItemsMaster)
+    {
+        fWRItemsMaster->Clear();
+    }
+}
+
+void R3BRpcOnlineSpectra::FinishTask()
+{
+    // Write canvas for Rpc WR data
+    if (fWRItemsRpc)
+    {
+        cRpc_wr->Write();
+    }
+
+    // Write canvas for Master-Rpc WR data
+    if (fWRItemsMaster && fWRItemsRpc)
+    {
+        cWrs->Write();
+        if (fHitItemsRpc)
+            cRpc_wr_energy->Write();
+    }
+
+    // Write canvas for Mapped data
+    if (fMappedItemsRpc)
+    {
+        cRpcMult->Write();
+        cRpc_sync->Write();
+        cRpc_cry_energy->Write();
+        for (Int_t i = 0; i < fNumRings; i++)
+        {
+            cMap_RingR[i]->Write();
+            cMap_RingL[i]->Write();
+        }
+        for (Int_t s = 0; s < fNumSides; s++)
+            for (Int_t r = 0; r < fNumRings; r++)
+                for (Int_t p = 0; p < fNumPreamps; p++)
+                {
+                    if (fFebexInfo[s][r][p][0] != -1)
+                        cMapCry[s][r][p]->Write();
+                    if (fFebexInfo[s][r][p][2] != -1)
+                        cMapCryP[s][r][p]->Write();
+                }
+    }
+
+    // Write canvas for Cal data
+    if (fCalItemsRpc)
+    {
+        cRpc_cry_energy_cal->Write();
+        cRpc_NsNf->Write();
+        for (Int_t s = 0; s < fNumSides; s++)
+            for (Int_t r = 0; r < fNumRings; r++)
+                for (Int_t p = 0; p < fNumPreamps; p++)
+                {
+                    if (fFebexInfo[s][r][p][0] != -1)
+                        cMapCryCal[s][r][p]->Write();
+                    if (fFebexInfo[s][r][p][2] != -1)
+                        cMapCryPCal[s][r][p]->Write();
+                }
+    }
+
+    // Write canvas for Hit data
+    if (fHitItemsRpc)
+    {
+        cRpcCoinE->Write();
+        cRpcCoinTheta->Write();
+        cRpcCoinPhi->Write();
+        cRpc_angles->Write();
+        cRpc_theta_energy->Write();
+        cRpc_hitenergy->Write();
+        cRpc_opening->Write();
+    }
+}
+
+ClassImp(R3BRpcOnlineSpectra)

--- a/rpc/R3BRpcOnlineSpectra.h
+++ b/rpc/R3BRpcOnlineSpectra.h
@@ -1,0 +1,150 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BRPCONLINESPECTRA
+#define R3BRPCONLINESPECTRA
+
+#include "FairTask.h"
+#include "TCanvas.h"
+#include "TMath.h"
+#include <array>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+#define Nb_Sides 2
+#define Nb_Channels 44
+
+class TClonesArray;
+class TH1F;
+class TH1I;
+class TH2F;
+class R3BEventHeader;
+
+/**
+ * This taks reads RPC data and plots online histograms
+ */
+class R3BRpcOnlineSpectra : public FairTask
+{
+
+  public:
+    /**
+     * Default constructor.
+     * Creates an instance of the task with default parameters.
+     */
+    R3BRpcOnlineSpectra();
+
+    /**
+     * Standard constructor.
+     * Creates an instance of the task.
+     * @param name a name of the task.
+     * @param iVerbose a verbosity level.
+     */
+    R3BRpcOnlineSpectra(const TString& name, Int_t iVerbose = 1);
+
+    /**
+     * Destructor.
+     * Frees the memory used by the object.
+     */
+    virtual ~R3BRpcOnlineSpectra();
+
+    /** Virtual method SetParContainers **/
+    virtual void SetParContainers();
+
+    /**
+     * Method for task initialization.
+     * This function is called by the framework before
+     * the event loop.
+     * @return Initialization status. kSUCCESS, kERROR or kFATAL.
+     */
+    virtual InitStatus Init();
+
+    /** Virtual method ReInit **/
+    virtual InitStatus ReInit();
+
+    /**
+     * Method for event loop implementation.
+     * Is called by the framework every time a new event is read.
+     * @param option an execution option.
+     */
+    virtual void Exec(Option_t* option);
+
+    /**
+     * A method for finish of processing of an event.
+     * Is called by the framework for each event after executing
+     * the tasks.
+     */
+    virtual void FinishEvent();
+
+    /**
+     * Method for finish of the task execution.
+     * Is called by the framework after processing the event loop.
+     */
+    virtual void FinishTask();
+
+    /**
+     * Method to select binning and max range
+     */
+    inline void SetRange_bins(Int_t Histos_bins) { fMapHistos_bins = Histos_bins; }
+    inline void SetRange_max(Int_t Histos_max) { fMapHistos_max = Histos_max; }
+
+    /**
+     * Method for setting Tot histograms
+     */
+    inline void SetTotHist(Bool_t opt) { fTotHist = opt; }
+
+    /**
+     * Method to reset histograms
+     */
+    void Reset_RPC_Histo();
+
+    /**
+     * Method to change histogram scales
+     */
+    void Log_RPC_Histo();
+
+  private:
+    void SetParameters();
+
+    Int_t fMapHistos_max;
+    Int_t fMapHistos_bins;
+
+    TClonesArray* fMappedItems; /**< Array with mapped items.    */
+    TClonesArray* fCalItems;    /**< Array with cal items.       */
+    TClonesArray* fHitItems;    /**< Array with hit items.       */
+
+    // Check for trigger should be done globablly (somewhere else)
+    R3BEventHeader* header; /**< Event header.  */
+    Int_t fNEvents;         /**< Event counter. */
+
+    Int_t fNumSides;          /**< Number of Sides, left and right.   */
+    Int_t fNumChannels;       /**< Number of Channels.   */
+
+    Bool_t fLogScale;       /**< Selecting scale. */
+    Bool_t fTotHist;        /**< Tot histograms selector. */
+
+    // Canvas
+    TCanvas* cRPCMult;
+    TCanvas* cMap[Nb_Sides][Nb_Channels];
+    TCanvas* cRPCTime;
+
+    // Histograms
+    TH1F* fh1_RPC_Mult;
+    TH2F* fh2_RPC_tof_time;
+
+  public:
+    ClassDef(R3BRpcOnlineSpectra, 1)
+};
+
+#endif

--- a/rpc/R3BRpcPars4Sim.cxx
+++ b/rpc/R3BRpcPars4Sim.cxx
@@ -1,0 +1,81 @@
+#include "R3BRpcPars4Sim.h"
+
+#include "FairLogger.h"
+#include "FairParamList.h"
+
+#include "TMath.h"
+
+#include "TString.h"
+
+#include <iostream>
+
+R3BRpcPars4Sim::R3BRpcPars4Sim(const char* name, const char* title, const char* context)
+    : FairParGenericSet(name, title, context)
+    , fNumChannels(64)
+{
+
+    fChannelIDArray = new TArrayI(fNumChannels);
+}
+
+R3BRpcPars4Sim::~R3BRpcPars4Sim()
+{
+    clear();
+    if (fChannelIDArray)
+        delete fChannelIDArray;
+}
+
+void R3BRpcPars4Sim::clear()
+{
+    status = kFALSE;
+    resetInputVersions();
+}
+
+void R3BRpcPars4Sim::putParams(FairParamList* list)
+{
+    LOG(INFO) << "R3BRpcPars4Sim::putParams() called";
+    if (!list)
+    {
+        return;
+    }
+
+    fChannelIDArray->Set(fNumChannels);
+    list->add("rpcChannelsIDPar", *fChannelIDArray);
+
+    list->add("rpcChannelsNumberPar", fNumChannels);
+}
+
+Bool_t R3BRpcPars4Sim::getParams(FairParamList* list)
+{
+    LOG(INFO) << "R3BRpcPars4Sim::getParams() called";
+    if (!list)
+    {
+        return kFALSE;
+    }
+
+    if (!list->fill("rpcChannelslNumberPar", &fNumChannels))
+    {
+        return kFALSE;
+    }
+
+    fChannelIDArray->Set(fNumChannels);
+    if (!(list->fill("rpcChannelsIDPar", fChannelIDArray)))
+    {
+        LOG(INFO) << "---Could not initialize rpcChannelsIDPar";
+        return kFALSE;
+    }
+
+    return kTRUE;
+}
+
+void R3BRpcPars4Sim::printParams()
+{
+    LOG(INFO) << "R3BRpcPars4Sim: RPC Simulation Parameters: ";
+
+    LOG(INFO) << "Channel ID"
+              << " ";
+
+    for (Int_t i = 0; i < fNumChannels; i++)
+    {
+        LOG(INFO) << i + 1 << " " << fChannelIDArray->GetAt(i);
+    }
+}

--- a/rpc/R3BRpcPars4Sim.h
+++ b/rpc/R3BRpcPars4Sim.h
@@ -1,0 +1,67 @@
+#ifndef R3BRPCPARS4SIM_H
+#define R3BRPCPARS4SIM_H
+
+#include "FairParGenericSet.h"
+
+#include "TArrayF.h"
+#include "TArrayI.h"
+#include "TObjArray.h"
+#include "TObject.h"
+#include <TObjString.h>
+
+using namespace std;
+
+class FairParamList;
+
+class R3BRpcPars4Sim : public FairParGenericSet
+{
+
+  public:
+    /** Standard constructor **/
+    R3BRpcPars4Sim(const char* name = "RpcPars4Sim",
+                   const char* title = "RPC Parameters for Sim",
+                   const char* context = "RpcSimParContext");
+
+    /** Destructor **/
+    virtual ~R3BRpcPars4Sim();
+
+    /** Method to reset all parameters **/
+    virtual void clear();
+
+    /** Method to store all parameters using FairRuntimeDB **/
+    virtual void putParams(FairParamList* list);
+
+    /** Method to retrieve all parameters using FairRuntimeDB**/
+    Bool_t getParams(FairParamList* list);
+
+    /** Method to print values of parameters to the standard output **/
+    void printParams();
+
+    /* ----- Accessor functions ---- */
+    const Int_t GetNumChannels() { return fNumChannels; }
+
+    const Bool_t GetInUse(Int_t channel)
+    {
+        if (fChannelIDArray->GetAt(channel - 1) == 0)
+            return kFALSE;
+
+        else
+            return kTRUE;
+    }
+
+    void SetNumChannels(Int_t numberCha) { fNumChannels = numberCha; }
+
+  private:
+    /* Simulation Parameters */
+    TArrayI* fChannelIDArray;
+
+    Int_t fNumChannels; /* Number of channels */
+
+    const R3BRpcPars4Sim& operator=(const R3BRpcPars4Sim&); /*< an assignment operator>*/
+
+    R3BRpcPars4Sim(const R3BRpcPars4Sim&); /*  a copy constructor  */
+
+    ClassDef(R3BRpcPars4Sim, 1);
+};
+
+#endif


### PR DESCRIPTION
Includes the r3bdata/rpcData structures (Mapped, Cal, Hit) according to the naming
conventions and a set of calibrators to move from a level to the next. It is also
included a prototype for the R3BRpc class for simulation and the point structure.
In this case, the connection should be checked with the geo files (volume names
should match the suggestions in this code for sensitive volumes).