### PR TITLE
Remove '#ifdef EXT_DATA_ITEM_MAP_MATCH', to always use struct_map_success

### DIFF
--- a/r3bsource/base/R3BUcesbSource.cxx
+++ b/r3bsource/base/R3BUcesbSource.cxx
@@ -151,13 +151,9 @@ Bool_t R3BUcesbSource::InitUnpackers()
     }
 
     /* Setup client */
-#ifdef EXT_DATA_ITEM_MAP_MATCH
     /* this is the version for ucesb setup with extended mapping info */
     uint32_t struct_map_success = 0;
     Bool_t status = fClient.setup(NULL, 0, &fStructInfo, &struct_map_success, fEventSize);
-#else
-    Bool_t status = fClient.setup(NULL, 0, &fStructInfo, fEventSize);
-#endif
     if (status != 0)
     {
         // perror("ext_data_clnt::setup()");
@@ -165,7 +161,6 @@ Bool_t R3BUcesbSource::InitUnpackers()
         R3BLOG(fatal, "UCESB error: " << fClient.last_error());
         return kFALSE;
     }
-#ifdef EXT_DATA_ITEM_MAP_MATCH
     /*
      * It is not needed, that *all* items are matched.
      * However, mapping should fail, if items are requested that don't exist
@@ -179,7 +174,6 @@ Bool_t R3BUcesbSource::InitUnpackers()
         ext_data_struct_info_print_map_success(fStructInfo, stderr, map_ok);
         return kFALSE;
     }
-#endif
 
     return kTRUE;
 }


### PR DESCRIPTION
See discussion in #705 .

This patch would make sure to always check that all requested data members have sources in the input.

Please someone try it out, so we can figure out either why the code was not called, or why it does not report the missing overflow item.