### PR TITLE
Adding R3BLogger.h to the HEADERS in the CMake file

### DIFF
--- a/r3bbase/CMakeLists.txt
+++ b/r3bbase/CMakeLists.txt
@@ -50,6 +50,7 @@ file(GLOB SRCS
 # fill list of header files from list of source files
 # by exchanging the file extension
 CHANGE_FILE_EXTENSION(*.cxx *.h HEADERS "${SRCS}")
+install(FILES "R3BLogger.h" DESTINATION include)
 
 Set(LINKDEF BaseLinkDef.h)
 


### PR DESCRIPTION
Since R3BLogger class has only header file, the header name won't be included in variable `${HEADERS}`. Thus, installing R3BRoot using command `make install` won't install `R3BLogger.h` into the designated folder.

Adding the header name to `${HEADERS}` fixes this issue.