### PR TITLE
Removed 'delete fEventHeader' in destructor functions as fEventHeader…

### DIFF
--- a/r3bsource/ams/R3BWhiterabbitAmsReader.cxx
+++ b/r3bsource/ams/R3BWhiterabbitAmsReader.cxx
@@ -43,10 +43,6 @@ R3BWhiterabbitAmsReader::~R3BWhiterabbitAmsReader()
     {
         delete fArray;
     }
-    if (fEventHeader)
-    {
-        delete fEventHeader;
-    }
 }
 
 Bool_t R3BWhiterabbitAmsReader::Init(ext_data_struct_info* a_struct_info)

--- a/r3bsource/base/R3BUcesbSource.cxx
+++ b/r3bsource/base/R3BUcesbSource.cxx
@@ -56,8 +56,6 @@ R3BUcesbSource::~R3BUcesbSource()
         fReaders->Delete();
         delete fReaders;
     }
-    if (fEventHeader)
-        delete fEventHeader;
     Close();
 }
 

--- a/r3bsource/califa/R3BWhiterabbitCalifaReader.cxx
+++ b/r3bsource/califa/R3BWhiterabbitCalifaReader.cxx
@@ -47,8 +47,6 @@ R3BWhiterabbitCalifaReader::~R3BWhiterabbitCalifaReader()
     {
         delete fArray;
     }
-    if (fEventHeader)
-        delete fEventHeader;
 }
 
 Bool_t R3BWhiterabbitCalifaReader::Init(ext_data_struct_info* a_struct_info)

--- a/r3bsource/foot/R3BWhiterabbitFootReader.cxx
+++ b/r3bsource/foot/R3BWhiterabbitFootReader.cxx
@@ -49,10 +49,6 @@ R3BWhiterabbitFootReader::~R3BWhiterabbitFootReader()
     {
         delete fArray;
     }
-    if (fEventHeader)
-    {
-        delete fEventHeader;
-    }
 }
 
 Bool_t R3BWhiterabbitFootReader::Init(ext_data_struct_info* a_struct_info)

--- a/r3bsource/music/R3BWhiterabbitMusicReader.cxx
+++ b/r3bsource/music/R3BWhiterabbitMusicReader.cxx
@@ -41,8 +41,6 @@ R3BWhiterabbitMusicReader::~R3BWhiterabbitMusicReader()
 {
     if (fArray)
         delete fArray;
-    if (fEventHeader)
-        delete fEventHeader;
 }
 
 Bool_t R3BWhiterabbitMusicReader::Init(ext_data_struct_info* a_struct_info)

--- a/r3bsource/neuland/R3BWhiterabbitNeulandReader.cxx
+++ b/r3bsource/neuland/R3BWhiterabbitNeulandReader.cxx
@@ -46,8 +46,6 @@ R3BWhiterabbitNeulandReader::~R3BWhiterabbitNeulandReader()
     {
         delete fArray;
     }
-    if (fEventHeader)
-        delete fEventHeader;
 }
 
 Bool_t R3BWhiterabbitNeulandReader::Init(ext_data_struct_info* a_struct_info)

--- a/r3bsource/trloii/R3BTrloiiTpatReader.cxx
+++ b/r3bsource/trloii/R3BTrloiiTpatReader.cxx
@@ -46,10 +46,6 @@ R3BTrloiiTpatReader::R3BTrloiiTpatReader(EXT_STR_h101_TPAT* data, size_t offset)
 R3BTrloiiTpatReader::~R3BTrloiiTpatReader()
 {
     R3BLOG(INFO, "");
-    if (fEventHeader)
-    {
-        delete fEventHeader;
-    }
 }
 
 Bool_t R3BTrloiiTpatReader::Init(ext_data_struct_info* a_struct_info)

--- a/r3bsource/wr/R3BWhiterabbitMasterReader.cxx
+++ b/r3bsource/wr/R3BWhiterabbitMasterReader.cxx
@@ -47,9 +47,6 @@ R3BWhiterabbitMasterReader::~R3BWhiterabbitMasterReader()
     {
         delete fArray;
     }
-    if (fEventHeader){
-        delete fEventHeader;
-        }
 }
 
 Bool_t R3BWhiterabbitMasterReader::Init(ext_data_struct_info* a_struct_info)

--- a/r3bsource/wr/R3BWhiterabbitPspReader.cxx
+++ b/r3bsource/wr/R3BWhiterabbitPspReader.cxx
@@ -45,8 +45,6 @@ R3BWhiterabbitPspReader::~R3BWhiterabbitPspReader()
     {
         delete fArray;
     }
-    if (fEventHeader)
-        delete fEventHeader;
 }
 
 Bool_t R3BWhiterabbitPspReader::Init(ext_data_struct_info* a_struct_info)

--- a/r3bsource/wr/R3BWhiterabbitReader.cxx
+++ b/r3bsource/wr/R3BWhiterabbitReader.cxx
@@ -34,8 +34,6 @@ R3BWhiterabbitReader::R3BWhiterabbitReader(EXT_STR_h101_whiterabbit* data, size_
 
 R3BWhiterabbitReader::~R3BWhiterabbitReader()
 {
-    if (fEventHeader)
-        delete fEventHeader;
 }
 
 Bool_t R3BWhiterabbitReader::Init(ext_data_struct_info* a_struct_info)

--- a/r3bsource/wr/R3BWhiterabbitS2Reader.cxx
+++ b/r3bsource/wr/R3BWhiterabbitS2Reader.cxx
@@ -43,8 +43,6 @@ R3BWhiterabbitS2Reader::~R3BWhiterabbitS2Reader()
     {
         delete fArray;
     }
-    if (fEventHeader)
-        delete fEventHeader;
 }
 
 Bool_t R3BWhiterabbitS2Reader::Init(ext_data_struct_info* a_struct_info)

--- a/r3bsource/wr/R3BWhiterabbitS8Reader.cxx
+++ b/r3bsource/wr/R3BWhiterabbitS8Reader.cxx
@@ -43,8 +43,6 @@ R3BWhiterabbitS8Reader::~R3BWhiterabbitS8Reader()
     {
         delete fArray;
     }
-    if (fEventHeader)
-        delete fEventHeader;
 }
 
 Bool_t R3BWhiterabbitS8Reader::Init(ext_data_struct_info* a_struct_info)

--- a/rpc/online/R3BRpcOnlineSpectra.cxx
+++ b/rpc/online/R3BRpcOnlineSpectra.cxx
@@ -82,8 +82,6 @@ R3BRpcOnlineSpectra::R3BRpcOnlineSpectra(const TString& name, Int_t iVerbose)
 R3BRpcOnlineSpectra::~R3BRpcOnlineSpectra()
 {
     R3BLOG(DEBUG1, "");
-    if (fEventHeader)
-        delete fEventHeader;
 
     if (fMappedDataItems)
        delete fMappedDataItems;

--- a/ssd/online/R3BFootOnlineSpectra.cxx
+++ b/ssd/online/R3BFootOnlineSpectra.cxx
@@ -67,8 +67,6 @@ R3BFootOnlineSpectra::R3BFootOnlineSpectra(const TString& name, Int_t iVerbose)
 R3BFootOnlineSpectra::~R3BFootOnlineSpectra()
 {
     LOG(DEBUG) << "R3BFootOnlineSpectra::Delete instance";
-    if (fEventHeader)
-        delete fEventHeader;
 }
 
 InitStatus R3BFootOnlineSpectra::Init()


### PR DESCRIPTION
… is not constructed anymore in the R3BRoot, but in macros. (The change implemented at PR #547)

These lines caused segmentation fault when using FairSoft_nov20, FairRoot18.4.2, and GCC9.3.0 on Ubuntu20.4.5 system.

