### PR TITLE
WIP: Trying to figure out why travis-clang-format-check.sh fails.

### DIFF
--- a/travis-clang-format-check.sh
+++ b/travis-clang-format-check.sh
@@ -6,6 +6,10 @@ CLANG_FORMAT=${1:-clang-format}
 echo -n "Running clang-format checks, version: "
 ${CLANG_FORMAT} --version
 
+echo "*** git describe : " ; /usr/bin/git describe --always
+echo "*** git log --oneline --all --decorate --graph : " ; /usr/bin/git log --oneline --all --decorate --graph
+echo "***"
+
 if [ 0 != $? ]; then
     echo -e "\033[1;31mclang-format missing: ${CLANG_FORMAT}\033[0m"
     exit 1


### PR DESCRIPTION
Do not merge!

This PR is trying to figure out why the CI prints git errors for the clang-format-check tests.

(I'm probably clumsy doing this via a PR.  Presumably there is a better way to CI test code without making a PR?)