### PR TITLE
added tpat related helper methods

### DIFF
--- a/r3bbase/R3BEventHeader.h
+++ b/r3bbase/R3BEventHeader.h
@@ -15,6 +15,7 @@
 #define R3BEVENTHEADER_h
 
 #include "FairEventHeader.h"
+#include <stdexcept>
 
 class R3BEventHeader : public FairEventHeader
 {
@@ -32,6 +33,16 @@ class R3BEventHeader : public FairEventHeader
     Int_t GetTrigger() const { return fTrigger; }
     uint64_t GetTimeStamp() const { return fTimeStamp; }
     Int_t GetTpat() const { return fTpat; }
+
+    static constexpr uint32_t MakeTpatBit(uint8_t trigNo)
+    {
+      return (1<=trigNo && trigNo<=16)
+        ?(1<<(trigNo-1))
+        :throw std::runtime_error("Bad trigNo.");
+    }
+  
+    bool HasTpatTrig(int trigNo) const { return fTpat & MakeTpatBit(trigNo);}
+    
     Double_t GetTStart() const { return fTStart; }
 
     virtual void Register(Bool_t Persistance = kTRUE);
@@ -43,7 +54,7 @@ class R3BEventHeader : public FairEventHeader
     Int_t fTpat;
     Double_t fTStart;
 
-    ClassDef(R3BEventHeader, 6)
+    ClassDef(R3BEventHeader, 7)
 };
 
 #endif


### PR DESCRIPTION
For convenience of the users less used to pushing bits around, I have added two helper methods to R3BEventHeader.

MakeTpatBit(n), where n is a trigNo, generates a bit mask. 

HasTpatTrig checks if a specific trigger is set in the tpat or not. 
Usage example (testing):

root [0] R3BEventHeader h
(R3BEventHeader &) Name:  Title: 
root [2] R3BEventHeader::MakeTpatBit(0)
Error in <TRint::HandleTermInput()>: std::runtime_error caught: Bad trigNo.
root [4] R3BEventHeader::MakeTpatBit(17)
Error in <TRint::HandleTermInput()>: std::runtime_error caught: Bad trigNo.
root [5] R3BEventHeader::MakeTpatBit(16)
(unsigned int) 32768

root [6] h.SetTpat(0xf)
root [8] h.HasTpatTrig(5)
(bool) false
root [9] h.HasTpatTrig(4)
(bool) true
