### PR TITLE
Renamed CalifaHit to CalifaCluster

### DIFF
--- a/analysis/online/R3BCalifavsFootOnlineSpectra.cxx
+++ b/analysis/online/R3BCalifavsFootOnlineSpectra.cxx
@@ -12,8 +12,8 @@
  ******************************************************************************/
 
 #include "R3BCalifavsFootOnlineSpectra.h"
+#include "R3BCalifaClusterData.h"
 #include "R3BCalifaCrystalCalData.h"
-#include "R3BCalifaHitData.h"
 #include "R3BEventHeader.h"
 #include "R3BFootCalData.h"
 #include "R3BFootHitData.h"
@@ -191,7 +191,7 @@ void R3BCalifavsFootOnlineSpectra::Exec(Option_t* option)
 
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        auto hit = (R3BCalifaHitData*)fHitItemsCalifa->At(ihit);
+        auto hit = (R3BCalifaClusterData*)fHitItemsCalifa->At(ihit);
         if (hit->GetEnergy() < 50e3) // 50MeV
             continue;
 

--- a/analysis/online/R3BCalifavsTofDOnlineSpectra.cxx
+++ b/analysis/online/R3BCalifavsTofDOnlineSpectra.cxx
@@ -12,7 +12,7 @@
  ******************************************************************************/
 
 #include "R3BCalifavsTofDOnlineSpectra.h"
-#include "R3BCalifaHitData.h"
+#include "R3BCalifaClusterData.h"
 #include "R3BEventHeader.h"
 #include "R3BLogger.h"
 #include "R3BTofdHitData.h"
@@ -177,7 +177,7 @@ void R3BCalifavsTofDOnlineSpectra::Exec(Option_t* option)
     Int_t nHits = fHitItemsCalifa->GetEntriesFast();
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        auto hit = (R3BCalifaHitData*)fHitItemsCalifa->At(ihit);
+        auto hit = (R3BCalifaClusterData*)fHitItemsCalifa->At(ihit);
         if (hit->GetEnergy() < fMinProtonE)
             continue;
 
@@ -198,7 +198,7 @@ void R3BCalifavsTofDOnlineSpectra::Exec(Option_t* option)
         Double_t califa_e[nHits];
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto hit = (R3BCalifaHitData*)fHitItemsCalifa->At(ihit);
+            auto hit = (R3BCalifaClusterData*)fHitItemsCalifa->At(ihit);
             if (!hit)
                 continue;
             theta = hit->GetTheta() * TMath::RadToDeg();

--- a/califa/CMakeLists.txt
+++ b/califa/CMakeLists.txt
@@ -62,7 +62,7 @@ set(SRCS
 ./calibration/R3BCalifaMapped2CrystalCalPar.cxx
 ./calibration/R3BCalifaCrystalCal2TotCalPar.cxx
 ./calibration/R3BCalifaMapped2CrystalCal.cxx
-./calibration/R3BCalifaCrystalCal2Hit.cxx
+./calibration/R3BCalifaCrystalCal2Cluster.cxx
 ./calibration/R3BCalifaCrystalCal2CrystalCalPID.cxx
 ./online/R3BCalifaOnlineSpectra.cxx
 ./online/R3BCalifaJulichOnlineSpectra.cxx

--- a/califa/CalifaLinkDef.h
+++ b/califa/CalifaLinkDef.h
@@ -33,7 +33,7 @@
 #pragma link C++ class R3BCalifaMapped2CrystalCal+;
 #pragma link C++ class R3BCalifaMapped2CrystalCalPar+;
 #pragma link C++ class R3BCalifaCrystalCal2TotCalPar+;
-#pragma link C++ class R3BCalifaCrystalCal2Hit+;
+#pragma link C++ class R3BCalifaCrystalCal2Cluster+;
 #pragma link C++ class R3BCalifaCrystalCalDataAnalysis+;
 #pragma link C++ class R3BCalifaCrystalCal2CrystalCalPID+;
 #pragma link C++ class R3BCalifaOnlineSpectra+;

--- a/califa/README.md
+++ b/califa/README.md
@@ -14,7 +14,7 @@ Tasks are:
 
 - ./sim/R3BCalifaDigitizer.h
 - ./calibration/R3BCalifaMapped2CrystalCal.h
-- ./calibration/R3BCalifaCrystalCal2Hit.h
+- ./calibration/R3BCalifaCrystalCal2Cluster.h
 - ./calibration/R3BCalifaCrystalCal2CrystalCalPID.h
 
 ### Parameter containers
@@ -76,9 +76,9 @@ to generate [[../r3bdata/califaData/R3BCalifaCrystalCalData.h]] by applying per-
 ### Processing to hit level aka clustering
 
 [[../r3bdata/califaData/R3BCalifaCrystalCalData.h]] data from either source (sim/exp) is converted by
-{{./R3BCalifaCrystalCal2Hit.h}}
+{{./R3BCalifaCrystalCal2Cluster.h}}
 to
-[[../r3bdata/califaData/R3BCalifaHitData.h]]
+[[../r3bdata/califaData/R3BCalifaClusterData.h]]
 
 
 

--- a/califa/calibration/R3BCalifaCrystalCal2Cluster.h
+++ b/califa/calibration/R3BCalifaCrystalCal2Cluster.h
@@ -11,12 +11,12 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 
-#ifndef R3BCALIFACRYSTALCAL2HIT_H
-#define R3BCALIFACRYSTALCAL2HIT_H 1
+#ifndef R3BCALIFACRYSTALCAL2CLUSTER_H
+#define R3BCALIFACRYSTALCAL2CLUSTER_H 1
 
 #include "FairTask.h"
 #include "R3BCalifaGeometry.h"
-#include "R3BCalifaHitData.h"
+#include "R3BCalifaClusterData.h"
 #include "Rtypes.h"
 
 #include "TH2F.h"
@@ -25,16 +25,16 @@
 class TClonesArray;
 class R3BTGeoPar;
 
-class R3BCalifaCrystalCal2Hit : public FairTask
+class R3BCalifaCrystalCal2Cluster : public FairTask
 {
 
   public:
     /** Default constructor
      **/
-    R3BCalifaCrystalCal2Hit();
+    R3BCalifaCrystalCal2Cluster();
 
     /** Destructor **/
-    virtual ~R3BCalifaCrystalCal2Hit();
+    virtual ~R3BCalifaCrystalCal2Cluster();
 
     /** Virtual method Exec **/
     virtual void Exec(Option_t* opt);
@@ -214,7 +214,7 @@ class R3BCalifaCrystalCal2Hit : public FairTask
      **
      ** Adds a CalifaHit to the HitCollection
      **/
-    R3BCalifaHitData* AddHit(UInt_t Nbcrystals,
+    R3BCalifaClusterData* AddHit(UInt_t Nbcrystals,
                              Double_t ene,
                              Double_t Nf,
                              Double_t Ns,
@@ -228,7 +228,8 @@ class R3BCalifaCrystalCal2Hit : public FairTask
      **/
     virtual bool Match(R3BCalifaCrystalCalData* ref, R3BCalifaCrystalCalData* hit);
 
-    ClassDef(R3BCalifaCrystalCal2Hit, 2);
+    ClassDef(R3BCalifaCrystalCal2Cluster, 2);
 };
+using R3BCalifaCrystalCal2Hit [[deprecated("R3BCalifaCrystalCal2Hit was renamed R3BCalifaCrystalCal2Cluster")]] =R3BCalifaCrystalCal2Cluster;
 
 #endif /* R3BCALIFACRYSTALCAL2HIT_H */

--- a/califa/online/R3BCalifaDemoOnlineSpectra.cxx
+++ b/califa/online/R3BCalifaDemoOnlineSpectra.cxx
@@ -12,8 +12,8 @@
  ******************************************************************************/
 
 #include "R3BCalifaDemoOnlineSpectra.h"
+#include "R3BCalifaClusterData.h"
 #include "R3BCalifaCrystalCalData.h"
-#include "R3BCalifaHitData.h"
 #include "R3BCalifaMappedData.h"
 #include "R3BEventHeader.h"
 #include "R3BWRData.h"
@@ -1210,7 +1210,7 @@ void R3BCalifaDemoOnlineSpectra::Exec(Option_t* option)
         Double_t theta = 0., phi = 0.;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BCalifaHitData* hit = (R3BCalifaHitData*)fHitItemsCalifa->At(ihit);
+            R3BCalifaClusterData* hit = (R3BCalifaClusterData*)fHitItemsCalifa->At(ihit);
             if (!hit)
                 continue;
             theta = hit->GetTheta() / TMath::Pi() * 180.;

--- a/califa/online/R3BCalifaOnlineSpectra.cxx
+++ b/califa/online/R3BCalifaOnlineSpectra.cxx
@@ -12,8 +12,8 @@
  ******************************************************************************/
 
 #include "R3BCalifaOnlineSpectra.h"
+#include "R3BCalifaClusterData.h"
 #include "R3BCalifaCrystalCalData.h"
-#include "R3BCalifaHitData.h"
 #include "R3BCalifaMappedData.h"
 #include "R3BCalifaMappingPar.h"
 #include "R3BEventHeader.h"
@@ -1491,7 +1491,7 @@ void R3BCalifaOnlineSpectra::Exec(Option_t* option)
         Double_t califa_e[nHits];
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto hit = (R3BCalifaHitData*)fHitItemsCalifa->At(ihit);
+            auto hit = (R3BCalifaClusterData*)fHitItemsCalifa->At(ihit);
             if (!hit)
                 continue;
             theta = hit->GetTheta() * TMath::RadToDeg();

--- a/evtvis/R3BCalifaHitEventDisplay.cxx
+++ b/evtvis/R3BCalifaHitEventDisplay.cxx
@@ -26,7 +26,7 @@
 #include "TClonesArray.h"
 #include "TObjArray.h"
 
-#include "R3BCalifaHitData.h"
+#include "R3BCalifaClusterData.h"
 
 #include "TEveBrowser.h"
 #include "TEveCalo.h"
@@ -147,7 +147,7 @@ void R3BCalifaHitEventDisplay::Exec(Option_t* opt)
         Reset();
 
         // Besides if conditions, both objects must be defined
-        R3BCalifaHitData* caloHit;
+        R3BCalifaClusterData* caloHit;
 
         Int_t caloHits = 0; // Nb of CaloHits in current event
         caloHits = fCaloHitCA->GetEntriesFast();
@@ -164,7 +164,7 @@ void R3BCalifaHitEventDisplay::Exec(Option_t* opt)
         {
 
             Int_t binx = -1, biny = -1;
-            caloHit = (R3BCalifaHitData*)fCaloHitCA->At(i);
+            caloHit = (R3BCalifaClusterData*)fCaloHitCA->At(i);
             theta = caloHit->GetTheta();
             phi = caloHit->GetPhi();
 

--- a/r3bdata/CMakeLists.txt
+++ b/r3bdata/CMakeLists.txt
@@ -81,7 +81,7 @@ xballData/R3BXBallCrystalHit.cxx
 xballData/R3BXBallCrystalHitSim.cxx
 califaData/R3BCalifaCrystalCalData.cxx
 califaData/R3BCalifaMappedData.cxx
-califaData/R3BCalifaHitData.cxx
+califaData/R3BCalifaClusterData.cxx
 califaData/R3BCalifaPoint.cxx
 dchData/R3BDchPoint.cxx
 dchData/R3BDchFullPoint.cxx

--- a/r3bdata/DataLinkDef.h
+++ b/r3bdata/DataLinkDef.h
@@ -30,7 +30,7 @@
 #pragma link C++ class R3BXBallCrystalHitSim+;
 #pragma link C++ class R3BCalifaMappedData+;
 #pragma link C++ class R3BCalifaCrystalCalData+;
-#pragma link C++ class R3BCalifaHitData+;
+#pragma link C++ class R3BCalifaClusterData+;
 #pragma link C++ class R3BCalifaPoint+;
 #pragma link C++ class R3BDchPoint+;
 #pragma link C++ class R3BDchFullPoint+;

--- a/r3bdata/califaData/R3BCalifaClusterData.cxx
+++ b/r3bdata/califaData/R3BCalifaClusterData.cxx
@@ -11,9 +11,9 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 
-#include "R3BCalifaHitData.h"
+#include "R3BCalifaClusterData.h"
 
-R3BCalifaHitData::R3BCalifaHitData()
+R3BCalifaClusterData::R3BCalifaClusterData()
     : FairMultiLinkedData()
     , fNbOfCrystalHits(0)
     , fEnergy(NAN)
@@ -23,13 +23,13 @@ R3BCalifaHitData::R3BCalifaHitData()
 {
 }
 
-R3BCalifaHitData::R3BCalifaHitData(UInt_t Nb,
-                                   Double_t ene,
-                                   Double_t nf,
-                                   Double_t ns,
-                                   Double_t theta,
-                                   Double_t phi,
-                                   ULong64_t time)
+R3BCalifaClusterData::R3BCalifaClusterData(UInt_t Nb,
+                                           Double_t ene,
+                                           Double_t nf,
+                                           Double_t ns,
+                                           Double_t theta,
+                                           Double_t phi,
+                                           ULong64_t time)
     : FairMultiLinkedData()
     , fNbOfCrystalHits(Nb)
     , fEnergy(ene)
@@ -41,7 +41,7 @@ R3BCalifaHitData::R3BCalifaHitData(UInt_t Nb,
 {
 }
 
-R3BCalifaHitData::R3BCalifaHitData(const R3BCalifaHitData& right)
+R3BCalifaClusterData::R3BCalifaClusterData(const R3BCalifaClusterData& right)
     : FairMultiLinkedData(right)
     , fNbOfCrystalHits(right.fNbOfCrystalHits)
     , fEnergy(right.fEnergy)
@@ -53,4 +53,4 @@ R3BCalifaHitData::R3BCalifaHitData(const R3BCalifaHitData& right)
 {
 }
 
-ClassImp(R3BCalifaHitData);
+ClassImp(R3BCalifaClusterData);

--- a/r3bdata/califaData/R3BCalifaClusterData.h
+++ b/r3bdata/califaData/R3BCalifaClusterData.h
@@ -11,20 +11,20 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 
-#ifndef R3BCALIFAHITDATA_H
-#define R3BCALIFAHITDATA_H
+#ifndef R3BCALIFACLUSTERDATA_H
+#define R3BCALIFACLUSTERDATA_H
 
 #include "TObject.h"
 
 #include "FairMultiLinkedData.h"
 #include "R3BCalifaCrystalCalData.h"
 
-class R3BCalifaHitData : public FairMultiLinkedData
+class R3BCalifaClusterData : public FairMultiLinkedData
 {
 
   public:
     /** Default constructor **/
-    R3BCalifaHitData();
+    R3BCalifaClusterData();
 
     /** Constructor with arguments
      *@param fNbOfCrystalHits		Crystal unique identifier
@@ -32,9 +32,9 @@ class R3BCalifaHitData : public FairMultiLinkedData
      *@param fTheta					Reconstructed theta
      *@param fPhi					Reconstructed phi
      **/
-    R3BCalifaHitData(UInt_t Nb, Double_t ene, Double_t nf, Double_t ns, Double_t theta, Double_t phi, ULong64_t time);
+    R3BCalifaClusterData(UInt_t Nb, Double_t ene, Double_t nf, Double_t ns, Double_t theta, Double_t phi, ULong64_t time);
 
-    R3BCalifaHitData(uint64_t time, double theta, double phi, uint32_t clusterId)
+    R3BCalifaClusterData(uint64_t time, double theta, double phi, uint32_t clusterId)
         : fTime(time)
         , fTheta(theta)
         , fPhi(phi)
@@ -47,10 +47,10 @@ class R3BCalifaHitData : public FairMultiLinkedData
     }
 
     /** Copy constructor **/
-    R3BCalifaHitData(const R3BCalifaHitData&);
+    R3BCalifaClusterData(const R3BCalifaClusterData&);
 
     /** += operator **/
-    R3BCalifaHitData& operator+=(R3BCalifaCrystalCalData& cH)
+    R3BCalifaClusterData& operator+=(R3BCalifaCrystalCalData& cH)
     {
         this->fEnergy += cH.GetEnergy();
         this->fNf += cH.GetNf();
@@ -59,10 +59,10 @@ class R3BCalifaHitData : public FairMultiLinkedData
         return *this;
     }
 
-    R3BCalifaHitData& operator=(const R3BCalifaHitData&) { return *this; }
+    R3BCalifaClusterData& operator=(const R3BCalifaClusterData&) { return *this; }
 
     /** Destructor **/
-    virtual ~R3BCalifaHitData() {}
+    virtual ~R3BCalifaClusterData() {}
 
     /** Accessors **/
     UInt_t GetNbOfCrystalHits() const { return fNbOfCrystalHits; }
@@ -86,7 +86,7 @@ class R3BCalifaHitData : public FairMultiLinkedData
 
   protected:
     // Basic Hit information
-    UInt_t fNbOfCrystalHits; // number of crystals contribuying to the R3BCalifaHitData
+    UInt_t fNbOfCrystalHits; // number of crystals contribuying to the R3BCalifaClusterData
     Double_t fEnergy;        // total energy deposited
     Double_t fNf;            // total Nf deposited
     Double_t fNs;            // total Ns deposited
@@ -95,7 +95,9 @@ class R3BCalifaHitData : public FairMultiLinkedData
     ULong64_t fTime;         // WR time stamp
     uint32_t fClusterId;
 
-    ClassDef(R3BCalifaHitData, 3)
+    ClassDef(R3BCalifaClusterData, 3)
 };
+
+using R3BCalifaHitData [[deprecated("R3BCalifaHitData was renamed to R3BCalifaClusterData.")]] =R3BCalifaClusterData;
 
 #endif

--- a/ssd/online/R3BAmsCalifaCorrelatedOnlineSpectra.cxx
+++ b/ssd/online/R3BAmsCalifaCorrelatedOnlineSpectra.cxx
@@ -24,7 +24,7 @@
 
 #include "R3BAmsCalifaCorrelatedOnlineSpectra.h"
 #include "R3BAmsHitData.h"
-#include "R3BCalifaHitData.h"
+#include "R3BCalifaClusterData.h"
 #include "R3BEventHeader.h"
 #include "R3BLosCalData.h"
 #include "THttpServer.h"
@@ -640,7 +640,7 @@ void R3BAmsCalifaCorrelatedOnlineSpectra::Exec(Option_t* option)
         Double_t theta = 0., phi = 0.;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BCalifaHitData* hit = (R3BCalifaHitData*)fHitItemsCalifa->At(ihit);
+            R3BCalifaClusterData* hit = (R3BCalifaClusterData*)fHitItemsCalifa->At(ihit);
             if (!hit)
                 continue;
             theta = hit->GetTheta() / TMath::Pi() * 180.;

--- a/startrack/R3BStartrackEvent.h
+++ b/startrack/R3BStartrackEvent.h
@@ -14,7 +14,7 @@
 #ifndef R3BStartrackEvent_H
 #define R3BStartrackEvent_H
 
-#include "../califaData/R3BCalifaHitData.h"
+#include "../califaData/R3BCalifaClusterData.h"
 #include "R3BStartrackerHit.h"
 #include <TObjArray.h>
 #include <TObject.h>
@@ -107,7 +107,7 @@ class R3BStartrackEvent : public TObject
     Double_t fVtxPosition[3];    // primary vertex position
     Double_t fVtxError[3];       // primary vertex error
     TObjArray* fSTHits;          // Hits in the Silicon Tracker (R3BSTaRTrackerHit), min 3 (1 track), or 6 (2 protons)
-    TObjArray* fCalifaHits;      // CALIFA hit (R3BCalifaHitData)
+    TObjArray* fCalifaHits;      // CALIFA hit (R3BCalifaClusterData)
     TString fGeometryST;         // geometry Silicon Tracker
 
     ClassDef(R3BStartrackEvent, 1);

--- a/utils/rename.sh
+++ b/utils/rename.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+if test $# -ne 2
+then
+    echo "Usage: $0 <oldname> <newname>"
+    echo "Where <oldname> is an extended regex and newname is a sed-compatible replacement."
+    echo "This will change checked out files without prompting!"
+fi
+
+grep -E "$1" -r . --exclude .git -l | xargs -L 1 sed -E "s@$1@$2@g" -i 


### PR DESCRIPTION
The name "R3BCalifaHitData" is a relic from ancient times, much like the class name "R3BCalifa". 

Nice person that I am, I added using declarations so that the old name can still be used. 

(Yes, this breaks from the Mapped -> Cal (or for whatever reason, CrystalCal) -> Hit scheme. This is intentional. The fixed "there are exactly two steps in data processing for any detector" is just not true for many detectors. 