### PR TITLE
Rewrite NeuLAND simulated digitisation modules

### DIFF
--- a/neuland/digitizing/CMakeLists.txt
+++ b/neuland/digitizing/CMakeLists.txt
@@ -13,6 +13,7 @@
 
 set(INCLUDE_DIRECTORIES 
 ${INCLUDE_DIRECTORIES} 
+${R3BROOT_SOURCE_DIR}/neuland/calibration
 ${R3BROOT_SOURCE_DIR}/neuland/digitizing
 )
 include_directories(${INCLUDE_DIRECTORIES})
@@ -29,6 +30,6 @@ CHANGE_FILE_EXTENSION(*.cxx *.h HEADERS "${SRCS}")
 
 set(LINKDEF NeulandDigitizingLinkDef.h)
 set(LIBRARY_NAME R3BNeulandDigitizing)
-set(DEPENDENCIES R3BNeulandShared R3BData)
+set(DEPENDENCIES R3BNeulandShared R3BData R3BNeulandCalibration)
 
 GENERATE_LIBRARY()

--- a/neuland/digitizing/DigitizingEngine.cxx
+++ b/neuland/digitizing/DigitizingEngine.cxx
@@ -20,6 +20,18 @@ namespace Neuland
 {
     namespace Digitizing
     {
+
+        template <Int_t iterations = 8>
+        const Float_t FastExp(const Float_t val)
+        {
+            auto exp = 1.f + val / (1 << iterations);
+            for (auto i = 0; i < iterations; ++i)
+            {
+                exp *= exp;
+            }
+            return exp;
+        }
+
         // Calculate the time of arrival and the amount of light that arrives at
         // the PMT based on the deposition in the paddle
         PMTHit::PMTHit(const Double_t mcTime, const Double_t mcLight, const Double_t dist)
@@ -28,10 +40,31 @@ namespace Neuland
             light = mcLight * exp(-Paddle::gAttenuation * (Paddle::gHalfLength + dist));
         }
 
-        Paddle::Paddle(std::unique_ptr<Channel> l, std::unique_ptr<Channel> r)
+        Channel::Channel(SideOfChannel side)
+            : fSide(side)
+        {
+        }
+
+        const std::vector<Channel::Signal>& Channel::GetSignals() const
+        {
+            if (!fSignals.valid())
+                ConstructSignals();
+            return fSignals.getRef();
+        }
+
+        Paddle::Paddle(const Int_t paddleID,
+                       std::unique_ptr<Channel> l,
+                       std::unique_ptr<Channel> r,
+                       R3BNeulandHitPar* par)
             : fLeftChannel(std::move(l))
             , fRightChannel(std::move(r))
+            , fPaddleId(paddleID)
         {
+            if (fLeftChannel->GetSide() != Channel::left && fRightChannel->GetSide() != Channel::right)
+                LOG(fatal) << "DigitizingEngine::Paddle ctor: side of channels is not correct!";
+            SetHitModulePar(par);
+            fLeftChannel->SetPaddle(this);
+            fRightChannel->SetPaddle(this);
         }
 
         void Paddle::DepositLight(const Double_t time, const Double_t light, const Double_t dist)
@@ -40,7 +73,16 @@ namespace Neuland
             fRightChannel->AddHit(time, light, dist);
         }
 
-        bool Paddle::HasFired() const { return (fLeftChannel->HasFired() && fRightChannel->HasFired()); }
+        bool Paddle::HasFired() const
+        {
+            if (fLeftChannel.get() && fRightChannel.get())
+                return (fLeftChannel->HasFired() && fRightChannel->HasFired());
+            else
+            {
+                LOG(fatal) << "channels failed to be constructed when checking fire! ";
+                return false;
+            }
+        }
 
         bool Paddle::HasHalfFired() const
         {
@@ -48,32 +90,168 @@ namespace Neuland
                    (!fLeftChannel->HasFired() && fRightChannel->HasFired());
         }
 
-        Double_t Paddle::GetEnergy(UShort_t index) const
+        inline Double_t Paddle::ComputeEnergy(const Channel::Signal& firstSignal,
+                                              const Channel::Signal& secondSignal) const
         {
-            return std::sqrt(fLeftChannel->GetEnergy(index) * fRightChannel->GetEnergy(index));
+            return std::sqrt(firstSignal.energy * secondSignal.energy);
         }
 
-        Double_t Paddle::GetTime(UShort_t index) const
+        inline Double_t Paddle::ComputeTime(const Channel::Signal& firstSignal,
+                                            const Channel::Signal& secondSignal) const
         {
-            return (fLeftChannel->GetTDC(index) + fRightChannel->GetTDC(index)) / 2. - gHalfLength / gCMedium;
+            return (firstSignal.tdc + secondSignal.tdc) / 2. - gHalfLength / gCMedium;
         }
 
-        Double_t Paddle::GetPosition(UShort_t index) const
+        inline Double_t Paddle::ComputePosition(const Channel::Signal& leftSignal,
+                                                const Channel::Signal& rightSignal) const
         {
-            return (fRightChannel->GetTDC(index) - fLeftChannel->GetTDC(index)) / 2. * gCMedium;
+            assert((leftSignal.side == Channel::left) && (rightSignal.side == Channel::right));
+            return (rightSignal.tdc - leftSignal.tdc) / 2. * gCMedium;
         }
 
-        const UShort_t Paddle::GetNHits() const
+        Float_t Paddle::CompareSignals(const Channel::Signal& firstSignal, const Channel::Signal& secondSignal) const
         {
-            if (fRightChannel->GetNHits() != fLeftChannel->GetNHits())
-            {
-                LOG(ERROR) << "DigitizingEngine: nhits from both side of PMTs don't match!";
-                return 0;
-            }
+            auto firstE = static_cast<Float_t>(firstSignal.energy);
+            auto secondE = static_cast<Float_t>(secondSignal.energy);
+            auto firstT = firstSignal.tdc;
+            auto secondT = secondSignal.tdc;
+
+            // keep the exponent always negative to prevent the exploding of exponential function
+            if (firstT > secondT)
+                return std::abs((firstE / secondE) *
+                                    FastExp<4>(static_cast<Float_t>(gAttenuation * gCMedium * (firstT - secondT))) -
+                                1);
             else
+                return std::abs((secondE / firstE) *
+                                    FastExp<4>(static_cast<Float_t>(gAttenuation * gCMedium *
+                                                                    static_cast<Float_t>(secondT - firstT))) -
+                                1);
+        }
+
+        std::vector<Paddle::Pair<int>> Paddle::ConstructIndexMap(const ChannelSignals& leftSignals,
+                                                                 const ChannelSignals& rightSignals) const
+        {
+            if (leftSignals.size() == 0 || rightSignals.size() == 0)
+                LOG(fatal) << "DigitizingEngine.cxx::GetIndexMap(): Can't get index map from the signals with size 0.";
+
+            assert((leftSignals[0].side == Channel::left) && (rightSignals[0].side == Channel::right));
+
+            auto indexMap = std::vector<Pair<int>>(leftSignals.size(), { -1, -1 });
+            auto valueMap = std::vector<Double_t>(leftSignals.size(), 0);
+
+            for (auto i = 0; i < indexMap.size(); i++)
             {
-                return fRightChannel->GetNHits();
+                std::vector<Double_t> compareValues(rightSignals.size());
+                for (auto j = 0; j < rightSignals.size(); j++)
+                {
+                    compareValues[j] = CompareSignals(leftSignals[i], rightSignals[j]);
+                }
+                auto compareValues_it = std::min_element(
+                    compareValues.begin(), compareValues.end(), [](const Double_t& left, const Double_t& right) {
+                        return left < right;
+                    });
+
+                if (compareValues_it == compareValues.end())
+                    LOG(fatal) << "DigitizingEngine.cxx::GetIndexMap(): failed to find minimum value!";
+
+                valueMap[i] = *compareValues_it;
+                auto indexMatch = static_cast<int>(compareValues_it - compareValues.begin());
+
+                auto findResult = std::find_if(indexMap.begin(), indexMap.end(), [indexMatch](const Pair<int>& pair) {
+                    return pair.right == indexMatch;
+                });
+                if (findResult == indexMap.end())
+                {
+                    indexMap[i] = { i, indexMatch };
+                }
+                else
+                {
+                    if (*compareValues_it > valueMap[findResult->left])
+                        indexMap[i] = { i, -1 };
+                    else
+                    {
+                        indexMap[findResult->left].right = -1;
+                        indexMap[i] = { i, indexMatch };
+                    }
+                }
             }
+            return indexMap;
+        }
+
+        std::vector<Paddle::Signal> Paddle::ConstructPaddelSignals(const ChannelSignals& leftSignals,
+                                                                   const ChannelSignals& rightSignals,
+                                                                   const std::vector<Pair<int>>& indexMapping) const
+        {
+            if (leftSignals.size() == 0 || rightSignals.size() == 0)
+                LOG(fatal) << "DigitizingEngine.cxx::ConstructpaddleSignals(): Can't construct from the channel "
+                              "signals with size 0.";
+
+            assert((leftSignals[0].side == Channel::left) && (rightSignals[0].side == Channel::right));
+
+            auto paddleSignals = std::vector<Signal>();
+            paddleSignals.reserve(indexMapping.size());
+
+            for (const auto it : indexMapping)
+            {
+                if (it.right < 0)
+                    continue;
+
+                assert((it.left < leftSignals.size()) && (it.right < rightSignals.size()));
+
+                auto paddleSignal = Signal{ leftSignals[it.left], rightSignals[it.right] };
+
+                paddleSignal.energy = ComputeEnergy(leftSignals[it.left], rightSignals[it.right]);
+                paddleSignal.time = ComputeTime(leftSignals[it.left], rightSignals[it.right]);
+                paddleSignal.position = ComputePosition(leftSignals[it.left], rightSignals[it.right]);
+
+                paddleSignals.push_back(std::move(paddleSignal));
+            }
+            return paddleSignals;
+        }
+
+        void Paddle::SetHitModulePar(R3BNeulandHitPar* par)
+        {
+            if (fPaddleId < 0)
+                LOG(fatal) << "NeulandPaddle: parameters cannot be initilizied without setting paddle ID first!";
+
+            if (par)
+            {
+                auto PaddleId_max = par->GetNumModulePar();
+                if (fPaddleId > PaddleId_max)
+                {
+                    LOG(fatal) << "Paddle id exceeds the id in the parameter file!";
+                }
+                else
+                {
+                    fHitModulePar = par->GetModuleParAt(fPaddleId - 1);
+                    if (!fHitModulePar)
+                        LOG(warn) << "hitModulePar failed to be read!";
+                    if (fPaddleId != fHitModulePar->GetModuleId())
+                        LOG(warn) << "Wrong paddleID for the parameters!";
+                }
+            }
+        }
+
+        const std::vector<Paddle::Signal>& Paddle::GetSignals() const
+        {
+            if (!fSignals.valid())
+            {
+                if (HasFired())
+                {
+                    auto indexmap = std::vector<Pair<int>>{ { 0, 0 } };
+
+                    if (fLeftChannel->GetSignals().size() != 1 || fRightChannel->GetSignals().size() != 1)
+                        indexmap = ConstructIndexMap(fLeftChannel->GetSignals(), fRightChannel->GetSignals());
+
+                    auto signals = ConstructPaddelSignals(
+                        fLeftChannel->GetSignals(), fRightChannel->GetSignals(), std::move(indexmap));
+                    fSignals.set(std::move(signals));
+                }
+                else
+                    fSignals.set({});
+            }
+
+            return fSignals.getRef();
         }
     } // namespace Digitizing
 
@@ -84,8 +262,11 @@ namespace Neuland
     {
         if (paddles.find(paddle_id) == paddles.end())
         {
-            paddles[paddle_id] =
-                std::unique_ptr<Digitizing::Paddle>(new Digitizing::Paddle(this->BuildChannel(), this->BuildChannel()));
+            paddles[paddle_id] = std::unique_ptr<Digitizing::Paddle>(
+                new Digitizing::Paddle(paddle_id,
+                                       this->BuildChannel(Digitizing::Channel::left),
+                                       this->BuildChannel(Digitizing::Channel::right),
+                                       fNeulandHitPar));
         }
         paddles.at(paddle_id)->DepositLight(time, light, dist);
     }
@@ -98,13 +279,13 @@ namespace Neuland
             const auto& paddle = kv.second;
 
             // TODO: Should be easier with std::min?
-            if (paddle->GetLeftChannel()->HasFired() && paddle->GetLeftChannel()->GetTDC(0) < triggerTime)
+            if (paddle->GetLeftChannel()->HasFired() && paddle->GetLeftChannel()->GetTrigTime() < triggerTime)
             {
-                triggerTime = paddle->GetLeftChannel()->GetTDC(0);
+                triggerTime = paddle->GetLeftChannel()->GetTrigTime();
             }
-            if (paddle->GetRightChannel()->HasFired() && paddle->GetRightChannel()->GetTDC(0) < triggerTime)
+            if (paddle->GetRightChannel()->HasFired() && paddle->GetRightChannel()->GetTrigTime() < triggerTime)
             {
-                triggerTime = paddle->GetRightChannel()->GetTDC(0);
+                triggerTime = paddle->GetRightChannel()->GetTrigTime();
             }
         }
         return triggerTime;

--- a/neuland/digitizing/DigitizingEngine.h
+++ b/neuland/digitizing/DigitizingEngine.h
@@ -14,11 +14,13 @@
 #ifndef NEULAND_DIGITIZING_ENGINE_H
 #define NEULAND_DIGITIZING_ENGINE_H
 
+#include "FairLogger.h"
+#include "R3BNeulandHitPar.h"
 #include "Rtypes.h"
+#include "Validated.h"
 #include <map>
 #include <memory>
 #include <vector>
-#include "FairLogger.h"
 
 namespace Neuland
 {
@@ -35,46 +37,128 @@ namespace Neuland
             PMTHit(Double_t mcTime, Double_t mcLight, Double_t dist);
         };
 
+        class Paddle;
+
+        // channels of PMT plus digitisation module. Input interaction points and output digital signals.
         class Channel
         {
           public:
+            enum SideOfChannel
+            {
+                right = 1,
+                left = 2
+            };
+
+            struct Signal
+            {
+                Double_t qdc{};
+                Double_t tdc{};
+                Double_t energy{};
+                SideOfChannel side{};
+                Signal() = default;
+                Signal(Double_t q, Double_t t, Double_t e, SideOfChannel s)
+                    : qdc{ q }
+                    , tdc{ t }
+                    , energy{ e }
+                    , side{ s }
+                {
+                }
+            };
+
+            Channel(SideOfChannel);
             virtual ~Channel() = default; // FIXME: Root doesn't like pure virtual destructors (= 0;)
             virtual void AddHit(Double_t mcTime, Double_t mcLight, Double_t dist) = 0;
             virtual bool HasFired() const = 0;
-            virtual Double_t GetQDC(UShort_t index) const = 0;
-            virtual Double_t GetTDC(UShort_t index) const = 0;
-            virtual Double_t GetEnergy(UShort_t index) const = 0;
-            virtual Int_t GetNHits() const {return 1;};
+            virtual void SetPaddle(Paddle* paddle) { fPaddle = paddle; };
+            virtual const Double_t GetTrigTime() const = 0;
+
+            const std::vector<Signal>& GetSignals() const;
+            const SideOfChannel GetSide() const { return fSide; }
 
           protected:
-            std::vector<PMTHit> fPMTHits;
+            std::vector<PMTHit> fPMTHits;                    // input PMT hits to the channel
+            const SideOfChannel fSide;                       // side of the channel
+            mutable Validated<std::vector<Signal>> fSignals; // output signals from the channel
+            Paddle* fPaddle;                                 // pointer to the paddle who owns this channel
+
+          private:
+            virtual void ConstructSignals() const = 0;
         };
 
         class Paddle
         {
           public:
-            Paddle(std::unique_ptr<Channel> l, std::unique_ptr<Channel> r);
+            template <class T>
+            struct Pair
+            {
+                T left;
+                T right;
+                Pair(T l, T r)
+                    : left(l)
+                    , right(r){};
+            };
+
+            struct Signal
+            {
+                Double_t energy{};
+                Double_t time{};
+                Double_t position{};
+                const Channel::Signal& leftChannel;
+                const Channel::Signal& rightChannel;
+                Signal(const Channel::Signal& leftSignal, const Channel::Signal& rightSignal)
+                    : leftChannel{ leftSignal }
+                    , rightChannel{ rightSignal }
+                {
+                }
+            };
+
+            Paddle(const Int_t paddleID,
+                   std::unique_ptr<Channel> l,
+                   std::unique_ptr<Channel> r,
+                   R3BNeulandHitPar* par = nullptr);
+            virtual ~Paddle() {}
             void DepositLight(Double_t time, Double_t light, Double_t dist);
 
             bool HasFired() const;
             bool HasHalfFired() const;
-            Double_t GetEnergy(UShort_t index = 0) const;
-            Double_t GetTime(UShort_t index = 0) const;
-            Double_t GetPosition(UShort_t index = 0) const;
-            const UShort_t GetNHits() const;
+
+            void SetHitModulePar(R3BNeulandHitPar* par);
+            R3BNeulandHitModulePar* GetHitModulePar() const { return fHitModulePar; }
+
+            Int_t GetPaddleId() const { return fPaddleId; }
+            const std::vector<Signal>& GetSignals() const;
 
             const Channel* GetLeftChannel() const { return fLeftChannel.get(); }
             const Channel* GetRightChannel() const { return fRightChannel.get(); }
 
           protected:
+            using ChannelSignals = std::vector<Channel::Signal>;
+            using PaddleSignals = std::vector<Signal>;
             std::unique_ptr<Channel> fLeftChannel;
             std::unique_ptr<Channel> fRightChannel;
+            R3BNeulandHitModulePar* fHitModulePar = nullptr;
+            mutable Validated<PaddleSignals> fSignals;
+            const Int_t fPaddleId;
 
           public:
             static constexpr Double_t gHalfLength = 135.;   // [cm]
             static constexpr Double_t gCMedium = 14.;       // speed of light in material in [cm/ns]
             static constexpr Double_t gAttenuation = 0.008; // light attenuation of plastic scintillator [1/cm]
             static constexpr Double_t gLambda = 1. / 2.1;
+
+          private:
+            virtual std::vector<Pair<int>> ConstructIndexMap(const ChannelSignals& leftSignals,
+                                                             const ChannelSignals& rightSignals) const;
+            virtual PaddleSignals ConstructPaddelSignals(const ChannelSignals& leftSignals,
+                                                         const ChannelSignals& rightSignals,
+                                                         const std::vector<Pair<int>>& indexMapping) const;
+            virtual Float_t CompareSignals(const Channel::Signal& firstSignal,
+                                           const Channel::Signal& secondSignal) const;
+            virtual Double_t ComputeTime(const Channel::Signal& firstSignal, const Channel::Signal& secondSignal) const;
+            virtual Double_t ComputeEnergy(const Channel::Signal& firstSignal,
+                                           const Channel::Signal& secondSignal) const;
+            virtual Double_t ComputePosition(const Channel::Signal& rightSignal,
+                                             const Channel::Signal& leftSignal) const;
         };
     } // namespace Digitizing
 
@@ -83,14 +167,16 @@ namespace Neuland
     {
       public:
         virtual ~DigitizingEngine() = default; // FIXME: Root doesn't like pure virtual destructors (= 0;)
-        virtual std::unique_ptr<Digitizing::Channel> BuildChannel() = 0;
+        virtual std::unique_ptr<Digitizing::Channel> BuildChannel(Digitizing::Channel::SideOfChannel) = 0;
 
+        void SetHitPar(R3BNeulandHitPar* par) { fNeulandHitPar = par; }
         void DepositLight(Int_t paddle_id, Double_t time, Double_t light, Double_t dist);
         Double_t GetTriggerTime() const;
         std::map<Int_t, std::unique_ptr<Digitizing::Paddle>> ExtractPaddles();
 
       protected:
         std::map<Int_t, std::unique_ptr<Digitizing::Paddle>> paddles;
+        R3BNeulandHitPar* fNeulandHitPar = nullptr;
     };
 } // namespace Neuland
 

--- a/neuland/digitizing/DigitizingTacQuila.cxx
+++ b/neuland/digitizing/DigitizingTacQuila.cxx
@@ -32,8 +32,8 @@ namespace Neuland
         {
         }
 
-        Channel::Channel(const Params& p)
-            : par(p)
+        Channel::Channel(const Params& p, SideOfChannel side)
+            : par(p), Digitizing::Channel(side)
         {
         }
 
@@ -59,7 +59,7 @@ namespace Neuland
             return cachedFirstHitOverThresh.get() != fPMTHits.end();
         }
 
-        Double_t Channel::GetQDC(UShort_t index) const
+        Double_t Channel::GetQDC() const
         {
             if (!cachedQDC.valid())
             {
@@ -68,7 +68,7 @@ namespace Neuland
             return cachedQDC;
         }
 
-        Double_t Channel::GetTDC(UShort_t index) const
+        Double_t Channel::GetTDC() const
         {
             if (!cachedTDC.valid())
             {
@@ -77,7 +77,7 @@ namespace Neuland
             return cachedTDC;
         }
 
-        Double_t Channel::GetEnergy(UShort_t index) const
+        Double_t Channel::GetEnergy() const
         {
             if (!cachedEnergy.valid())
             {
@@ -124,7 +124,7 @@ namespace Neuland
 
         Double_t Channel::BuildEnergy() const
         {
-            Double_t e = GetQDC(0);
+            Double_t e = GetQDC();
             // Apply reverse attenuation (TODO: Should be last?)
             e = e * exp((2. * (Digitizing::Paddle::gHalfLength)) * Digitizing::Paddle::gAttenuation / 2.);
             // Apply saturation
@@ -178,8 +178,8 @@ namespace Neuland
     {
     }
 
-    std::unique_ptr<Digitizing::Channel> DigitizingTacQuila::BuildChannel()
+    std::unique_ptr<Digitizing::Channel> DigitizingTacQuila::BuildChannel(Digitizing::Channel::SideOfChannel side)
     {
-        return std::unique_ptr<Digitizing::Channel>(new TacQuila::Channel(fTQP));
+        return std::unique_ptr<Digitizing::Channel>(new TacQuila::Channel(fTQP, side));
     }
 }; // namespace Neuland

--- a/neuland/digitizing/DigitizingTacQuila.h
+++ b/neuland/digitizing/DigitizingTacQuila.h
@@ -38,13 +38,14 @@ namespace Neuland
         class Channel : public Digitizing::Channel
         {
           public:
-            explicit Channel(const TacQuila::Params&);
+            explicit Channel(const TacQuila::Params&, SideOfChannel);
             ~Channel() override = default;
             void AddHit(Double_t mcTime, Double_t mcLight, Double_t dist) override;
             bool HasFired() const override;
-            Double_t GetQDC(UShort_t index) const override;
-            Double_t GetTDC(UShort_t index) const override;
-            Double_t GetEnergy(UShort_t index) const override;
+            Double_t GetQDC() const;
+            Double_t GetTDC() const;
+            Double_t GetEnergy() const;
+            const Double_t GetTrigTime() const override { return GetTDC(); } 
 
           private:
             // NOTE: Some expensive calculations and random distributions are cached
@@ -62,6 +63,11 @@ namespace Neuland
             mutable Validated<Double_t> cachedEnergy;
 
             const TacQuila::Params& par;
+
+            void ConstructSignals() const override
+            {
+                 fSignals.set({Signal{GetQDC(), GetTDC(), GetEnergy(), this->GetSide()}});
+            }
         };
 
     } // namespace TacQuila
@@ -71,7 +77,7 @@ namespace Neuland
       public:
         DigitizingTacQuila();
         ~DigitizingTacQuila() override = default;
-        std::unique_ptr<Digitizing::Channel> BuildChannel() override;
+        std::unique_ptr<Digitizing::Channel> BuildChannel(Digitizing::Channel::SideOfChannel side) override;
 
         void SetPMTThreshold(const Double_t v) { fTQP.fPMTThresh = v; }
         void SetSaturationCoefficient(const Double_t v) { fTQP.fSaturationCoefficient = v; }

--- a/neuland/digitizing/R3BNeulandDigitizer.cxx
+++ b/neuland/digitizing/R3BNeulandDigitizer.cxx
@@ -45,22 +45,33 @@ void R3BNeulandDigitizer::SetParContainers()
     FairRunAna* run = FairRunAna::Instance();
     if (!run)
     {
-        LOG(FATAL) << "R3BNeulandDigitizer::SetParContainers: No analysis run";
+        LOG(fatal) << "R3BNeulandDigitizer::SetParContainers: No analysis run";
         return;
     }
 
     FairRuntimeDb* rtdb = run->GetRuntimeDb();
     if (!rtdb)
     {
-        LOG(FATAL) << "R3BNeulandDigitizer::SetParContainers: No runtime database";
+        LOG(fatal) << "R3BNeulandDigitizer::SetParContainers: No runtime database";
         return;
     }
 
-    fNeulandGeoPar = (R3BNeulandGeoPar*)rtdb->getContainer("R3BNeulandGeoPar");
+    fNeulandGeoPar = dynamic_cast<R3BNeulandGeoPar*>(rtdb->getContainer("R3BNeulandGeoPar"));
     if (!fNeulandGeoPar)
     {
-        LOG(FATAL) << "R3BNeulandDigitizer::SetParContainers: No R3BNeulandGeoPar";
+        LOG(fatal) << "R3BNeulandDigitizer::SetParContainers: No R3BNeulandGeoPar";
         return;
+    }
+
+    auto fNeulandHitPar = dynamic_cast<R3BNeulandHitPar*>(rtdb->findContainer(fHitParName));
+    if (fNeulandHitPar)
+    {
+        LOG(info) << "R3BNeulandDigitizer::SetHitParContainers: HitPar found from " << fHitParName;
+        fDigitizingEngine->SetHitPar(fNeulandHitPar);
+    }
+    else
+    {
+        LOG(info) << "R3BNeulandDigitizer::SetHitParContainers: HitPar rootfile not found. Using default values.";
     }
 }
 
@@ -96,9 +107,9 @@ void R3BNeulandDigitizer::Exec(Option_t*)
             // Convert position of point to paddle-coordinates, including any rotation or translation
             const TVector3 position = point->GetPosition();
             const TVector3 converted_position = fNeulandGeoPar->ConvertToLocalCoordinates(position, paddleID);
-            LOG(DEBUG) << "NeulandDigitizer: Point in paddle " << paddleID
+            LOG(debug) << "NeulandDigitizer: Point in paddle " << paddleID
                        << " with global position XYZ: " << position.X() << " " << position.Y() << " " << position.Z();
-            LOG(DEBUG) << "NeulandDigitizer: Converted to local position XYZ: " << converted_position.X() << " "
+            LOG(debug) << "NeulandDigitizer: Converted to local position XYZ: " << converted_position.X() << " "
                        << converted_position.Y() << " " << converted_position.Z();
 
             // Within the paddle frame, the relevant distance of the light from the pmt is always given by the
@@ -115,15 +126,13 @@ void R3BNeulandDigitizer::Exec(Option_t*)
     // Fill control histograms
     hMultOne->Fill(std::count_if(paddles.begin(),
                                  paddles.end(),
-                                 [](const std::pair<const Int_t, std::unique_ptr<Neuland::Digitizing::Paddle>>& kv) {
-                                     return kv.second->HasHalfFired();
-                                 }));
+                                 [](const std::pair<const Int_t, std::unique_ptr<Neuland::Digitizing::Paddle>>& kv)
+                                 { return kv.second->HasHalfFired(); }));
 
     hMultTwo->Fill(std::count_if(paddles.begin(),
                                  paddles.end(),
-                                 [](const std::pair<const Int_t, std::unique_ptr<Neuland::Digitizing::Paddle>>& kv) {
-                                     return kv.second->HasFired();
-                                 }));
+                                 [](const std::pair<const Int_t, std::unique_ptr<Neuland::Digitizing::Paddle>>& kv)
+                                 { return kv.second->HasFired(); }));
 
     // Create Hits
     for (const auto& kv : paddles)
@@ -136,31 +145,34 @@ void R3BNeulandDigitizer::Exec(Option_t*)
             continue;
         }
 
-        for (UInt_t i = 0; i < paddle->GetNHits(); i++)
+        auto signals = paddle->GetSignals();
+
+        for (const auto signal : signals)
         {
-            const TVector3 hitPositionLocal = TVector3(paddle->GetPosition(i), 0., 0.);
+            const TVector3 hitPositionLocal = TVector3(signal.position, 0., 0.);
             const TVector3 hitPositionGlobal = fNeulandGeoPar->ConvertToGlobalCoordinates(hitPositionLocal, paddleID);
             const TVector3 hitPixel = fNeulandGeoPar->ConvertGlobalToPixel(hitPositionGlobal);
 
             R3BNeulandHit hit(paddleID,
-                              paddle->GetLeftChannel()->GetTDC(i),
-                              paddle->GetRightChannel()->GetTDC(i),
-                              paddle->GetTime(i),
-                              paddle->GetLeftChannel()->GetEnergy(i),
-                              paddle->GetRightChannel()->GetEnergy(i),
-                              paddle->GetEnergy(i),
+                              signal.leftChannel.tdc,
+                              signal.rightChannel.tdc,
+                              signal.time,
+                              signal.leftChannel.energy,
+                              signal.rightChannel.energy,
+                              signal.energy,
                               hitPositionGlobal,
                               hitPixel);
 
             if (fHitFilters.IsValid(hit))
             {
                 fHits.Insert(std::move(hit));
+                LOG(debug) << "Adding neuland hit with id = " << paddleID << ", time = " << signal.time
+                           << ", energy = " << signal.energy;
             }
         } // loop over all hits for each paddle
+    }     // loop over paddles
 
-    } // loop over paddles
-
-    LOG(DEBUG) << "R3BNeulandDigitizer: produced " << fHits.Size() << " hits";
+    LOG(debug) << "R3BNeulandDigitizer: produced " << fHits.Size() << " hits";
 }
 
 void R3BNeulandDigitizer::Finish()

--- a/neuland/digitizing/R3BNeulandDigitizer.h
+++ b/neuland/digitizing/R3BNeulandDigitizer.h
@@ -19,6 +19,7 @@
 #include "Filterable.h"
 #include "R3BNeulandGeoPar.h"
 #include "R3BNeulandHit.h"
+#include "R3BNeulandHitPar.h"
 #include "R3BNeulandPoint.h"
 #include "TCAConnector.h"
 
@@ -62,6 +63,7 @@ class R3BNeulandDigitizer : public FairTask
   public:
     void Exec(Option_t*) override;
     void AddFilter(const Filterable<R3BNeulandHit&>::Filter& f) { fHitFilters.Add(f); }
+    void SetHitParName(const TString& name) { fHitParName = name; };
 
   private:
     TCAInputConnector<R3BNeulandPoint> fPoints;
@@ -73,6 +75,7 @@ class R3BNeulandDigitizer : public FairTask
 
     R3BNeulandGeoPar* fNeulandGeoPar; // non-owning
 
+    TString fHitParName{};
     TH1F* hMultOne;
     TH1F* hMultTwo;
     TH1F* hRLTimeToTrig;


### PR DESCRIPTION
The new digitisation module takes into the consideration both multi-hit property of TAMEX digitiser and signal overlapping of PMTs.

Previous version could not and failed to merge two PMT signals that are temporally close, which leads to a massive increase of hit sizes per bar. The new version assigns every PMT signal with a (temporal) width. Two signals would be added up linearly into a single signal if their temporal difference is smaller than the width of the early arrived signal, a.k.a, signal overlapping.

The value of signal width is calculated by the equation:
```
width = qdc * a + b
```
Users can either adopt the default values of a&b or import a parameter file containing `R3BNeulandHitPar` and specify it using:
```cpp
R3BNeulandDigitizer::SetHitParName("name_of_your_parameter");
```

The abstraction of digitisation modules is also modified to increase the memory safety of the code (out-of-bounds read).
For obtaining the energy values of each signals, Instead of 
```cpp
auto e = Digitizing::Paddle::GetEnergy(Int_t index);
```
now, user can only obtain the energy value from the output signals:
```cpp
auto signals = Digitizing::Paddle::GetSignals();
for(const auto& signal : signals)
{
    auto e = signal.energy;
}
```

Further work will be done to include the similar simulated digitisation of TofD and a detailed markdown file about how to use classes in this module will be provided soon.

If anyone has any suggestions, regarding the code format or general way of implementations, please don't hesitate to comment below.