### PR TITLE
add ignore for .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ macros/
 .cache
 .idea/
 .vscode/
+.DS_Store
 build-r3broot.sh
 cmake-build-debug/
 


### PR DESCRIPTION
Add an additional git ignore for .DS_Store file which can be generated automatically in macOS.