### PR TITLE
clang formatting and fixing potential infinite loop of NeuLAND digitization

### DIFF
--- a/neuland/digitizing/DigitizingEngine.cxx
+++ b/neuland/digitizing/DigitizingEngine.cxx
@@ -12,9 +12,9 @@
  ******************************************************************************/
 
 #include "DigitizingEngine.h"
+#include "FairLogger.h"
 #include <algorithm>
 #include <cmath>
-#include "FairLogger.h"
 
 namespace Neuland
 {
@@ -48,7 +48,8 @@ namespace Neuland
                    (!fLeftChannel->HasFired() && fRightChannel->HasFired());
         }
 
-        Double_t Paddle::GetEnergy(UShort_t index ) const { 
+        Double_t Paddle::GetEnergy(UShort_t index) const
+        {
             return std::sqrt(fLeftChannel->GetEnergy(index) * fRightChannel->GetEnergy(index));
         }
 
@@ -62,12 +63,15 @@ namespace Neuland
             return (fRightChannel->GetTDC(index) - fLeftChannel->GetTDC(index)) / 2. * gCMedium;
         }
 
-        const UShort_t Paddle::GetNHits() const {
-            if (fRightChannel->GetNHits() != fLeftChannel->GetNHits()){
+        const UShort_t Paddle::GetNHits() const
+        {
+            if (fRightChannel->GetNHits() != fLeftChannel->GetNHits())
+            {
                 LOG(ERROR) << "DigitizingEngine: nhits from both side of PMTs don't match!";
                 return 0;
             }
-            else{
+            else
+            {
                 return fRightChannel->GetNHits();
             }
         }
@@ -94,13 +98,13 @@ namespace Neuland
             const auto& paddle = kv.second;
 
             // TODO: Should be easier with std::min?
-            if (paddle->GetLeftChannel()->HasFired() && paddle->GetLeftChannel()->GetTDC() < triggerTime)
+            if (paddle->GetLeftChannel()->HasFired() && paddle->GetLeftChannel()->GetTDC(0) < triggerTime)
             {
-                triggerTime = paddle->GetLeftChannel()->GetTDC();
+                triggerTime = paddle->GetLeftChannel()->GetTDC(0);
             }
-            if (paddle->GetRightChannel()->HasFired() && paddle->GetRightChannel()->GetTDC() < triggerTime)
+            if (paddle->GetRightChannel()->HasFired() && paddle->GetRightChannel()->GetTDC(0) < triggerTime)
             {
-                triggerTime = paddle->GetRightChannel()->GetTDC();
+                triggerTime = paddle->GetRightChannel()->GetTDC(0);
             }
         }
         return triggerTime;

--- a/neuland/digitizing/DigitizingEngine.h
+++ b/neuland/digitizing/DigitizingEngine.h
@@ -41,15 +41,10 @@ namespace Neuland
             virtual ~Channel() = default; // FIXME: Root doesn't like pure virtual destructors (= 0;)
             virtual void AddHit(Double_t mcTime, Double_t mcLight, Double_t dist) = 0;
             virtual bool HasFired() const = 0;
-            virtual Double_t GetQDC(UShort_t index) const {return GetQDC();}
-            virtual Double_t GetTDC(UShort_t index) const {return GetTDC();}
-            virtual Double_t GetEnergy(UShort_t index) const {return GetEnergy();}
+            virtual Double_t GetQDC(UShort_t index) const = 0;
+            virtual Double_t GetTDC(UShort_t index) const = 0;
+            virtual Double_t GetEnergy(UShort_t index) const = 0;
             virtual Int_t GetNHits() const {return 1;};
-
-            // for backward compatibility
-            virtual Double_t GetQDC() const {return GetQDC(0);}
-            virtual Double_t GetTDC() const {return GetTDC(0);}
-            virtual Double_t GetEnergy() const {return GetEnergy(0);}
 
           protected:
             std::vector<PMTHit> fPMTHits;

--- a/neuland/digitizing/DigitizingTacQuila.cxx
+++ b/neuland/digitizing/DigitizingTacQuila.cxx
@@ -59,7 +59,7 @@ namespace Neuland
             return cachedFirstHitOverThresh.get() != fPMTHits.end();
         }
 
-        Double_t Channel::GetQDC() const
+        Double_t Channel::GetQDC(UShort_t index) const
         {
             if (!cachedQDC.valid())
             {
@@ -68,7 +68,7 @@ namespace Neuland
             return cachedQDC;
         }
 
-        Double_t Channel::GetTDC() const
+        Double_t Channel::GetTDC(UShort_t index) const
         {
             if (!cachedTDC.valid())
             {
@@ -77,7 +77,7 @@ namespace Neuland
             return cachedTDC;
         }
 
-        Double_t Channel::GetEnergy() const
+        Double_t Channel::GetEnergy(UShort_t index) const
         {
             if (!cachedEnergy.valid())
             {
@@ -124,7 +124,7 @@ namespace Neuland
 
         Double_t Channel::BuildEnergy() const
         {
-            Double_t e = GetQDC();
+            Double_t e = GetQDC(0);
             // Apply reverse attenuation (TODO: Should be last?)
             e = e * exp((2. * (Digitizing::Paddle::gHalfLength)) * Digitizing::Paddle::gAttenuation / 2.);
             // Apply saturation

--- a/neuland/digitizing/DigitizingTacQuila.h
+++ b/neuland/digitizing/DigitizingTacQuila.h
@@ -42,9 +42,9 @@ namespace Neuland
             ~Channel() override = default;
             void AddHit(Double_t mcTime, Double_t mcLight, Double_t dist) override;
             bool HasFired() const override;
-            Double_t GetQDC() const override;
-            Double_t GetTDC() const override;
-            Double_t GetEnergy() const override;
+            Double_t GetQDC(UShort_t index) const override;
+            Double_t GetTDC(UShort_t index) const override;
+            Double_t GetEnergy(UShort_t index) const override;
 
           private:
             // NOTE: Some expensive calculations and random distributions are cached

--- a/neuland/digitizing/DigitizingTamex.cxx
+++ b/neuland/digitizing/DigitizingTamex.cxx
@@ -18,108 +18,125 @@
 
 #include "FairLogger.h"
 
-namespace Neuland {
+namespace Neuland
+{
 
-Tamex::Params::Params()
-    : fPMTThresh(1.)  // [MeV]
-      ,
-      fSaturationCoefficient(0.012)  //
-      ,
-      fExperimentalDataIsCorrectedForSaturation(true),
-      fTimeRes(0.15)  // time + Gaus(0., fTimeRes) [ns]
-      ,
-      fEResRel(0.05)  // Gaus(e, fEResRel * e) []
-      ,
-      fRnd(new TRandom3()) {}
-
-Tamex::Channel::Channel(const Tamex::Params& p) : par(p) {}
-
-void Tamex::Channel::AddHit(Double_t mcTime, Double_t mcLight, Double_t dist) {
-    fPMTHits.emplace_back(mcTime, mcLight, dist);
-
-    cachedQDC.push_back(Validated<Double_t>());
-    cachedTDC.push_back(Validated<Double_t>());
-    cachedEnergy.push_back(Validated<Double_t>());
-}
-
-bool Tamex::Channel::HasFired() const {
-    Bool_t hasFired = false;
-    if (fPMTHits.size() == 0) {
-        return false;
-    } else {
-        // hasFired = (fPMTHits.back().light > par.fPMTThresh);
-        hasFired = std::any_of(fPMTHits.begin(), fPMTHits.end(), [this](Digitizing::PMTHit e){return e.light > par.fPMTThresh;});
-    }
-    return hasFired;
-}
-
-Int_t Tamex::Channel::GetNHits() const { return fPMTHits.size(); }
-
-Double_t Tamex::Channel::GetQDC(UShort_t index) const {
-    if (!HasFired()) {
-        LOG(ERROR)
-            << "Error: Cannot get QDC values from unfired NeuLAND paddle!";
-        return 0;
+    Tamex::Params::Params()
+        : fPMTThresh(1.)                // [MeV]
+        , fSaturationCoefficient(0.012) //
+        , fExperimentalDataIsCorrectedForSaturation(true)
+        , fTimeRes(0.15) // time + Gaus(0., fTimeRes) [ns]
+        , fEResRel(0.05) // Gaus(e, fEResRel * e) []
+        , fRnd(new TRandom3())
+    {
     }
 
-    if (!cachedQDC[index].valid()) {
-        // get light depostion
-        Double_t l = fPMTHits[index].light;
-
-        // apply PMT saturation
-        l = l / (1. + par.fSaturationCoefficient * l);
-
-        // apply energy smearing
-        l = par.fRnd->Gaus(l, par.fEResRel * l);
-
-        //set qdc to zero if below PMT threshold
-        l = (l > par.fPMTThresh)? l : 0.0;
-
-        cachedQDC[index].set(l);
-    }
-    return cachedQDC[index].get();
-}
-
-Double_t Tamex::Channel::GetTDC(UShort_t index) const {
-    if (!HasFired()) {
-        LOG(ERROR)
-            << "Error: Cannot get TDC values from unfired NeuLAND paddle!";
-        return 0;
-    }
-    if (!cachedTDC[index].valid()) {
-        cachedTDC[index].set(fPMTHits.back().time + par.fRnd->Gaus(0., par.fTimeRes));
+    Tamex::Channel::Channel(const Tamex::Params& p)
+        : par(p)
+    {
     }
 
-    return cachedTDC[index].get();
-}
+    void Tamex::Channel::AddHit(Double_t mcTime, Double_t mcLight, Double_t dist)
+    {
+        fPMTHits.emplace_back(mcTime, mcLight, dist);
 
-Double_t Tamex::Channel::GetEnergy(UShort_t index) const {
-    if (!HasFired()) {
-        LOG(ERROR)
-            << "Error: Cannot get energy values from unfired NeuLAND paddle!";
-        return 0;
+        cachedQDC.push_back(Validated<Double_t>());
+        cachedTDC.push_back(Validated<Double_t>());
+        cachedEnergy.push_back(Validated<Double_t>());
     }
 
-    if (!cachedEnergy[index].valid()) {
-        Double_t e = GetQDC(index);
-
-        // Apply reverse saturation
-        if (par.fExperimentalDataIsCorrectedForSaturation) {
-            e = e / (1. - par.fSaturationCoefficient * e);
+    bool Tamex::Channel::HasFired() const
+    {
+        Bool_t hasFired = false;
+        if (fPMTHits.size() == 0)
+        {
+            return false;
         }
-        // Apply reverse attenuation
-        e = e * exp((2. * (Digitizing::Paddle::gHalfLength)) *
-                    Digitizing::Paddle::gAttenuation / 2.);
-        cachedEnergy[index].set(e);
+        else
+        {
+            // hasFired = (fPMTHits.back().light > par.fPMTThresh);
+            hasFired = std::any_of(
+                fPMTHits.begin(), fPMTHits.end(), [this](Digitizing::PMTHit e) { return e.light > par.fPMTThresh; });
+        }
+        return hasFired;
     }
-    return cachedEnergy[index].get();
-}
 
-DigitizingTamex::DigitizingTamex() : fTmP(Tamex::Params()) {
-}
+    Int_t Tamex::Channel::GetNHits() const { return fPMTHits.size(); }
 
-std::unique_ptr<Digitizing::Channel> DigitizingTamex::BuildChannel() {
-    return std::unique_ptr<Digitizing::Channel>(new Tamex::Channel(fTmP));
-}
+    Double_t Tamex::Channel::GetQDC(UShort_t index) const
+    {
+        if (!HasFired())
+        {
+            LOG(ERROR) << "Error: Cannot get QDC values from unfired NeuLAND paddle!";
+            return 0;
+        }
 
-}  // namespace Neuland
+        if (!cachedQDC[index].valid())
+        {
+            // get light depostion
+            Double_t l = fPMTHits[index].light;
+
+            // apply PMT saturation
+            l = l / (1. + par.fSaturationCoefficient * l);
+
+            // apply energy smearing
+            l = par.fRnd->Gaus(l, par.fEResRel * l);
+
+            // set qdc to zero if below PMT threshold
+            l = (l > par.fPMTThresh) ? l : 0.0;
+
+            cachedQDC[index].set(l);
+        }
+        return cachedQDC[index].get();
+    }
+
+    Double_t Tamex::Channel::GetTDC(UShort_t index) const
+    {
+        if (!HasFired())
+        {
+            LOG(ERROR) << "Error: Cannot get TDC values from unfired NeuLAND paddle!";
+            return 0;
+        }
+        if (!cachedTDC[index].valid())
+        {
+            cachedTDC[index].set(fPMTHits.back().time + par.fRnd->Gaus(0., par.fTimeRes));
+        }
+
+        return cachedTDC[index].get();
+    }
+
+    Double_t Tamex::Channel::GetEnergy(UShort_t index) const
+    {
+        if (!HasFired())
+        {
+            LOG(ERROR) << "Error: Cannot get energy values from unfired NeuLAND paddle!";
+            return 0;
+        }
+
+        if (!cachedEnergy[index].valid())
+        {
+            Double_t e = GetQDC(index);
+
+            // Apply reverse saturation
+            if (par.fExperimentalDataIsCorrectedForSaturation)
+            {
+                e = e / (1. - par.fSaturationCoefficient * e);
+            }
+            // Apply reverse attenuation
+            e = e * exp((2. * (Digitizing::Paddle::gHalfLength)) * Digitizing::Paddle::gAttenuation / 2.);
+            cachedEnergy[index].set(e);
+        }
+        return cachedEnergy[index].get();
+    }
+
+    DigitizingTamex::DigitizingTamex()
+        : fTmP(Tamex::Params())
+    {
+    }
+
+    std::unique_ptr<Digitizing::Channel> DigitizingTamex::BuildChannel()
+    {
+        return std::unique_ptr<Digitizing::Channel>(new Tamex::Channel(fTmP));
+    }
+
+} // namespace Neuland

--- a/neuland/digitizing/R3BNeulandDigitizer.cxx
+++ b/neuland/digitizing/R3BNeulandDigitizer.cxx
@@ -17,13 +17,13 @@
 #include "FairRootManager.h"
 #include "FairRunAna.h"
 #include "FairRuntimeDb.h"
-#include <TFile.h>
 #include "TGeoManager.h"
 #include "TGeoNode.h"
 #include "TH1F.h"
 #include "TH2F.h"
 #include "TMath.h"
 #include "TString.h"
+#include <TFile.h>
 #include <iostream>
 #include <stdexcept>
 
@@ -125,7 +125,6 @@ void R3BNeulandDigitizer::Exec(Option_t*)
                                      return kv.second->HasFired();
                                  }));
 
-
     // Create Hits
     for (const auto& kv : paddles)
     {
@@ -144,14 +143,14 @@ void R3BNeulandDigitizer::Exec(Option_t*)
             const TVector3 hitPixel = fNeulandGeoPar->ConvertGlobalToPixel(hitPositionGlobal);
 
             R3BNeulandHit hit(paddleID,
-                    paddle->GetLeftChannel()->GetTDC(i),
-                    paddle->GetRightChannel()->GetTDC(i),
-                    paddle->GetTime(i),
-                    paddle->GetLeftChannel()->GetEnergy(i),
-                    paddle->GetRightChannel()->GetEnergy(i),
-                    paddle->GetEnergy(i),
-                    hitPositionGlobal,
-                    hitPixel);
+                              paddle->GetLeftChannel()->GetTDC(i),
+                              paddle->GetRightChannel()->GetTDC(i),
+                              paddle->GetTime(i),
+                              paddle->GetLeftChannel()->GetEnergy(i),
+                              paddle->GetRightChannel()->GetEnergy(i),
+                              paddle->GetEnergy(i),
+                              hitPositionGlobal,
+                              hitPixel);
 
             if (fHitFilters.IsValid(hit))
             {


### PR DESCRIPTION
1. Apply clang-format on the new implemented NeuLAND digitisation code.
2. Fixing a potential infinite loop which could occur when digitisation class has no getter methods.