### PR TITLE
Small spell fix that triggers format check failure.

### DIFF
--- a/r3bsource/base/R3BUcesbSource.cxx
+++ b/r3bsource/base/R3BUcesbSource.cxx
@@ -73,7 +73,7 @@ Bool_t R3BUcesbSource::Init()
     else
     {
         eventHeader = new R3BEventHeader();
-        run -> SetEventHeader(eventHeader); // implicit conversion and trasfer ownership to FairRun
+        run -> SetEventHeader(eventHeader); // Implicit conversion and transfer ownership to FairRun
         R3BLOG(WARNING, "EventHeader. has been created from R3BEventHeader");
     }
 

--- a/travis-clang-format-check.sh
+++ b/travis-clang-format-check.sh
@@ -13,12 +13,17 @@ fi
 
 if [ "$TRAVIS" != "true" ] ; then
   # Not in a pull request, so compare against parent commit
-  base_commit="HEAD^"
+  base_commit="origin/dev"
   echo "Checking against parent commit $(git rev-parse $base_commit)"
 else
   base_commit="$TRAVIS_COMMIT_RANGE"
   echo "Checking against commit $base_commit"
 fi
+
+# To simplify CI debugging, tell what files are considered.
+echo "--- Listing all changed files:"
+git diff --name-only ${base_commit}
+echo "---"
 
 filesToCheck="$(git diff --name-only ${base_commit} | grep -e '.(\.C\|\.cpp\|\.cxx\|\.h)$' || true)"
 for f in $filesToCheck; do


### PR DESCRIPTION
This commit changes a file which also has a clang-format error, and thus triggers to CI error.  That is intentional to see that the format check works.

It is based on #714 which re-enables the format checking.

After #714 has been applied, I can fix the formatting of this commit such that it passes CI before being merged.