### PR TITLE
Report FATAL error when ext_data_clnt::setup() failed to map all items.

### DIFF
--- a/r3bsource/base/R3BUcesbSource.cxx
+++ b/r3bsource/base/R3BUcesbSource.cxx
@@ -173,9 +173,9 @@ Bool_t R3BUcesbSource::InitUnpackers()
         R3BLOG(warn, "ext_data_clnt::setup() failed to map all items:");
         ext_data_struct_info_print_map_success(fStructInfo, stderr, map_ok);
         /* FairRunOnline::Init() ignores the return value from
-         * GetSource()->InitUnpackers(); so do a (FATAL) error.
+         * GetSource()->InitUnpackers(); so do a FATAL error.
          */
-        R3BLOG(error,
+        R3BLOG(fatal,
                "ext_data_clnt::setup() mapping failure may "
                "cause unexpected analysis results due to missing "
                "data members. Unpacker needs fixing.");


### PR DESCRIPTION
See discussion in #705 .

This patch to exit processing if any requested data members have no source in the input, such that user is alerted and does not get unexpected results.

Please try it out to see what detectors may have issues.