### PR TITLE
Remake of Califa Hit Finder

### DIFF
--- a/califa/calibration/R3BCalifaCrystalCal2Hit.h
+++ b/califa/calibration/R3BCalifaCrystalCal2Hit.h
@@ -12,18 +12,20 @@
  ******************************************************************************/
 
 #ifndef R3BCALIFACRYSTALCAL2HIT_H
-#define R3BCALIFACRYSTALCAL2HIT_H 1
+#define R3BCALIFACRYSTALCAL2HIT_H
 
 #include "FairTask.h"
 #include "R3BCalifaGeometry.h"
 #include "R3BCalifaHitData.h"
 #include "Rtypes.h"
 
-#include "TH2F.h"
 #include <TVector3.h>
+#include "TH2F.h"
 
 class TClonesArray;
 class R3BTGeoPar;
+class R3BCalifaMappingPar;
+
 
 class R3BCalifaCrystalCal2Hit : public FairTask
 {
@@ -42,81 +44,18 @@ class R3BCalifaCrystalCal2Hit : public FairTask
     /** Virtual method Reset **/
     virtual void Reset();
 
-    /** Public method SelectGeometryVersion
-     **
-     ** Defines the geometry
-     *@param version  Integer parameter used to select the geometry:
-     ** (see documentation /r3broot/cal/perlScripts/README))
-     **/
+    /** Public method SelectGeometryVersion **/
     void SelectGeometryVersion(Int_t version);
 
-    /** Public method SetSquareWindowAlg
-     **
-     ** Select the square window clustering algorithm
-     *@param xDeltaPolar Polar aperture
-     *@param xDeltaAzimuthal Azimuthal aperture
-     **/
-    virtual void SetSquareWindowAlg(double xDeltaPolar = 0.25, double xDeltaAzimuthal = 0.25)
-    {
-        fClusterAlgorithmSelector = RECT;
-        fDeltaPolar = xDeltaPolar;
-        fDeltaAzimuthal = xDeltaAzimuthal;
-    }
 
-    /** Public method SetRoundWindowAlg
-     **
-     ** Select the round window clustering algorithm
-     *@param xDeltaAngleClust  Angular aperture
-     **/
-    virtual void SetRoundWindowAlg(double xDeltaAngleClust = 0.25)
-    {
-        fClusterAlgorithmSelector = ROUND;
-        fDeltaAngleClust = xDeltaAngleClust;
-    }
+    void SetCrystalThreshold(Double_t cryThresh)    {fCrystalThreshold = cryThresh;}
 
-    /** Public method SetRoundEnergyScaledAlg
-     **
-     ** Select the round window clustering algorithm
-     *@param xDeltaAngleClust Angular aperture
-     *@param xenergyFactor Energy factor
-     **/
-    virtual void SetRoundEnergyScaledAlg(double xDeltaAngleClust = 0.25, double xenergyFactor = 0)
-    {
-        fClusterAlgorithmSelector = ROUND_SCALED;
-        fDeltaAngleClust = xDeltaAngleClust;
-        energyFactor = xenergyFactor;
-    }
+    void SetProtonThreshold(Double_t protonThresh)  {fProtonThreshold = protonThresh;}
 
-    /** Public method SetConeAlg
-     **
-     ** Select the angular cone clustering algorithm
-     *@param xDeltaAngleClust Angular aperture
-     **/
-    virtual void SetConeAlg(double xDeltaAngleClust = 0.25)
-    {
-        fClusterAlgorithmSelector = CONE;
-        fDeltaAngleClust = xDeltaAngleClust;
-    }
+    void SetGammaClusterThreshold(Double_t clusterThresh){fGammaClusterThreshold = clusterThresh;}
+    void SetProtonClusterThreshold(Double_t clusterThresh){fProtonClusterThreshold = clusterThresh;}
 
-    /** Public method SetPetalAlg
-     **
-     ** Select the petal clustering algorithm (2018 experiments)
-     **/
-    virtual void SetPetalAlg() { fClusterAlgorithmSelector = PETAL; }
-
-    /** Public method SetCrystalThreshold
-     **
-     ** Defines the minimum energy requested in a crystal to be considered in a calorimeter Hit
-     *@param thresholdEne  Double parameter used to set the threshold
-     **/
-    void SetCrystalThreshold(Double_t thresholdEne);
-
-    /** Public method SetDRThreshold (for double reading)
-     **
-     ** Defines the minimum energy requested in a crystal to be considered in a calorimeter Hit
-     *@param thresholdEne  Double parameter used to set the threshold
-     **/
-    void SetDRThreshold(Double_t DRthresholdEne);
+    void SetSaturationEnergy(Double_t saturation) {fSaturation = saturation;}
 
     /** Virtual method SetParContainers **/
     virtual void SetParContainers();
@@ -124,31 +63,6 @@ class R3BCalifaCrystalCal2Hit : public FairTask
     /** Accessor to select online mode **/
     void SetOnline(Bool_t option) { fOnline = option; }
 
-    static int AngleToPetalId(TVector3& vec)
-    {
-        // internal [double] petal number, not corresponding to anything real
-        // only relevant for 2019 beam times
-        auto a = vec.Phi();
-        if (a < 0)
-        {
-            if (a < -2)
-                return 0;
-            else
-                return 1;
-        }
-        else
-        {
-            if (a < 2)
-            {
-                if (a < 0.2)
-                    return 2;
-                else
-                    return 3;
-            }
-            else
-                return 4;
-        }
-    }
 
     /** Virtual method Init **/
     virtual InitStatus Init();
@@ -156,77 +70,61 @@ class R3BCalifaCrystalCal2Hit : public FairTask
     /** Virtual method ReInit **/
     virtual InitStatus ReInit();
 
-    void SetRandomization(Bool_t rand) { fRand = rand; }
+    void SetRandomization(Bool_t rand){fRand=rand;}
 
-    void SetRandomizationFile(TString file)
-    {
+    void SetRandomizationFile(TString file) {
 
-        fRandFile = file;
-        fHistoFile = new TFile(fRandFile);
+      fRandFile = file;
+      fHistoFile = new TFile(fRandFile);
+
     }
 
-  protected:
-    /** Method GetAnglesVector (calls R3BCalifaGeometry::GetAngles(id)) **/
-    TVector3 GetAnglesVector(int id);
-    TVector3 fTargetPos;
-    TVector3 fCalifaPos;
-    TVector3 fCalifatoTargetPos;
+    // Defines the maximum "opening" angle between two crystals inside a cluster
+    void SetClusterWindow(Double_t window){fRoundWindow = window;}
 
-    // Clustering algorithm selector
-    enum
-    {
-        INVALID = 0,
-        RECT = 1,
-        ROUND = 2,
-        ROUND_SCALED = 3,
-        CONE = 4,
-        ALL = 5,
-        NONE = 6,
-        PETAL = 7
-    } fClusterAlgorithmSelector; // Clustering algorithm selector
+    void IsSimulation(Bool_t simu) {fSimulation = simu;}
 
   private:
+
+
     TClonesArray* fCrystalCalData;
     TClonesArray* fCalifaHitData;
+    R3BCalifaMappingPar* fMap_Par;
 
     R3BTGeoPar* fTargetGeoPar;
     R3BTGeoPar* fCalifaGeoPar;
 
-    Bool_t fOnline;              // Selector for online data storage
-    Int_t fGeometryVersion;      // Selecting the geometry of the CALIFA calorimeter
-    Int_t fNbCrystalsGammaRange; // Define max. number of crystals with gamma range
-    Double_t fDeltaPolar;        // Angular window (polar angle)
-    Double_t fDeltaAzimuthal;    // Angular window (azimuthal angle)
-    Double_t fDeltaAngleClust;   // Angular opening used for the cluster condition
-    Double_t fParCluster1;       // Clustering parameter 1
-    Double_t fThreshold;         // Minimum energy requested in a crystal to be included in a Cal
-    Double_t fDRThreshold;       // Threshold for selecting gamma or proton branch in double reading channels
-    Double_t energyFactor;
-    // Parameter class
-    // R3BCalifaHitPar* fCalifaHitPar;
+    Bool_t fOnline;                   // Selector for online data storage
+    Int_t fGeometryVersion;           // Selecting the geometry of the CALIFA calorimeter
+
+    Double_t fCrystalThreshold;       // Minimum energy requested in a crystal to be included in a cluster
+    Double_t fProtonClusterThreshold; // Minimum energy in a crystal to be considered as a proton cluster candidate
+    Double_t fGammaClusterThreshold;  // Minimum energy in a crystal to be considered as a gamma cluster candidate
+    Double_t fProtonThreshold;        // Defines the cut energy between proton and gamma readout
+
+    Double_t fRoundWindow;        // Cluster window
+    Bool_t fSimulation;           // Simulation flag
+    Double_t fSaturation;         // Crystal Saturation
 
     R3BCalifaGeometry* fCalifaGeo;
-    Bool_t fRand;      // Flag to set randomization procedure
-    TString fRandFile; // File with angular coverages for each crystal
-    TFile* fHistoFile;
-    TH2F** fAngularDistributions;
-    /** Private method AddHit
+    Bool_t fRand;                // Flag to set randomization procedure
+    TString fRandFile;           // File with angular coverages for each crystal
+    TFile *fHistoFile;
+    TH2F **fAngularDistributions;
+
+     /** Private method AddHit
      **
      ** Adds a CalifaHit to the HitCollection
      **/
-    R3BCalifaHitData* AddHit(UInt_t Nbcrystals,
+    R3BCalifaHitData* AddHit(std::vector<Int_t> crystalList,
                              Double_t ene,
                              Double_t Nf,
                              Double_t Ns,
                              Double_t pAngle,
                              Double_t aAngle,
-                             ULong64_t time);
+                             ULong64_t time,
+                             Int_t clusterType);
 
-    /** Private method Match
-     **
-     ** Decides if hit is in the cluster started by ref
-     **/
-    virtual bool Match(R3BCalifaCrystalCalData* ref, R3BCalifaCrystalCalData* hit);
 
     ClassDef(R3BCalifaCrystalCal2Hit, 2);
 };

--- a/r3bdata/califaData/R3BCalifaHitData.cxx
+++ b/r3bdata/califaData/R3BCalifaHitData.cxx
@@ -15,7 +15,6 @@
 
 R3BCalifaHitData::R3BCalifaHitData()
     : FairMultiLinkedData()
-    , fNbOfCrystalHits(0)
     , fEnergy(NAN)
     , fTheta(NAN)
     , fPhi(NAN)
@@ -23,34 +22,38 @@ R3BCalifaHitData::R3BCalifaHitData()
 {
 }
 
-R3BCalifaHitData::R3BCalifaHitData(UInt_t Nb,
+R3BCalifaHitData::R3BCalifaHitData(std::vector<Int_t> crystalList,
                                    Double_t ene,
                                    Double_t nf,
                                    Double_t ns,
                                    Double_t theta,
                                    Double_t phi,
-                                   ULong64_t time)
+                                   ULong64_t time,
+                                   Int_t clusterType)
     : FairMultiLinkedData()
-    , fNbOfCrystalHits(Nb)
+    , fCrystalList(crystalList)
     , fEnergy(ene)
     , fNf(nf)
     , fNs(ns)
     , fTheta(theta)
     , fPhi(phi)
     , fTime(time)
+    , fClusterType(clusterType)
 {
 }
 
 R3BCalifaHitData::R3BCalifaHitData(const R3BCalifaHitData& right)
     : FairMultiLinkedData(right)
-    , fNbOfCrystalHits(right.fNbOfCrystalHits)
+    , fCrystalList(right.fCrystalList)
     , fEnergy(right.fEnergy)
     , fNf(right.fNf)
     , fNs(right.fNs)
     , fTheta(right.fTheta)
     , fPhi(right.fPhi)
     , fTime(right.fTime)
+    , fClusterType(right.fClusterType)
 {
 }
 
 ClassImp(R3BCalifaHitData);
+ 

--- a/r3bdata/califaData/R3BCalifaHitData.h
+++ b/r3bdata/califaData/R3BCalifaHitData.h
@@ -27,37 +27,37 @@ class R3BCalifaHitData : public FairMultiLinkedData
     R3BCalifaHitData();
 
     /** Constructor with arguments
-     *@param fNbOfCrystalHits		Crystal unique identifier
      *@param fEnergy				Total energy deposited
      *@param fTheta					Reconstructed theta
      *@param fPhi					Reconstructed phi
      **/
-    R3BCalifaHitData(UInt_t Nb, Double_t ene, Double_t nf, Double_t ns, Double_t theta, Double_t phi, ULong64_t time);
+    R3BCalifaHitData(std::vector<Int_t> crystalList, Double_t ene, Double_t nf, Double_t ns, Double_t theta, Double_t phi, ULong64_t time,Int_t clusterType);
 
-    R3BCalifaHitData(uint64_t time, double theta, double phi, uint32_t clusterId)
-        : fTime(time)
-        , fTheta(theta)
-        , fPhi(phi)
-        , fClusterId(clusterId)
-        , fEnergy(0.)
-        , fNf(0.)
-        , fNs(0)
-        , fNbOfCrystalHits(0)
-    {
-    }
+    // R3BCalifaHitData(std::vector<Int_t> crystalList, Double_t ene, Double_t nf, Double_t ns, Double_t theta, Double_t phi, ULong64_t time,Int_t clusterType)
+    //     : fCrystalList(crystalList)
+    //     , fEnergy(ene)
+    //     , fNf(nf)
+    //     , fNs(ns)
+    //     , fTheta(theta)
+    //     , fPhi(phi)
+    //     , fTime(time)
+    //     , fClusterType(clusterType)
+    //
+    // {
+    // }
 
     /** Copy constructor **/
     R3BCalifaHitData(const R3BCalifaHitData&);
 
-    /** += operator **/
-    R3BCalifaHitData& operator+=(R3BCalifaCrystalCalData& cH)
-    {
-        this->fEnergy += cH.GetEnergy();
-        this->fNf += cH.GetNf();
-        this->fNs += cH.GetNs();
-        this->fNbOfCrystalHits++;
-        return *this;
-    }
+    // /** += operator **/
+    // R3BCalifaHitData& operator+=(R3BCalifaCrystalCalData& cH)
+    // {
+    //     this->fEnergy += cH.GetEnergy();
+    //     this->fNf += cH.GetNf();
+    //     this->fNs += cH.GetNs();
+    //     this->fNbOfCrystalHits++;
+    //     return *this;
+    // }
 
     R3BCalifaHitData& operator=(const R3BCalifaHitData&) { return *this; }
 
@@ -65,35 +65,36 @@ class R3BCalifaHitData : public FairMultiLinkedData
     virtual ~R3BCalifaHitData() {}
 
     /** Accessors **/
-    UInt_t GetNbOfCrystalHits() const { return fNbOfCrystalHits; }
     Double_t GetEnergy() const { return fEnergy; }
     Double_t GetNf() const { return fNf; }
     Double_t GetNs() const { return fNs; }
     Double_t GetTheta() const { return fTheta; }
     Double_t GetPhi() const { return fPhi; }
     ULong64_t GetTime() const { return fTime; }
-    uint32_t GetClusterId() const { return fClusterId; }
+    uint32_t GetClusterType() const { return fClusterType; }
+    std::vector<Int_t> GetCrystalList(){return fCrystalList; }
+
+    Int_t GetNbCrystals() const {return fCrystalList.size();}
 
     /** Modifiers **/
-    void SetNbOfCrystalHits(UInt_t number) { fNbOfCrystalHits = number; }
     void SetEnergy(Double_t ene) { fEnergy = ene; }
     void SetNf(Double_t nf) { fNf = nf; }
     void SetNs(Double_t ns) { fNs = ns; }
     void SetTheta(Double_t theta) { fTheta = theta; }
     void SetPhi(Double_t phi) { fPhi = phi; }
     void SetTime(ULong64_t time) { fTime = time; }
-    void SetClusterId(uint32_t id) { fClusterId = id; }
-
+    void SetClusterType(uint32_t id) { fClusterType = id; }
+    void SetCrystalList(std::vector<Int_t> list) {fCrystalList = list;}
   protected:
-    // Basic Hit information
-    UInt_t fNbOfCrystalHits; // number of crystals contribuying to the R3BCalifaHitData
+
     Double_t fEnergy;        // total energy deposited
     Double_t fNf;            // total Nf deposited
     Double_t fNs;            // total Ns deposited
     Double_t fTheta;         // reconstructed theta
     Double_t fPhi;           // reconstructed phi
     ULong64_t fTime;         // WR time stamp
-    uint32_t fClusterId;
+    uint32_t fClusterType;
+    std::vector<Int_t> fCrystalList; // List with crystals inside the cluster. First one is the mother crystal
 
     ClassDef(R3BCalifaHitData, 3)
 };


### PR DESCRIPTION
Remake of Califa Hit finder class. Some new features :

- Addition of Get Crystal List method. Retrieves a list of crystals that belong to the cluster :
`std::vector<Int_t> crystalList` 
`crystalList = hit->GetCrystalList()`

The first element of the list is the one that was taken as a cluster center candidate (the one with more energy inside the cluster). That one is also the crystal that gives angular information.

- Cluster Thresholds. There are three different clusters : gammas , protons and saturated (with a gamma saturated crystal as cluster candidate). Each one has its own energy threshold. Typical Usage : 
  
   `R3BCalifaCrystalCal2Hit* CalifaCal2Hit = new R3BCalifaCrystalCal2Hit();`
     `CalifaCal2Hit->SetRandomization(kTRUE);`
     `CalifaCal2Hit->SetRandomizationFile("angular_histograms.root");`
     `CalifaCal2Hit->SetClusterWindow(0.25);`
     `CalifaCal2Hit->SetCrystalThreshold(200); `
     `CalifaCal2Hit->SetGammaClusterThreshold(800);`
     `CalifaCal2Hit->SetProtonClusterThreshold(50000);`
     `CalifaCal2Hit->SetSaturationEnergy(30000);`
     `CalifaCal2Hit->IsSimulation(kFALSE);`

- Is Simulation flag.
- Cluster Types. Gamma, proton and saturated clusters are retrieved by :
`Int_t clusterType = hit -> GetClusterType()` (0 for protons, 1 for gammas and 2 for saturated )
