### PR TITLE
Fixed some instances of C-style casts by replacing them with dynamic_cast

### DIFF
--- a/actar/R3BActar.cxx
+++ b/actar/R3BActar.cxx
@@ -201,7 +201,7 @@ Bool_t R3BActar::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of PspPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kACTAR);
 
         ResetParameters();
@@ -278,7 +278,7 @@ void R3BActar::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BActarPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BActarPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BActarPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BActarPoint(*oldpoint);

--- a/alpide/calibration/R3BAlpideCal2Hit.cxx
+++ b/alpide/calibration/R3BAlpideCal2Hit.cxx
@@ -85,11 +85,11 @@ void R3BAlpideCal2Hit::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(fatal, !rtdb, "FairRuntimeDb not found");
 
-    fMap_Par = (R3BAlpideMappingPar*)rtdb->getContainer("alpideMappingPar");
+    fMap_Par = dynamic_cast<R3BAlpideMappingPar*>(rtdb->getContainer("alpideMappingPar"));
     R3BLOG_IF(fatal, !fMap_Par, "Container alpideMappingPar not found");
 
-    fAlpideGeoPar = (R3BTGeoPar*)rtdb->getContainer("AlpideGeoPar");
-    fTargetGeoPar = (R3BTGeoPar*)rtdb->getContainer("TargetGeoPar");
+    fAlpideGeoPar = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer("AlpideGeoPar"));
+    fTargetGeoPar = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer("TargetGeoPar"));
     if (!fAlpideGeoPar || !fTargetGeoPar)
     {
         R3BLOG_IF(warning, !fAlpideGeoPar, "Could not get access to AlpideGeoPar container.");
@@ -193,7 +193,7 @@ nextround:
     auto calData = new R3BAlpideCalData*[fAlpidePixel->GetEntriesFast()];
     for (Int_t i = 0; i < fAlpidePixel->GetEntriesFast(); i++)
     {
-        calData[i] = (R3BAlpideCalData*)(fAlpidePixel->At(i));
+        calData[i] = dynamic_cast<R3BAlpideCalData*>((fAlpidePixel->At(i)));
         auto sen = calData[i]->GetSensorId();
         auto col = calData[i]->GetCol();
         auto row = calData[i]->GetRow();
@@ -212,7 +212,7 @@ nextround:
             auto cluster = new R3BAlpideCluster*[cHits];
             for (Int_t j = 0; j < cHits; j++)
             {
-                cluster[j] = (R3BAlpideCluster*)fAlpideCluster->At(j);
+                cluster[j] = dynamic_cast<R3BAlpideCluster*>(fAlpideCluster->At(j));
                 if (((std::abs(cluster[j]->GetCol() - col) == 1 && std::abs(cluster[j]->GetRow() - row) == 0) ||
                      (std::abs(cluster[j]->GetRow() - row) == 1 && std::abs(cluster[j]->GetCol() - col) == 0) ||
                      (std::abs(cluster[j]->GetRow() - row) == 1 && std::abs(cluster[j]->GetCol() - col) == 1)) &&
@@ -301,7 +301,7 @@ void R3BAlpideCal2Hit::FindClusters()
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        cluster[i] = (R3BAlpideCluster*)fAlpideCluster->At(i);
+        cluster[i] = dynamic_cast<R3BAlpideCluster*>(fAlpideCluster->At(i));
         auto clid = cluster[i]->GetClusterId() - 1;
         auto senid = cluster[i]->GetSensorId() - 1;
         mult[senid][clid]++;

--- a/alpide/calibration/R3BAlpideMapped2Cal.cxx
+++ b/alpide/calibration/R3BAlpideMapped2Cal.cxx
@@ -65,7 +65,7 @@ void R3BAlpideMapped2Cal::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(FATAL, !rtdb, "FairRuntimeDb not found");
 
-    fMap_Par = (R3BAlpideMappingPar*)rtdb->getContainer("alpideMappingPar");
+    fMap_Par = dynamic_cast<R3BAlpideMappingPar*>(rtdb->getContainer("alpideMappingPar"));
     R3BLOG_IF(FATAL, !fMap_Par, "Container alpideMappingPar not found");
 }
 
@@ -128,7 +128,7 @@ void R3BAlpideMapped2Cal::Exec(Option_t* option)
     auto mappedData = new R3BAlpideMappedData*[nHits];
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BAlpideMappedData*)(fAlpideMappedData->At(i));
+        mappedData[i] = dynamic_cast<R3BAlpideMappedData*>((fAlpideMappedData->At(i)));
         auto det = mappedData[i]->GetSensorId();
         auto col = mappedData[i]->GetCol();
         auto row = mappedData[i]->GetRow();

--- a/alpide/digi/R3BAlpideDigitizer.cxx
+++ b/alpide/digi/R3BAlpideDigitizer.cxx
@@ -67,7 +67,7 @@ R3BAlpideDigitizer::~R3BAlpideDigitizer()
 void R3BAlpideDigitizer::SetParContainers()
 {
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
-    fMappingPar = (R3BAlpideMappingPar*)rtdb->getContainer("alpideMappingPar");
+    fMappingPar = dynamic_cast<R3BAlpideMappingPar*>(rtdb->getContainer("alpideMappingPar"));
     R3BLOG_IF(warning, !fMappingPar, "Could not get access to alpideMappingPar");
     R3BLOG_IF(warning, fMappingPar, "Container alpideMappingPar found.");
 }
@@ -124,11 +124,11 @@ void R3BAlpideDigitizer::Exec(Option_t* opt)
     for (Int_t i = 0; i < nHits; i++)
     {
         fRot.SetToIdentity();
-        pointData[i] = (R3BAlpidePoint*)(fAlpidePoints->At(i));
+        pointData[i] = dynamic_cast<R3BAlpidePoint*>((fAlpidePoints->At(i)));
         TrackId = pointData[i]->GetTrackID();
         auto sid = pointData[i]->GetSensorID();
 
-        auto Track = (R3BMCTrack*)fMCTrack->At(TrackId);
+        auto Track = dynamic_cast<R3BMCTrack*>(fMCTrack->At(TrackId));
         PID = Track->GetPdgCode();
 
         // if (PID > 1000080160) // Z=8 and A=16

--- a/alpide/online/R3BAlpideOnlineSpectra.cxx
+++ b/alpide/online/R3BAlpideOnlineSpectra.cxx
@@ -72,7 +72,7 @@ void R3BAlpideOnlineSpectra::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(fatal, !rtdb, "FairRuntimeDb not found");
 
-    fMap_Par = (R3BAlpideMappingPar*)rtdb->getContainer("alpideMappingPar");
+    fMap_Par = dynamic_cast<R3BAlpideMappingPar*>(rtdb->getContainer("alpideMappingPar"));
     R3BLOG_IF(fatal, !fMap_Par, "Container alpideMappingPar not found");
 }
 
@@ -92,11 +92,11 @@ InitStatus R3BAlpideOnlineSpectra::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     R3BLOG_IF(FATAL, NULL == mgr, "FairRootManager not found");
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
     {
         R3BLOG(warning, "EventHeader. not found");
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     }
     else
     {
@@ -316,7 +316,7 @@ void R3BAlpideOnlineSpectra::Exec(Option_t* option)
         auto nHits = fMappedItems->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto hit = (R3BAlpideMappedData*)fMappedItems->At(ihit);
+            auto hit = dynamic_cast<R3BAlpideMappedData*>(fMappedItems->At(ihit));
             if (!hit)
                 continue;
             fh2_ColVsRow[hit->GetSensorId() - 1]->Fill(hit->GetCol(), hit->GetRow());
@@ -334,7 +334,7 @@ void R3BAlpideOnlineSpectra::Exec(Option_t* option)
             auto nHits = fCalItems->GetEntriesFast();
             for (Int_t ihit = 0; ihit < nHits; ihit++)
             {
-                auto hit = (R3BAlpideCalData*)fCalItems->At(ihit);
+                auto hit = dynamic_cast<R3BAlpideCalData*>(fCalItems->At(ihit));
                 if (!hit)
                     continue;
                 Int_t senid = hit->GetSensorId() - 1;
@@ -361,7 +361,7 @@ void R3BAlpideOnlineSpectra::Exec(Option_t* option)
         auto nHits = fHitItems->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto hit = (R3BAlpideHitData*)fHitItems->At(ihit);
+            auto hit = dynamic_cast<R3BAlpideHitData*>(fHitItems->At(ihit));
             if (!hit)
                 continue;
             Int_t senid = hit->GetSensorId() - 1;

--- a/alpide/online/R3BSingleAlpideCorrelationOnlineSpectra.cxx
+++ b/alpide/online/R3BSingleAlpideCorrelationOnlineSpectra.cxx
@@ -184,7 +184,7 @@ void R3BSingleAlpideCorrelationOnlineSpectra::Exec(Option_t* option)
         int size1 = 0, size2 = 0;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto hit = (R3BAlpideHitData*)fHitItems->At(ihit);
+            auto hit = dynamic_cast<R3BAlpideHitData*>(fHitItems->At(ihit));
             if (!hit)
                 continue;
             Int_t senid = hit->GetSensorId();

--- a/alpide/pars/R3BAlpideNoisyPixels.cxx
+++ b/alpide/pars/R3BAlpideNoisyPixels.cxx
@@ -92,7 +92,7 @@ InitStatus R3BAlpideNoisyPixels::Init()
 
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(FATAL, !rtdb, "FairRuntimeDb not found");
-    fMap_Par = (R3BAlpideMappingPar*)rtdb->getContainer("alpideMappingPar");
+    fMap_Par = dynamic_cast<R3BAlpideMappingPar*>(rtdb->getContainer("alpideMappingPar"));
     if (!fMap_Par)
     {
         R3BLOG(FATAL, "Couldn't get handle on alpideMappingPar container");
@@ -114,7 +114,7 @@ void R3BAlpideNoisyPixels::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BAlpideMappedData*)(fAlpideMappedData->At(i));
+        mappedData[i] = dynamic_cast<R3BAlpideMappedData*>((fAlpideMappedData->At(i)));
         auto det = mappedData[i]->GetSensorId() - 1;
         auto col = mappedData[i]->GetCol() - 1;
         auto row = mappedData[i]->GetAds() - 1;

--- a/alpide/sim/R3BAlpide.cxx
+++ b/alpide/sim/R3BAlpide.cxx
@@ -60,7 +60,7 @@ void R3BAlpide::SetParameter()
 {
     // Parameter Container
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
-    fMap_Par = (R3BAlpideMappingPar*)rtdb->getContainer("alpideMappingPar");
+    fMap_Par = dynamic_cast<R3BAlpideMappingPar*>(rtdb->getContainer("alpideMappingPar"));
     R3BLOG_IF(warning, !fMap_Par, "Container alpideMappingPar not found");
     //--- Parameter Container ---
     if (fMap_Par)
@@ -454,7 +454,7 @@ Bool_t R3BAlpide::ProcessHits(FairVolume* vol)
                gMC->TrackPid());
 
         // Increment number of TraPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kTRA);
 
         ResetParameters();
@@ -517,7 +517,7 @@ void R3BAlpide::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BAlpidePoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BAlpidePoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BAlpidePoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BAlpidePoint(*oldpoint);

--- a/analysis/CMakeLists.txt
+++ b/analysis/CMakeLists.txt
@@ -97,7 +97,7 @@ Set(LINKDEF AnaLinkDef.h)
 
 Set(DEPENDENCIES
 GeoBase ParBase MbsAPI Base FairTools R3BPassive R3BData Core Geom GenVector Physics Matrix MathCore R3BTraRene R3BTracking
-R3BSsd R3BLos R3BCalifa
+R3BSsd R3BLos R3BCalifa R3BMwpc R3BBunchedFiber R3BTwim R3BMusic R3BTofD
 )
 
 Set(LIBRARY_NAME R3BAnalysis)

--- a/analysis/offline/R3BAnalysisIncomingFrs.cxx
+++ b/analysis/offline/R3BAnalysisIncomingFrs.cxx
@@ -134,7 +134,7 @@ InitStatus R3BAnalysisIncomingFrs::Init()
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
 
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     // Get objects for detectors on all levels
     assert(DET_MAX + 1 == sizeof(fDetectorNames) / sizeof(fDetectorNames[0]));
@@ -192,7 +192,7 @@ void R3BAnalysisIncomingFrs::Exec(Option_t* option)
         Int_t nHits = fHitItemsMus->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMusicHitData* hit = (R3BMusicHitData*)fHitItemsMus->At(ihit);
+            R3BMusicHitData* hit = dynamic_cast<R3BMusicHitData*>(fHitItemsMus->At(ihit));
             if (!hit)
                 continue;
             Zmusic = hit->GetZcharge();
@@ -259,7 +259,7 @@ void R3BAnalysisIncomingFrs::Exec(Option_t* option)
         Int_t nHitsSamp = det->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHitsSamp; ihit++)
         {
-            auto hit = (R3BSamplerMappedData*)det->At(ihit);
+            auto hit = dynamic_cast<R3BSamplerMappedData*>(det->At(ihit));
             // time is in steps of 10 ns
             // is is a 34 bit number, so max 1073741823
             samplerCurr = hit->GetTime();
@@ -358,7 +358,7 @@ void R3BAnalysisIncomingFrs::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BLosMappedData* hit = (R3BLosMappedData*)det->At(ihit);
+            R3BLosMappedData* hit = dynamic_cast<R3BLosMappedData*>(det->At(ihit));
             if (!hit)
                 continue;
 
@@ -383,7 +383,7 @@ void R3BAnalysisIncomingFrs::Exec(Option_t* option)
             /*
              * nPart is the number of particle passing through LOS detector in one event
              */
-            R3BLosCalData* calData = (R3BLosCalData*)det->At(iPart);
+            R3BLosCalData* calData = dynamic_cast<R3BLosCalData*>(det->At(iPart));
             iDet = calData->GetDetector();
 
             Double_t sumvtemp = 0, sumltemp = 0, sumttemp = 0;

--- a/analysis/offline/R3BAnalysisIncomingID.cxx
+++ b/analysis/offline/R3BAnalysisIncomingID.cxx
@@ -94,7 +94,7 @@ void R3BAnalysisIncomingID::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(FATAL, !rtdb, "FairRuntimeDb not found");
 
-    fIncomingID_Par = (R3BIncomingIDPar*)rtdb->getContainer("IncomingIDPar");
+    fIncomingID_Par = dynamic_cast<R3BIncomingIDPar*>(rtdb->getContainer("IncomingIDPar"));
     R3BLOG_IF(FATAL, !fIncomingID_Par, "Couldn't get handle on IncomingIDPar container");
     R3BLOG_IF(INFO, fIncomingID_Par, "IncomingIDPar container was found");
 
@@ -137,7 +137,7 @@ InitStatus R3BAnalysisIncomingID::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     R3BLOG_IF(FATAL, NULL == mgr, "FairRootManager not found");
 
-    fHeader = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    fHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
 
     // Get access to hit data of the MUSIC
     fHitItemsMus = (TClonesArray*)mgr->GetObject("MusicHitData");
@@ -183,7 +183,7 @@ void R3BAnalysisIncomingID::Exec(Option_t* option)
         Int_t nHits = fHitItemsMus->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto hit = (R3BMusicHitData*)fHitItemsMus->At(ihit);
+            auto hit = dynamic_cast<R3BMusicHitData*>(fHitItemsMus->At(ihit));
             if (!hit)
                 continue;
             Zmusic = hit->GetZcharge();
@@ -196,7 +196,7 @@ void R3BAnalysisIncomingID::Exec(Option_t* option)
         Int_t nHits = fHitItemsMusli->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto hit = (R3BMusliHitData*)fHitItemsMusli->At(ihit);
+            auto hit = dynamic_cast<R3BMusliHitData*>(fHitItemsMusli->At(ihit));
             if (!hit)
                 continue;
             if (hit->GetType() == 2)
@@ -229,7 +229,7 @@ void R3BAnalysisIncomingID::Exec(Option_t* option)
         nHits = fHitLos->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BLosHitData* hittcal = (R3BLosHitData*)fHitLos->At(ihit);
+            R3BLosHitData* hittcal = dynamic_cast<R3BLosHitData*>(fHitLos->At(ihit));
             numDet = hittcal->GetDetector();
             if (multLos[numDet - 1] == 0)
             {
@@ -248,13 +248,13 @@ void R3BAnalysisIncomingID::Exec(Option_t* option)
         // treatment of multihit events needs to be implemented.
         if (fHitPspx1_x && fHitPspx1_x->GetEntriesFast() == 1)
         {
-            auto pspx1hitx = (R3BPspxHitData*)fHitPspx1_x->At(0);
+            auto pspx1hitx = dynamic_cast<R3BPspxHitData*>(fHitPspx1_x->At(0));
             en_pspx = pspx1hitx->GetEnergy();
         }
 
         if (fHitPspx1_y && fHitPspx1_y->GetEntriesFast() == 1)
         {
-            auto pspx1hity = (R3BPspxHitData*)fHitPspx1_y->At(0);
+            auto pspx1hity = dynamic_cast<R3BPspxHitData*>(fHitPspx1_y->At(0));
             en_pspy = pspx1hity->GetEnergy();
         }
 
@@ -281,7 +281,7 @@ void R3BAnalysisIncomingID::Exec(Option_t* option)
                 R3BLOG_IF(ERROR, nHits > 1, "Multiplicity from FRS detector larger than 1: " << nHits);
                 for (Int_t ihit = 0; ihit < nHits; ihit++)
                 {
-                    hitfrs = (R3BFrsData*)fFrsDataCA->At(ihit);
+                    hitfrs = dynamic_cast<R3BFrsData*>(fFrsDataCA->At(ihit));
                     if (!hitfrs)
                         continue;
                     betaS2 = hitfrs->GetBeta();

--- a/analysis/offline/R3BGlobalAnalysis.cxx
+++ b/analysis/offline/R3BGlobalAnalysis.cxx
@@ -118,7 +118,7 @@ InitStatus R3BGlobalAnalysis::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     FairRunOnline* run = FairRunOnline::Instance();
 
     // Get objects for detectors on all levels
@@ -538,7 +538,7 @@ void R3BGlobalAnalysis::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BLosHitData* hitData = (R3BLosHitData*)det->At(ihit);
+            R3BLosHitData* hitData = dynamic_cast<R3BLosHitData*>(det->At(ihit));
             timeLos[ihit] = hitData->fTime_ns;
 
             fh_los_pos->Fill(hitData->fX_cm, hitData->fY_cm);
@@ -575,7 +575,7 @@ void R3BGlobalAnalysis::Exec(Option_t* option)
 
             for (Int_t ihit = 0; ihit < nHits; ihit++)
             {
-                R3BTofdHitData* hit = (R3BTofdHitData*)det->At(ihit);
+                R3BTofdHitData* hit = dynamic_cast<R3BTofdHitData*>(det->At(ihit));
                 if (!hit)
                     continue; // should not happen
                 if (ihit > 15)
@@ -647,7 +647,7 @@ void R3BGlobalAnalysis::Exec(Option_t* option)
             std::vector<UInt_t> spmt_num(16);
             for (Int_t ihit = 0; ihit < nHits; ihit++)
             {
-                R3BBunchedFiberMappedData* hit = (R3BBunchedFiberMappedData*)detMapped->At(ihit);
+                R3BBunchedFiberMappedData* hit = dynamic_cast<R3BBunchedFiberMappedData*>(detMapped->At(ihit));
                 if (!hit)
                     continue;
 
@@ -718,7 +718,7 @@ void R3BGlobalAnalysis::Exec(Option_t* option)
                 Double_t tMAPMT = 0. / 0.;
                 Double_t tSPMT = 0. / 0.;
 
-                R3BBunchedFiberHitData* hit = (R3BBunchedFiberHitData*)detHit->At(ihit);
+                R3BBunchedFiberHitData* hit = dynamic_cast<R3BBunchedFiberHitData*>(detHit->At(ihit));
                 if (!hit)
                     continue;
 

--- a/analysis/offline/R3BGlobalAnalysisS454.cxx
+++ b/analysis/offline/R3BGlobalAnalysisS454.cxx
@@ -113,7 +113,7 @@ InitStatus R3BGlobalAnalysisS454::Init()
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
 
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     FairRunOnline* run = FairRunOnline::Instance();
 
     // Get objects for detectors on all levels
@@ -435,7 +435,7 @@ void R3BGlobalAnalysisS454::Exec(Option_t* option)
         // if(nHitsTrack>0) cout << "Track hits: " << nHitsTrack << endl;
         for (Int_t l = 0; l < nHitsTrack; l++)
         {
-            R3BTrack* aTrack = (R3BTrack*)fTrack->At(l);
+            R3BTrack* aTrack = dynamic_cast<R3BTrack*>(fTrack->At(l));
 
             LOG(DEBUG) << "Charge " << aTrack->GetQ() << endl;
 
@@ -511,7 +511,7 @@ void R3BGlobalAnalysisS454::Exec(Option_t* option)
         for (Int_t l = 0; l < nHitsMCTrack; l++)
         {
             // cout << "Original MC Data is analyzed" << endl;
-            R3BMCTrack* aTrack = (R3BMCTrack*)fMCTrack->At(l);
+            R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fMCTrack->At(l));
 
             Int_t PID = aTrack->GetPdgCode();
             Int_t mother = aTrack->GetMotherId();

--- a/analysis/offline/R3BIncomingBeta.cxx
+++ b/analysis/offline/R3BIncomingBeta.cxx
@@ -78,7 +78,7 @@ void R3BIncomingBeta::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(FATAL, !rtdb, "FairRuntimeDb not found");
 
-    fIncomingID_Par = (R3BIncomingIDPar*)rtdb->getContainer("IncomingIDPar");
+    fIncomingID_Par = dynamic_cast<R3BIncomingIDPar*>(rtdb->getContainer("IncomingIDPar"));
     R3BLOG_IF(FATAL, !fIncomingID_Par, "Couldn't get handle on IncomingIDPar container");
     R3BLOG_IF(INFO, fIncomingID_Par, "IncomingIDPar container was found");
 
@@ -108,7 +108,7 @@ InitStatus R3BIncomingBeta::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     R3BLOG_IF(FATAL, NULL == mgr, "FairRootManager not found");
 
-    fHeader = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    fHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
 
     // Get access to Sci2 data at hit level
     fHitSci2 = (TClonesArray*)mgr->GetObject("Sci2Hit");
@@ -207,7 +207,7 @@ void R3BIncomingBeta::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BLosHitData* hittcal = (R3BLosHitData*)fHitLos->At(ihit);
+            R3BLosHitData* hittcal = dynamic_cast<R3BLosHitData*>(fHitLos->At(ihit));
             numDet = hittcal->GetDetector();
 
             if (multLos[numDet - 1] >= MAXMULT)

--- a/analysis/offline/R3BTrackS454.cxx
+++ b/analysis/offline/R3BTrackS454.cxx
@@ -130,7 +130,7 @@ InitStatus R3BTrackS454::Init()
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
 
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     FairRunOnline* run = FairRunOnline::Instance();
 
     // Get objects for detectors on all levels
@@ -781,7 +781,7 @@ void R3BTrackS454::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHitsbm; ihit++)
         {
-            R3BBeamMonitorMappedData* hit = (R3BBeamMonitorMappedData*)detBmon->At(ihit);
+            R3BBeamMonitorMappedData* hit = dynamic_cast<R3BBeamMonitorMappedData*>(detBmon->At(ihit));
             if (!hit)
                 continue;
 
@@ -836,7 +836,7 @@ void R3BTrackS454::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHitsRolu; ihit++)
         {
-            R3BRoluMappedData* hitRolu = (R3BRoluMappedData*)detRolu->At(ihit);
+            R3BRoluMappedData* hitRolu = dynamic_cast<R3BRoluMappedData*>(detRolu->At(ihit));
             if (!hitRolu)
                 continue;
 
@@ -863,7 +863,7 @@ void R3BTrackS454::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHitsCalifa; ihit++)
         {
-            R3BCalifaMappedData* hitCalifa = (R3BCalifaMappedData*)detCalifa->At(ihit);
+            R3BCalifaMappedData* hitCalifa = dynamic_cast<R3BCalifaMappedData*>(detCalifa->At(ihit));
             if (!hitCalifa)
                 continue;
 
@@ -891,7 +891,7 @@ void R3BTrackS454::Exec(Option_t* option)
 
         for (Int_t l = 0; l < nHitsMCTrack; l++)
         {
-            R3BMCTrack* aTrack = (R3BMCTrack*)fMCTrack->At(l);
+            R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fMCTrack->At(l));
 
             Int_t PID = aTrack->GetPdgCode();
             Int_t mother = aTrack->GetMotherId();
@@ -1155,7 +1155,7 @@ void R3BTrackS454::Exec(Option_t* option)
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
 
-        R3BTofdHitData* hitTofd = (R3BTofdHitData*)detTofd->At(ihit);
+        R3BTofdHitData* hitTofd = dynamic_cast<R3BTofdHitData*>(detTofd->At(ihit));
         pair = false;
 
         if (IS_NAN(hitTofd->GetTime()))
@@ -1462,7 +1462,7 @@ void R3BTrackS454::Exec(Option_t* option)
         for (Int_t ihit13 = 0; ihit13 < nHits13; ihit13++)
         {
             det = fi13;
-            R3BBunchedFiberHitData* hit13 = (R3BBunchedFiberHitData*)detHit13->At(ihit13);
+            R3BBunchedFiberHitData* hit13 = dynamic_cast<R3BBunchedFiberHitData*>(detHit13->At(ihit13));
             x1[det] = hit13->GetX() / 100.;
             y1[det] = hit13->GetY() / 100.;
             z1[det] = 0.;
@@ -1570,7 +1570,7 @@ void R3BTrackS454::Exec(Option_t* option)
         for (Int_t ihit11 = 0; ihit11 < nHits11; ihit11++)
         {
             det = fi11;
-            R3BBunchedFiberHitData* hit11 = (R3BBunchedFiberHitData*)detHit11->At(ihit11);
+            R3BBunchedFiberHitData* hit11 = dynamic_cast<R3BBunchedFiberHitData*>(detHit11->At(ihit11));
             x1[det] = hit11->GetX() / 100.;
             y1[det] = hit11->GetY() / 100.;
             z1[det] = 0.;
@@ -1677,7 +1677,7 @@ void R3BTrackS454::Exec(Option_t* option)
         for (Int_t ihit10 = 0; ihit10 < nHits10; ihit10++)
         {
             det = fi10;
-            R3BBunchedFiberHitData* hit10 = (R3BBunchedFiberHitData*)detHit10->At(ihit10);
+            R3BBunchedFiberHitData* hit10 = dynamic_cast<R3BBunchedFiberHitData*>(detHit10->At(ihit10));
             x1[det] = hit10->GetX() / 100.;
             y1[det] = hit10->GetY() / 100.;
             z1[det] = 0.;
@@ -1779,7 +1779,7 @@ void R3BTrackS454::Exec(Option_t* option)
         for (Int_t ihit12 = 0; ihit12 < nHits12; ihit12++)
         {
             det = fi12;
-            R3BBunchedFiberHitData* hit12 = (R3BBunchedFiberHitData*)detHit12->At(ihit12);
+            R3BBunchedFiberHitData* hit12 = dynamic_cast<R3BBunchedFiberHitData*>(detHit12->At(ihit12));
             x1[det] = hit12->GetX() / 100.;
             y1[det] = hit12->GetY() / 100.;
             z1[det] = 0.;
@@ -1882,7 +1882,7 @@ void R3BTrackS454::Exec(Option_t* option)
         for (Int_t ihit3a = 0; ihit3a < nHits3a; ihit3a++)
         {
             det = fi3a;
-            R3BBunchedFiberHitData* hit3a = (R3BBunchedFiberHitData*)detHit3a->At(ihit3a);
+            R3BBunchedFiberHitData* hit3a = dynamic_cast<R3BBunchedFiberHitData*>(detHit3a->At(ihit3a));
             x1[det] = hit3a->GetX() / 100.;
             y1[det] = hit3a->GetY() / 100.;
             z1[det] = 0.;
@@ -1983,7 +1983,7 @@ void R3BTrackS454::Exec(Option_t* option)
         for (Int_t ihit3b = 0; ihit3b < nHits3b; ihit3b++)
         {
             det = fi3b;
-            R3BBunchedFiberHitData* hit3b = (R3BBunchedFiberHitData*)detHit3b->At(ihit3b);
+            R3BBunchedFiberHitData* hit3b = dynamic_cast<R3BBunchedFiberHitData*>(detHit3b->At(ihit3b));
             x1[det] = hit3b->GetX() / 100.;
             y1[det] = hit3b->GetY() / 100.;
             z1[det] = 0.;

--- a/analysis/offline/R3BTrackerTestS454.cxx
+++ b/analysis/offline/R3BTrackerTestS454.cxx
@@ -784,7 +784,7 @@ void R3BTrackerTestS454::Exec(Option_t* option)
 
         for (Int_t l = 0; l < nHitsMCTrack; l++)
         {
-            R3BMCTrack* aTrack = (R3BMCTrack*)fMCTrack->At(l);
+            R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fMCTrack->At(l));
 
             Int_t PID = aTrack->GetPdgCode();
             Int_t mother = aTrack->GetMotherId();
@@ -863,7 +863,7 @@ void R3BTrackerTestS454::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        R3BTofdPoint* hit = (R3BTofdPoint*)fTofdPoints->At(i);
+        R3BTofdPoint* hit = dynamic_cast<R3BTofdPoint*>(fTofdPoints->At(i));
         Int_t ID = hit->GetDetectorID();
         if (ID <= 122)
         {
@@ -931,7 +931,7 @@ void R3BTrackerTestS454::Exec(Option_t* option)
     nHits = fFi3aPoints->GetEntriesFast();
     for (Int_t i = 0; i < nHits; i++)
     {
-        R3BFibPoint* hit = (R3BFibPoint*)fFi3aPoints->At(i);
+        R3BFibPoint* hit = dynamic_cast<R3BFibPoint*>(fFi3aPoints->At(i));
         Int_t ID = hit->GetDetectorID();
         qqq = sqrt(hit->GetEnergyLoss()) * 137.61468;
         if (qqq >= 5)
@@ -954,7 +954,7 @@ void R3BTrackerTestS454::Exec(Option_t* option)
     nHits = fFi3bPoints->GetEntriesFast();
     for (Int_t i = 0; i < nHits; i++)
     {
-        R3BFibPoint* hit = (R3BFibPoint*)fFi3bPoints->At(i);
+        R3BFibPoint* hit = dynamic_cast<R3BFibPoint*>(fFi3bPoints->At(i));
         Int_t ID = hit->GetDetectorID();
         qqq = sqrt(hit->GetEnergyLoss()) * 137.61468;
         if (qqq >= 5)
@@ -978,7 +978,7 @@ void R3BTrackerTestS454::Exec(Option_t* option)
     nHits = fFi10Points->GetEntriesFast();
     for (Int_t i = 0; i < nHits; i++)
     {
-        R3BFibPoint* hit = (R3BFibPoint*)fFi10Points->At(i);
+        R3BFibPoint* hit = dynamic_cast<R3BFibPoint*>(fFi10Points->At(i));
         Int_t ID = hit->GetDetectorID();
         qqq = sqrt(hit->GetEnergyLoss()) * 89.060413;
         if (qqq >= 5)
@@ -1001,7 +1001,7 @@ void R3BTrackerTestS454::Exec(Option_t* option)
     nHits = fFi11Points->GetEntriesFast();
     for (Int_t i = 0; i < nHits; i++)
     {
-        R3BFibPoint* hit = (R3BFibPoint*)fFi11Points->At(i);
+        R3BFibPoint* hit = dynamic_cast<R3BFibPoint*>(fFi11Points->At(i));
         Int_t ID = hit->GetDetectorID();
         qqq = sqrt(hit->GetEnergyLoss()) * 89.060413;
         if (qqq >= 5)
@@ -1024,7 +1024,7 @@ void R3BTrackerTestS454::Exec(Option_t* option)
     nHits = fFi12Points->GetEntriesFast();
     for (Int_t i = 0; i < nHits; i++)
     {
-        R3BFibPoint* hit = (R3BFibPoint*)fFi12Points->At(i);
+        R3BFibPoint* hit = dynamic_cast<R3BFibPoint*>(fFi12Points->At(i));
         Int_t ID = hit->GetDetectorID();
         qqq = sqrt(hit->GetEnergyLoss()) * 89.060413;
         if (qqq >= 5)
@@ -1047,7 +1047,7 @@ void R3BTrackerTestS454::Exec(Option_t* option)
     nHits = fFi13Points->GetEntriesFast();
     for (Int_t i = 0; i < nHits; i++)
     {
-        R3BFibPoint* hit = (R3BFibPoint*)fFi13Points->At(i);
+        R3BFibPoint* hit = dynamic_cast<R3BFibPoint*>(fFi13Points->At(i));
         Int_t ID = hit->GetDetectorID();
         qqq = sqrt(hit->GetEnergyLoss()) * 89.060413;
         if (qqq >= 5)

--- a/analysis/online/R3BCalifavsFootOnlineSpectra.cxx
+++ b/analysis/online/R3BCalifavsFootOnlineSpectra.cxx
@@ -93,7 +93,7 @@ InitStatus R3BCalifavsFootOnlineSpectra::Init()
 
     R3BLOG_IF(FATAL, NULL == mgr, "FairRootManager not found");
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
 
     FairRunOnline* run = FairRunOnline::Instance();
     run->GetHttpServer()->Register("", this);
@@ -180,7 +180,7 @@ void R3BCalifavsFootOnlineSpectra::Exec(Option_t* option)
     bool ffoot = false;
     for (Int_t ihit = 0; ihit < fMappedItemsFoot->GetEntriesFast(); ihit++)
     {
-        auto hit = (R3BFootMappedData*)fMappedItemsFoot->At(ihit);
+        auto hit = dynamic_cast<R3BFootMappedData*>(fMappedItemsFoot->At(ihit));
         if (!hit)
             continue;
         if (hit->GetDetId() == 11 && hit->GetEnergy() > 500)
@@ -191,7 +191,7 @@ void R3BCalifavsFootOnlineSpectra::Exec(Option_t* option)
 
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        auto hit = (R3BCalifaHitData*)fHitItemsCalifa->At(ihit);
+        auto hit = dynamic_cast<R3BCalifaHitData*>(fHitItemsCalifa->At(ihit));
         if (hit->GetEnergy() < 50e3) // 50MeV
             continue;
 

--- a/analysis/online/R3BCalifavsTofDOnlineSpectra.cxx
+++ b/analysis/online/R3BCalifavsTofDOnlineSpectra.cxx
@@ -74,7 +74,7 @@ InitStatus R3BCalifavsTofDOnlineSpectra::Init()
 
     R3BLOG_IF(FATAL, NULL == mgr, "FairRootManager not found");
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
 
     FairRunOnline* run = FairRunOnline::Instance();
     run->GetHttpServer()->Register("", this);
@@ -167,7 +167,7 @@ void R3BCalifavsTofDOnlineSpectra::Exec(Option_t* option)
     bool fZminus1 = false;
     for (Int_t ihit = 0; ihit < fHitItemsTofd->GetEntriesFast(); ihit++)
     {
-        auto hit = (R3BTofdHitData*)fHitItemsTofd->At(ihit);
+        auto hit = dynamic_cast<R3BTofdHitData*>(fHitItemsTofd->At(ihit));
         if (!hit)
             continue;
         if (hit->GetDetId() == 1 && hit->GetEloss() > (fZselection - 0.5) && hit->GetEloss() < (fZselection + 0.5))
@@ -177,7 +177,7 @@ void R3BCalifavsTofDOnlineSpectra::Exec(Option_t* option)
     Int_t nHits = fHitItemsCalifa->GetEntriesFast();
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        auto hit = (R3BCalifaHitData*)fHitItemsCalifa->At(ihit);
+        auto hit = dynamic_cast<R3BCalifaHitData*>(fHitItemsCalifa->At(ihit));
         if (hit->GetEnergy() < fMinProtonE)
             continue;
 
@@ -198,7 +198,7 @@ void R3BCalifavsTofDOnlineSpectra::Exec(Option_t* option)
         Double_t califa_e[nHits];
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto hit = (R3BCalifaHitData*)fHitItemsCalifa->At(ihit);
+            auto hit = dynamic_cast<R3BCalifaHitData*>(fHitItemsCalifa->At(ihit));
             if (!hit)
                 continue;
             theta = hit->GetTheta() * TMath::RadToDeg();

--- a/analysis/online/R3BFibervsTofDOnlineSpectra.cxx
+++ b/analysis/online/R3BFibervsTofDOnlineSpectra.cxx
@@ -71,7 +71,7 @@ R3BFibervsTofDOnlineSpectra::~R3BFibervsTofDOnlineSpectra()
 
 void R3BFibervsTofDOnlineSpectra::SetParContainers()
 {
-    fMapPar = (R3BFiberMappingPar*)FairRuntimeDb::instance()->getContainer(fName + "MappingPar");
+    fMapPar = dynamic_cast<R3BFiberMappingPar*>(FairRuntimeDb::instance()->getContainer(fName + "MappingPar"));
     R3BLOG_IF(ERROR, !fMapPar, "Couldn't get " << fName << "MappingPar");
     if (fMapPar)
     {
@@ -93,11 +93,11 @@ InitStatus R3BFibervsTofDOnlineSpectra::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     R3BLOG_IF(fatal, NULL == mgr, "FairRootManager not found");
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
     {
         R3BLOG(WARNING, "EventHeader. not found");
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     }
     else
         R3BLOG(INFO, " EventHeader. found");
@@ -216,7 +216,7 @@ void R3BFibervsTofDOnlineSpectra::Exec(Option_t* option)
         Int_t nHits1 = fHitItems->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits1; ihit++)
         {
-            auto hit = (R3BFiberMAPMTHitData*)fHitItems->At(ihit);
+            auto hit = dynamic_cast<R3BFiberMAPMTHitData*>(fHitItems->At(ihit));
             if (!hit)
                 continue;
             // Looking for the maximum
@@ -231,7 +231,7 @@ void R3BFibervsTofDOnlineSpectra::Exec(Option_t* option)
         Int_t nHits2 = fHitTofdItems->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits2; ihit++)
         {
-            auto hit = (R3BTofdHitData*)fHitTofdItems->At(ihit);
+            auto hit = dynamic_cast<R3BTofdHitData*>(fHitTofdItems->At(ihit));
             if (!hit)
                 continue;
             // Looking for the maximum

--- a/analysis/online/R3BGeneralOnlineSpectra.cxx
+++ b/analysis/online/R3BGeneralOnlineSpectra.cxx
@@ -107,7 +107,7 @@ InitStatus R3BGeneralOnlineSpectra::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     R3BLOG_IF(FATAL, NULL == mgr, "FairRootManager not found");
 
-    fEventHeader = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     R3BLOG_IF(WARNING, NULL == fEventHeader, "EventHeader. not found");
 
     FairRunOnline* run = FairRunOnline::Instance();
@@ -139,69 +139,69 @@ InitStatus R3BGeneralOnlineSpectra::Init()
     R3BLOG_IF(WARNING, !fWRItemsS8, "WRS8Data not found");
 
     // Looking for Mwpc0 online
-    fMwpc0Online = (R3BMwpcOnlineSpectra*)FairRunOnline::Instance()->GetTask("Mwpc0OnlineSpectra");
+    fMwpc0Online = dynamic_cast<R3BMwpcOnlineSpectra*>(FairRunOnline::Instance()->GetTask("Mwpc0OnlineSpectra"));
     R3BLOG_IF(WARNING, !fMwpc0Online, "Mwpc0OnlineSpectra not found");
 
     // Looking for Mwpc0_1 online
     fMwpc01Online =
-        (R3BMwpcCorrelationOnlineSpectra*)FairRunOnline::Instance()->GetTask("Mwpc0_1CorrelationOnlineSpectra");
+        dynamic_cast<R3BMwpcCorrelationOnlineSpectra*>(FairRunOnline::Instance()->GetTask("Mwpc0_1CorrelationOnlineSpectra"));
     R3BLOG_IF(WARNING, !fMwpc01Online, "Mwpc0_1CorrelationOnlineSpectra not found");
 
     // Looking for Mwpc0_2 online
     fMwpc02Online =
-        (R3BMwpcCorrelationOnlineSpectra*)FairRunOnline::Instance()->GetTask("Mwpc0_2CorrelationOnlineSpectra");
+        dynamic_cast<R3BMwpcCorrelationOnlineSpectra*>(FairRunOnline::Instance()->GetTask("Mwpc0_2CorrelationOnlineSpectra"));
     R3BLOG_IF(WARNING, !fMwpc02Online, "Mwpc0_2CorrelationOnlineSpectra not found");
 
     // Looking for Mwpc1_2 online
     fMwpc12Online =
-        (R3BMwpcCorrelationOnlineSpectra*)FairRunOnline::Instance()->GetTask("Mwpc1_2CorrelationOnlineSpectra");
+        dynamic_cast<R3BMwpcCorrelationOnlineSpectra*>(FairRunOnline::Instance()->GetTask("Mwpc1_2CorrelationOnlineSpectra"));
     R3BLOG_IF(WARNING, !fMwpc12Online, "Mwpc1_2CorrelationOnlineSpectra not found");
 
     // Looking for Mwpc1 online
-    fMwpc1Online = (R3BMwpcOnlineSpectra*)FairRunOnline::Instance()->GetTask("Mwpc1OnlineSpectra");
+    fMwpc1Online = dynamic_cast<R3BMwpcOnlineSpectra*>(FairRunOnline::Instance()->GetTask("Mwpc1OnlineSpectra"));
     R3BLOG_IF(WARNING, !fMwpc1Online, "Mwpc1OnlineSpectra not found");
 
     // Looking for Mwpc2 online
-    fMwpc2Online = (R3BMwpcOnlineSpectra*)FairRunOnline::Instance()->GetTask("Mwpc2OnlineSpectra");
+    fMwpc2Online = dynamic_cast<R3BMwpcOnlineSpectra*>(FairRunOnline::Instance()->GetTask("Mwpc2OnlineSpectra"));
     if (!fMwpc2Online)
         LOG(WARNING) << "R3BGeneralOnlineSpectra::Mwpc2OnlineSpectra not found";
 
     // Looking for Twim online
-    fTwimOnline = (R3BTwimOnlineSpectra*)FairRunOnline::Instance()->GetTask("TwimOnlineSpectra");
+    fTwimOnline = dynamic_cast<R3BTwimOnlineSpectra*>(FairRunOnline::Instance()->GetTask("TwimOnlineSpectra"));
     R3BLOG_IF(WARNING, !fTwimOnline, "TwimOnlineSpectra not found");
 
     // Looking for Music online
-    fMusicOnline = (R3BMusicOnlineSpectra*)FairRunOnline::Instance()->GetTask("MusicOnlineSpectra");
+    fMusicOnline = dynamic_cast<R3BMusicOnlineSpectra*>(FairRunOnline::Instance()->GetTask("MusicOnlineSpectra"));
     R3BLOG_IF(WARNING, !fMusicOnline, "MusicOnlineSpectra not found");
 
     // Looking for AMS online
-    fAmsOnline = (R3BAmsOnlineSpectra*)FairRunOnline::Instance()->GetTask("AmsOnlineSpectra");
+    fAmsOnline = dynamic_cast<R3BAmsOnlineSpectra*>(FairRunOnline::Instance()->GetTask("AmsOnlineSpectra"));
     R3BLOG_IF(WARNING, !fAmsOnline, "AmsOnlineSpectra not found");
 
     // Looking for LOS online
-    fLosOnline = (R3BLosOnlineSpectra*)FairRunOnline::Instance()->GetTask("LosOnlineSpectra");
+    fLosOnline = dynamic_cast<R3BLosOnlineSpectra*>(FairRunOnline::Instance()->GetTask("LosOnlineSpectra"));
     R3BLOG_IF(WARNING, !fLosOnline, "LosOnlineSpectra not found");
 
     // Looking for FOOT online
-    fFootOnline = (R3BFootOnlineSpectra*)FairRunOnline::Instance()->GetTask("FootOnlineSpectra");
+    fFootOnline = dynamic_cast<R3BFootOnlineSpectra*>(FairRunOnline::Instance()->GetTask("FootOnlineSpectra"));
     R3BLOG_IF(WARNING, !fFootOnline, "FootOnlineSpectra not found");
 
     // Looking for CALIFA online
-    fCalifaOnline = (R3BCalifaOnlineSpectra*)FairRunOnline::Instance()->GetTask("CALIFAOnlineSpectra");
+    fCalifaOnline = dynamic_cast<R3BCalifaOnlineSpectra*>(FairRunOnline::Instance()->GetTask("CALIFAOnlineSpectra"));
     R3BLOG_IF(WARNING, !fCalifaOnline, "CALIFAOnlineSpectra not found");
 
     // Looking for TOFD online
-    fTofdOnlineSpectra = (R3BTofDOnlineSpectra*)FairRunOnline::Instance()->GetTask("TofdOnlineSpectra");
+    fTofdOnlineSpectra = dynamic_cast<R3BTofDOnlineSpectra*>(FairRunOnline::Instance()->GetTask("TofdOnlineSpectra"));
     R3BLOG_IF(WARNING, !fTofdOnlineSpectra, "TofdOnlineSpectra not found");
 
     // Looking for Incoming Tracking online
     fIncomingTrackingOnline =
-        (R3BIncomingTrackingOnlineSpectra*)FairRunOnline::Instance()->GetTask("IncomingTrackingOnlineSpectra");
+        dynamic_cast<R3BIncomingTrackingOnlineSpectra*>(FairRunOnline::Instance()->GetTask("IncomingTrackingOnlineSpectra"));
     R3BLOG_IF(WARNING, !fIncomingTrackingOnline, "IncomingTrackingOnlineSpectra not found");
 
     // Looking for Incoming Tracking online
     fTwimvsFootOnlineSpectra =
-        (R3BTwimvsFootOnlineSpectra*)FairRunOnline::Instance()->GetTask("TwimvsFootOnlineSpectra");
+        dynamic_cast<R3BTwimvsFootOnlineSpectra*>(FairRunOnline::Instance()->GetTask("TwimvsFootOnlineSpectra"));
     R3BLOG_IF(WARNING, !fTwimvsFootOnlineSpectra, "TwimvsFootOnlineSpectra not found");
 
     // Create histograms for detectors
@@ -455,7 +455,7 @@ void R3BGeneralOnlineSpectra::Exec(Option_t* option)
         int64_t wrs[2];
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BWRData* hit = (R3BWRData*)fWRItemsSofia->At(ihit);
+            R3BWRData* hit = dynamic_cast<R3BWRData*>(fWRItemsSofia->At(ihit));
             if (!hit)
                 continue;
             wrs[ihit] = hit->GetTimeStamp();
@@ -468,7 +468,7 @@ void R3BGeneralOnlineSpectra::Exec(Option_t* option)
             int64_t wr[nHits];
             for (Int_t ihit = 0; ihit < nHits; ihit++)
             {
-                R3BWRData* hit = (R3BWRData*)fWRItemsCalifa->At(ihit);
+                R3BWRData* hit = dynamic_cast<R3BWRData*>(fWRItemsCalifa->At(ihit));
                 if (!hit)
                     continue;
                 wr[ihit] = hit->GetTimeStamp();
@@ -482,7 +482,7 @@ void R3BGeneralOnlineSpectra::Exec(Option_t* option)
             nHits = fWRItemsNeuland->GetEntriesFast();
             for (Int_t ihit = 0; ihit < nHits; ihit++)
             {
-                R3BWRData* hit = (R3BWRData*)fWRItemsNeuland->At(ihit);
+                R3BWRData* hit = dynamic_cast<R3BWRData*>(fWRItemsNeuland->At(ihit));
                 if (!hit)
                     continue;
                 fh1_wrs[2]->Fill(int64_t(wrs[0] - hit->GetTimeStamp()));
@@ -496,7 +496,7 @@ void R3BGeneralOnlineSpectra::Exec(Option_t* option)
             nHits = fWRItemsS2->GetEntriesFast();
             for (Int_t ihit = 0; ihit < nHits; ihit++)
             {
-                R3BWRData* hit = (R3BWRData*)fWRItemsS2->At(ihit);
+                R3BWRData* hit = dynamic_cast<R3BWRData*>(fWRItemsS2->At(ihit));
                 if (!hit)
                     continue;
                 fh1_wrs[3]->Fill(int64_t(wrs[0] - hit->GetTimeStamp()));
@@ -508,7 +508,7 @@ void R3BGeneralOnlineSpectra::Exec(Option_t* option)
             nHits = fWRItemsS8->GetEntriesFast();
             for (Int_t ihit = 0; ihit < nHits; ihit++)
             {
-                R3BWRData* hit = (R3BWRData*)fWRItemsS8->At(ihit);
+                R3BWRData* hit = dynamic_cast<R3BWRData*>(fWRItemsS8->At(ihit));
                 if (!hit)
                     continue;
                 fh1_wrs[4]->Fill(int64_t(wrs[0] - hit->GetTimeStamp()));
@@ -521,7 +521,7 @@ void R3BGeneralOnlineSpectra::Exec(Option_t* option)
             int64_t wrm = 0.;
             for (Int_t ihit = 0; ihit < nHits; ihit++)
             {
-                R3BWRData* hit = (R3BWRData*)fWRItemsMaster->At(ihit);
+                R3BWRData* hit = dynamic_cast<R3BWRData*>(fWRItemsMaster->At(ihit));
                 if (!hit)
                     continue;
                 wrm = hit->GetTimeStamp();

--- a/analysis/online/R3BIncomingIDOnlineSpectra.cxx
+++ b/analysis/online/R3BIncomingIDOnlineSpectra.cxx
@@ -85,10 +85,10 @@ void R3BIncomingIDOnlineSpectra::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(FATAL, NULL == rtdb, "FairRuntimeDb not found");
 
-    fMw0GeoPar = (R3BTGeoPar*)rtdb->getContainer("Mwpc0GeoPar");
+    fMw0GeoPar = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer("Mwpc0GeoPar"));
     R3BLOG_IF(ERROR, !fMw0GeoPar, "Could not get access to Mwpc0GeoPar container.");
 
-    fMw1GeoPar = (R3BTGeoPar*)rtdb->getContainer("Mwpc1GeoPar");
+    fMw1GeoPar = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer("Mwpc1GeoPar"));
     R3BLOG_IF(ERROR, !fMw1GeoPar, "Could not get access to Mwpc1GeoPar container.");
     return;
 }
@@ -102,7 +102,7 @@ InitStatus R3BIncomingIDOnlineSpectra::Init()
     FairRunOnline* run = FairRunOnline::Instance();
     run->GetHttpServer()->Register("", this);
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     R3BLOG_IF(ERROR, !header, "Branch EventHeader. not found");
 
     // get access to mapped data of FRS
@@ -382,7 +382,7 @@ void R3BIncomingIDOnlineSpectra::Exec(Option_t* option)
         Int_t nHits = fHitFrs->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BFrsData* hit = (R3BFrsData*)fHitFrs->At(ihit);
+            R3BFrsData* hit = dynamic_cast<R3BFrsData*>(fHitFrs->At(ihit));
             if (!hit)
                 continue;
             if (hit->GetStaId() != fStaId)
@@ -398,13 +398,13 @@ void R3BIncomingIDOnlineSpectra::Exec(Option_t* option)
             auto nHits_Mw1 = fMwpc1HitDataCA->GetEntriesFast();
             for (Int_t iMw0 = 0; iMw0 < nHits_Mw0; iMw0++)
             {
-                auto hit_mw0 = (R3BMwpcHitData*)fMwpc0HitDataCA->At(iMw0);
+                auto hit_mw0 = dynamic_cast<R3BMwpcHitData*>(fMwpc0HitDataCA->At(iMw0));
                 if (!hit_mw0)
                     continue;
                 auto mwpc0x = hit_mw0->GetX() + fMw0GeoPar->GetPosX() * 10.; // mm
                 for (Int_t iMw1 = 0; iMw1 < nHits_Mw1; iMw1++)
                 {
-                    auto hit_mw1 = (R3BMwpcHitData*)fMwpc1HitDataCA->At(iMw1);
+                    auto hit_mw1 = dynamic_cast<R3BMwpcHitData*>(fMwpc1HitDataCA->At(iMw1));
                     if (!hit_mw1)
                         continue;
                     auto mwpc1x = hit_mw1->GetX() + fMw1GeoPar->GetPosX() * 10.; // mm
@@ -428,7 +428,7 @@ void R3BIncomingIDOnlineSpectra::Exec(Option_t* option)
                 Int_t nHitsLos = fHitLos->GetEntriesFast();
                 for (Int_t ihitLos = 0; ihitLos < nHitsLos; ihitLos++)
                 {
-                    R3BLosHitData* hitLos = (R3BLosHitData*)fHitLos->At(ihitLos);
+                    R3BLosHitData* hitLos = dynamic_cast<R3BLosHitData*>(fHitLos->At(ihitLos));
                     if (!hitLos)
                         continue;
                     fh2_LosE_Tof->Fill(hit->GetTof(), hitLos->GetZ());
@@ -444,7 +444,7 @@ void R3BIncomingIDOnlineSpectra::Exec(Option_t* option)
             Int_t nHitsLos = fHitLos->GetEntriesFast();
             for (Int_t ihitLos = 0; ihitLos < nHitsLos; ihitLos++)
             {
-                R3BLosHitData* hitLos = (R3BLosHitData*)fHitLos->At(ihitLos);
+                R3BLosHitData* hitLos = dynamic_cast<R3BLosHitData*>(fHitLos->At(ihitLos));
                 if (!hitLos)
                     continue;
                 fh1_LosE_withoutTof->Fill(hitLos->GetZ());

--- a/analysis/online/R3BIncomingTrackingOnlineSpectra.cxx
+++ b/analysis/online/R3BIncomingTrackingOnlineSpectra.cxx
@@ -115,13 +115,13 @@ void R3BIncomingTrackingOnlineSpectra::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(FATAL, NULL == rtdb, "FairRuntimeDb not found");
 
-    fMw0GeoPar = (R3BTGeoPar*)rtdb->getContainer("Mwpc0GeoPar");
+    fMw0GeoPar = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer("Mwpc0GeoPar"));
     R3BLOG_IF(ERROR, !fMw0GeoPar, "Could not get access to Mwpc0GeoPar container.");
 
-    // fTargetGeoPar = (R3BTGeoPar*)rtdb->getContainer("TargetGeoPar");
+    // fTargetGeoPar = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer("TargetGeoPar"));
     // R3BLOG_IF(ERROR, !fTargetGeoPar, "Could not get access to TargetGeoPar container.");
 
-    fMw1GeoPar = (R3BTGeoPar*)rtdb->getContainer("Mwpc1GeoPar");
+    fMw1GeoPar = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer("Mwpc1GeoPar"));
     R3BLOG_IF(ERROR, !fMw1GeoPar, "Could not get access to Mwpc1GeoPar container.");
     return;
 }
@@ -346,7 +346,7 @@ void R3BIncomingTrackingOnlineSpectra::Exec(Option_t* option)
         float z = 0., aq = 0.;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto hit = (R3BFrsData*)fFrsHitDataCA->At(ihit);
+            auto hit = dynamic_cast<R3BFrsData*>(fFrsHitDataCA->At(ihit));
             if (!hit)
                 continue;
             z = hit->GetZ();
@@ -362,7 +362,7 @@ void R3BIncomingTrackingOnlineSpectra::Exec(Option_t* option)
         Int_t nHits = fMwpc0HitDataCA->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto hit = (R3BMwpcHitData*)fMwpc0HitDataCA->At(ihit);
+            auto hit = dynamic_cast<R3BMwpcHitData*>(fMwpc0HitDataCA->At(ihit));
             if (!hit)
                 continue;
             mwpc0x = hit->GetX() + fMw0GeoPar->GetPosX() * 10.; // mm
@@ -379,7 +379,7 @@ void R3BIncomingTrackingOnlineSpectra::Exec(Option_t* option)
             Float_t angY = -500.;
             for (Int_t ihit = 0; ihit < nHits; ihit++)
             {
-                auto hit = (R3BMwpcHitData*)fMwpc1HitDataCA->At(ihit);
+                auto hit = dynamic_cast<R3BMwpcHitData*>(fMwpc1HitDataCA->At(ihit));
                 if (!hit)
                     continue;
                 mwpc1x = hit->GetX() + fMw1GeoPar->GetPosX() * 10.;

--- a/analysis/online/R3BOnlineSpectra.cxx
+++ b/analysis/online/R3BOnlineSpectra.cxx
@@ -147,9 +147,9 @@ InitStatus R3BOnlineSpectra::Init()
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
 
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     if (!header)
-        header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
 
     FairRunOnline* run = FairRunOnline::Instance();
 
@@ -1257,7 +1257,7 @@ void R3BOnlineSpectra::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHitsbm; ihit++)
         {
-            R3BBeamMonitorMappedData* hit = (R3BBeamMonitorMappedData*)det->At(ihit);
+            R3BBeamMonitorMappedData* hit = dynamic_cast<R3BBeamMonitorMappedData*>(det->At(ihit));
             if (!hit)
                 continue;
 
@@ -1351,7 +1351,7 @@ void R3BOnlineSpectra::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BRoluMappedData* hit = (R3BRoluMappedData*)det->At(ihit);
+            R3BRoluMappedData* hit = dynamic_cast<R3BRoluMappedData*>(det->At(ihit));
             if (!hit)
                 continue;
 
@@ -1396,7 +1396,7 @@ void R3BOnlineSpectra::Exec(Option_t* option)
             /*
              * nParts is the number of particle passing through detector in one event
              */
-            R3BRoluCalData* calData = (R3BRoluCalData*)det->At(iPart);
+            R3BRoluCalData* calData = dynamic_cast<R3BRoluCalData*>(det->At(iPart));
             iDet = calData->GetDetector();
 
             for (Int_t iCha = 0; iCha < 4; iCha++)
@@ -1481,7 +1481,7 @@ void R3BOnlineSpectra::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BLosMappedData* hit = (R3BLosMappedData*)det->At(ihit);
+            R3BLosMappedData* hit = dynamic_cast<R3BLosMappedData*>(det->At(ihit));
             if (!hit)
                 continue;
 
@@ -1508,7 +1508,7 @@ void R3BOnlineSpectra::Exec(Option_t* option)
             /*
              * nPart is the number of particle passing through LOS detector in one event
              */
-            R3BLosCalData* calData = (R3BLosCalData*)det->At(iPart);
+            R3BLosCalData* calData = dynamic_cast<R3BLosCalData*>(det->At(iPart));
             iDet = calData->GetDetector();
 
             for (Int_t iCha = 0; iCha < 8; iCha++)
@@ -1945,7 +1945,7 @@ void R3BOnlineSpectra::Exec(Option_t* option)
             std::vector<UInt_t> spmt_num(16);
             for (Int_t ihit = 0; ihit < nHits; ihit++)
             {
-                R3BBunchedFiberMappedData* hit = (R3BBunchedFiberMappedData*)detMapped->At(ihit);
+                R3BBunchedFiberMappedData* hit = dynamic_cast<R3BBunchedFiberMappedData*>(detMapped->At(ihit));
                 if (!hit)
                     continue;
 
@@ -1995,7 +1995,7 @@ void R3BOnlineSpectra::Exec(Option_t* option)
                 Double_t tMAPMT = 0. / 0.;
                 Double_t tSPMT = 0. / 0.;
 
-                R3BBunchedFiberHitData* hit = (R3BBunchedFiberHitData*)detHit->At(ihit);
+                R3BBunchedFiberHitData* hit = dynamic_cast<R3BBunchedFiberHitData*>(detHit->At(ihit));
                 if (!hit)
                     continue;
 
@@ -2334,7 +2334,7 @@ void R3BOnlineSpectra::Exec(Option_t* option)
         LOG(DEBUG) << "nHits: " << nHits;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BPaddleCalData* hit = (R3BPaddleCalData*)det->At(ihit);
+            R3BPaddleCalData* hit = dynamic_cast<R3BPaddleCalData*>(det->At(ihit));
 
             if (!hit)
                 continue; // should not happen
@@ -2402,7 +2402,7 @@ void R3BOnlineSpectra::Exec(Option_t* option)
         //		LOG(DEBUG) << "nHits: " << nHits;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BPaddleCalData* hit = (R3BPaddleCalData*)det->At(ihit);
+            R3BPaddleCalData* hit = dynamic_cast<R3BPaddleCalData*>(det->At(ihit));
 
             if (!hit)
                 continue; // should not happen
@@ -2481,7 +2481,7 @@ void R3BOnlineSpectra::Exec(Option_t* option)
         Int_t nHits = fMappedItems.at(DET_PSPX)->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BPspxMappedData* mappedData = (R3BPspxMappedData*)fMappedItems.at(DET_PSPX)->At(ihit);
+            R3BPspxMappedData* mappedData = dynamic_cast<R3BPspxMappedData*>(fMappedItems.at(DET_PSPX)->At(ihit));
             UInt_t i = mappedData->GetDetector() - 1;
             if (mappedData->GetChannel() > N_STRIPS_PSPX * 2 && mappedData->GetChannel() < N_STRIPS_PSPX * 4 + 1)
             {
@@ -2561,7 +2561,7 @@ void R3BOnlineSpectra::Exec(Option_t* option)
         {
             for (UInt_t i = 0; i < N_PSPX; i++)
             {
-                R3BPspxCalData* calData = (R3BPspxCalData*)fCalItems.at(DET_PSPX)->At(ihit);
+                R3BPspxCalData* calData = dynamic_cast<R3BPspxCalData*>(fCalItems.at(DET_PSPX)->At(ihit));
                 num_strip[ihit][i] = calData->GetStrip();
                 if (calData->GetDetector() == i + 1 && calData->GetStrip() > N_STRIPS_PSPX &&
                     calData->GetStrip() < N_STRIPS_PSPX * 2 + 1)
@@ -2605,7 +2605,7 @@ void R3BOnlineSpectra::Exec(Option_t* option)
         {
             for (UInt_t i = 0; i < (N_PSPX + 1) / 2; i++)
             {
-                R3BPspxHitData* hitData = (R3BPspxHitData*)fHitItems.at(DET_PSPX)->At(ihit);
+                R3BPspxHitData* hitData = dynamic_cast<R3BPspxHitData*>(fHitItems.at(DET_PSPX)->At(ihit));
                 if (hitData->GetDetector() == i * 2 + 1)
                 {
                     etrue[i] = 0;

--- a/analysis/online/R3BOnlineSpectraBMON_S494.cxx
+++ b/analysis/online/R3BOnlineSpectraBMON_S494.cxx
@@ -110,7 +110,7 @@ InitStatus R3BOnlineSpectraBMON_S494::Init()
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     FairRunOnline* run = FairRunOnline::Instance();
 
     run->GetHttpServer()->Register("", this);
@@ -419,7 +419,7 @@ void R3BOnlineSpectraBMON_S494::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BRoluMappedData* hit = (R3BRoluMappedData*)det->At(ihit);
+            R3BRoluMappedData* hit = dynamic_cast<R3BRoluMappedData*>(det->At(ihit));
             if (!hit)
                 continue;
 
@@ -463,7 +463,7 @@ void R3BOnlineSpectraBMON_S494::Exec(Option_t* option)
                 /*
                  * nParts is the number of particle passing through detector in one event
                  */
-                R3BRoluCalData* calData = (R3BRoluCalData*)det->At(iPart);
+                R3BRoluCalData* calData = dynamic_cast<R3BRoluCalData*>(det->At(iPart));
                 iDet = calData->GetDetector();
 
                 for (Int_t iCha = 0; iCha < 4; iCha++)
@@ -519,7 +519,7 @@ void R3BOnlineSpectraBMON_S494::Exec(Option_t* option)
         for (Int_t ihit = 0; ihit < nHitsbm; ihit++)
         {
 
-            R3BBeamMonitorMappedData* hit = (R3BBeamMonitorMappedData*)detBmon->At(ihit);
+            R3BBeamMonitorMappedData* hit = dynamic_cast<R3BBeamMonitorMappedData*>(detBmon->At(ihit));
             if (!hit)
                 continue;
 

--- a/analysis/online/R3BOnlineSpectraDec2019.cxx
+++ b/analysis/online/R3BOnlineSpectraDec2019.cxx
@@ -136,9 +136,9 @@ InitStatus R3BOnlineSpectraDec2019::Init()
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
 
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     if (!header)
-        header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
 
     FairRunOnline* run = FairRunOnline::Instance();
 
@@ -1300,7 +1300,7 @@ void R3BOnlineSpectraDec2019::Exec(Option_t* option)
         Int_t nHitsSamp = det->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHitsSamp; ihit++)
         {
-            auto hit = (R3BSamplerMappedData*)det->At(ihit);
+            auto hit = dynamic_cast<R3BSamplerMappedData*>(det->At(ihit));
             // time is in steps of 10 ns
             // is is a 34 bit number, so max 1073741823
             samplerCurr = hit->GetTime();
@@ -1464,7 +1464,7 @@ void R3BOnlineSpectraDec2019::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHitsbm; ihit++)
         {
-            R3BBeamMonitorMappedData* hit = (R3BBeamMonitorMappedData*)det->At(ihit);
+            R3BBeamMonitorMappedData* hit = dynamic_cast<R3BBeamMonitorMappedData*>(det->At(ihit));
             if (!hit)
                 continue;
 
@@ -1543,7 +1543,7 @@ void R3BOnlineSpectraDec2019::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BRoluMappedData* hit = (R3BRoluMappedData*)det->At(ihit);
+            R3BRoluMappedData* hit = dynamic_cast<R3BRoluMappedData*>(det->At(ihit));
             if (!hit)
                 continue;
 
@@ -1590,7 +1590,7 @@ void R3BOnlineSpectraDec2019::Exec(Option_t* option)
             /*
              * nParts is the number of particle passing through detector in one event
              */
-            R3BRoluCalData* calData = (R3BRoluCalData*)det->At(iPart);
+            R3BRoluCalData* calData = dynamic_cast<R3BRoluCalData*>(det->At(iPart));
             iDet = calData->GetDetector();
 
             for (Int_t iCha = 0; iCha < 4; iCha++)
@@ -1705,7 +1705,7 @@ void R3BOnlineSpectraDec2019::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BLosMappedData* hit = (R3BLosMappedData*)det->At(ihit);
+            R3BLosMappedData* hit = dynamic_cast<R3BLosMappedData*>(det->At(ihit));
             if (!hit)
                 continue;
 
@@ -1744,7 +1744,7 @@ void R3BOnlineSpectraDec2019::Exec(Option_t* option)
             /*
              * nPart is the number of particle passing through LOS detector in one event
              */
-            R3BLosCalData* calData = (R3BLosCalData*)det->At(iPart);
+            R3BLosCalData* calData = dynamic_cast<R3BLosCalData*>(det->At(iPart));
             iDet = calData->GetDetector();
             Int_t nVftx = 0;
             Int_t nTamexL = 0;
@@ -2398,7 +2398,7 @@ void R3BOnlineSpectraDec2019::Exec(Option_t* option)
             std::vector<UInt_t> spmt_num(16);
             for (Int_t ihit = 0; ihit < nHits; ihit++)
             {
-                R3BBunchedFiberMappedData* hit = (R3BBunchedFiberMappedData*)detMapped->At(ihit);
+                R3BBunchedFiberMappedData* hit = dynamic_cast<R3BBunchedFiberMappedData*>(detMapped->At(ihit));
                 if (!hit)
                     continue;
 
@@ -2454,7 +2454,7 @@ void R3BOnlineSpectraDec2019::Exec(Option_t* option)
                 Double_t tMAPMT = 0. / 0.;
                 Double_t tSPMT = 0. / 0.;
 
-                R3BBunchedFiberHitData* hit = (R3BBunchedFiberHitData*)detHit->At(ihit);
+                R3BBunchedFiberHitData* hit = dynamic_cast<R3BBunchedFiberHitData*>(detHit->At(ihit));
                 if (!hit)
                     continue;
 
@@ -2845,7 +2845,7 @@ void R3BOnlineSpectraDec2019::Exec(Option_t* option)
         LOG(DEBUG) << "nHits: " << nHits;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BPaddleCalData* hit = (R3BPaddleCalData*)det->At(ihit);
+            R3BPaddleCalData* hit = dynamic_cast<R3BPaddleCalData*>(det->At(ihit));
 
             if (!hit)
                 continue; // should not happen
@@ -2913,7 +2913,7 @@ void R3BOnlineSpectraDec2019::Exec(Option_t* option)
         //		LOG(DEBUG) << "nHits: " << nHits;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BPaddleCalData* hit = (R3BPaddleCalData*)det->At(ihit);
+            R3BPaddleCalData* hit = dynamic_cast<R3BPaddleCalData*>(det->At(ihit));
 
             if (!hit)
                 continue; // should not happen

--- a/analysis/online/R3BOnlineSpectraFiber23.cxx
+++ b/analysis/online/R3BOnlineSpectraFiber23.cxx
@@ -96,7 +96,7 @@ InitStatus R3BOnlineSpectraFiber23::Init()
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
 
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     // uncomment lines below when ucesb avaliable
     FairRunOnline* run = FairRunOnline::Instance();
@@ -254,7 +254,7 @@ void R3BOnlineSpectraFiber23::Exec(Option_t* option)
         if (ihita < 100)
         {
             xpos_global = 0. / 0.;
-            R3BFiberMAPMTHitData* hitFi23a = (R3BFiberMAPMTHitData*)detFib23a->At(ihita);
+            R3BFiberMAPMTHitData* hitFi23a = dynamic_cast<R3BFiberMAPMTHitData*>(detFib23a->At(ihita));
             xpos_global = hitFi23a->GetX();
 
             auto detFib23b = fHitItems.at(DET_FI23B);
@@ -262,7 +262,7 @@ void R3BOnlineSpectraFiber23::Exec(Option_t* option)
             for (Int_t ihitb = 0; ihitb < nHitsb; ihitb++) // just first hit
             {
                 ypos_global = 0. / 0.;
-                R3BFiberMAPMTHitData* hitFi23b = (R3BFiberMAPMTHitData*)detFib23b->At(ihitb);
+                R3BFiberMAPMTHitData* hitFi23b = dynamic_cast<R3BFiberMAPMTHitData*>(detFib23b->At(ihitb));
                 ypos_global = hitFi23b->GetY();
                 auto dtime =
                     fmod(hitFi23a->GetTime() - hitFi23b->GetTime() + c_period + c_period / 2, c_period) - c_period / 2;

--- a/analysis/online/R3BOnlineSpectraFibvsToFDS494.cxx
+++ b/analysis/online/R3BOnlineSpectraFibvsToFDS494.cxx
@@ -174,11 +174,11 @@ InitStatus R3BOnlineSpectraFibvsToFDS494::Init()
         LOG(fatal) << "FairRootManager not found";
 
     // Look for the R3BEventHeader
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
     {
         LOG(WARNING) << "R3BOnlineSpectraFibvsToFDS494::Init() EventHeader. not found";
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     }
     else
         LOG(INFO) << "R3BOnlineSpectraFibvsToFDS494::Init() EventHeader. found";
@@ -852,7 +852,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
         // ***********************************************
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BTofdHitData* hitTofd = (R3BTofdHitData*)detTofd->At(ihit);
+            R3BTofdHitData* hitTofd = dynamic_cast<R3BTofdHitData*>(detTofd->At(ihit));
 
             if (IS_NAN(hitTofd->GetTime()))
                 continue;
@@ -951,7 +951,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
 
                             for (Int_t ihitRolu = 0; ihitRolu < nHitsRolu; ihitRolu++)
                             {
-                                R3BRoluHitData* hitRolu = (R3BRoluHitData*)detHitRolu->At(ihitRolu);
+                                R3BRoluHitData* hitRolu = dynamic_cast<R3BRoluHitData*>(detHitRolu->At(ihitRolu));
                                 Int_t iDetRolu = hitRolu->GetDetector();
                                 Int_t iCha = hitRolu->GetChannel();
                                 Double_t timeRolu = hitRolu->GetTime();
@@ -987,7 +987,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
                 for (Int_t ihitTofi = 0; ihitTofi < nHitsTofi; ihitTofi++)
                 {
                     det = tofi;
-                    R3BTofiHitData* hitTofi = (R3BTofiHitData*)detHitTofi->At(ihitTofi);
+                    R3BTofiHitData* hitTofi = dynamic_cast<R3BTofiHitData*>(detHitTofi->At(ihitTofi));
                     randx = (std::rand() / (float)RAND_MAX) - 0.5;
                     x1[det] = hitTofi->GetX() + 0.5 * randx; // cm
                     y1[det] = hitTofi->GetY();               // cm
@@ -1031,7 +1031,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
             for (Int_t ihit33 = 0; ihit33 < nHits33; ihit33++)
             {
                 det = fi33;
-                R3BFiberMAPMTHitData* hit33 = (R3BFiberMAPMTHitData*)detHit33->At(ihit33);
+                R3BFiberMAPMTHitData* hit33 = dynamic_cast<R3BFiberMAPMTHitData*>(detHit33->At(ihit33));
                 randx = (std::rand() / (float)RAND_MAX) - 0.5;
                 x1[det] = hit33->GetX() + 0.1 * randx; // cm
                 y1[det] = hit33->GetY();               // cm
@@ -1083,7 +1083,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
             for (Int_t ihit31 = 0; ihit31 < nHits31; ihit31++)
             {
                 det = fi31;
-                R3BFiberMAPMTHitData* hit31 = (R3BFiberMAPMTHitData*)detHit31->At(ihit31);
+                R3BFiberMAPMTHitData* hit31 = dynamic_cast<R3BFiberMAPMTHitData*>(detHit31->At(ihit31));
                 randx = (std::rand() / (float)RAND_MAX) - 0.5;
                 x1[det] = hit31->GetX() + 0.1 * randx; // cm
                 y1[det] = hit31->GetY();
@@ -1133,7 +1133,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
             for (Int_t ihit30 = 0; ihit30 < nHits30; ihit30++)
             {
                 det = fi30;
-                R3BFiberMAPMTHitData* hit30 = (R3BFiberMAPMTHitData*)detHit30->At(ihit30);
+                R3BFiberMAPMTHitData* hit30 = dynamic_cast<R3BFiberMAPMTHitData*>(detHit30->At(ihit30));
                 randx = (std::rand() / (float)RAND_MAX) - 0.5;
                 x1[det] = hit30->GetX() + 0.1 * randx; // cm
                 y1[det] = hit30->GetY();
@@ -1183,7 +1183,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
             for (Int_t ihit32 = 0; ihit32 < nHits32; ihit32++)
             {
                 det = fi32;
-                R3BFiberMAPMTHitData* hit32 = (R3BFiberMAPMTHitData*)detHit32->At(ihit32);
+                R3BFiberMAPMTHitData* hit32 = dynamic_cast<R3BFiberMAPMTHitData*>(detHit32->At(ihit32));
                 randx = (std::rand() / (float)RAND_MAX) - 0.5;
                 x1[det] = hit32->GetX() + 0.1 * randx; // cm
                 y1[det] = hit32->GetY();
@@ -1233,7 +1233,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
             for (Int_t ihit23a = 0; ihit23a < nHits23a; ihit23a++)
             {
                 det = fi23a;
-                R3BFiberMAPMTHitData* hit23a = (R3BFiberMAPMTHitData*)detHit23a->At(ihit23a);
+                R3BFiberMAPMTHitData* hit23a = dynamic_cast<R3BFiberMAPMTHitData*>(detHit23a->At(ihit23a));
                 randx = (std::rand() / (float)RAND_MAX) - 0.5;
                 x1[det] = hit23a->GetX() + 0.028 * randx; // cm
                 y1[det] = hit23a->GetY();
@@ -1283,7 +1283,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
             for (Int_t ihit23b = 0; ihit23b < nHits23b; ihit23b++)
             {
                 det = fi23b;
-                R3BFiberMAPMTHitData* hit23b = (R3BFiberMAPMTHitData*)detHit23b->At(ihit23b);
+                R3BFiberMAPMTHitData* hit23b = dynamic_cast<R3BFiberMAPMTHitData*>(detHit23b->At(ihit23b));
                 randx = (std::rand() / (float)RAND_MAX) - 0.5;
                 x1[det] = hit23b->GetX() + 0.028 * randx; // cm
                 y1[det] = hit23b->GetY();
@@ -1334,7 +1334,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
                 LOG(DEBUG) << "Rolu hits: " << nHitsRolu << endl;
                 for (Int_t ihitRolu = 0; ihitRolu < nHitsRolu; ihitRolu++)
                 {
-                    R3BRoluHitData* hitRolu = (R3BRoluHitData*)detHitRolu->At(ihitRolu);
+                    R3BRoluHitData* hitRolu = dynamic_cast<R3BRoluHitData*>(detHitRolu->At(ihitRolu));
                     Int_t iDetRolu = hitRolu->GetDetector();
                     Int_t iCha = hitRolu->GetChannel();
                     Double_t timeRolu = hitRolu->GetTime();
@@ -1360,7 +1360,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BTofdHitData* hitTofd = (R3BTofdHitData*)detTofd->At(ihit);
+            R3BTofdHitData* hitTofd = dynamic_cast<R3BTofdHitData*>(detTofd->At(ihit));
 
             if (IS_NAN(hitTofd->GetTime()))
                 continue;
@@ -1418,7 +1418,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
                 for (Int_t ihitTofi = 0; ihitTofi < nHitsTofi; ihitTofi++)
                 {
                     det = tofi;
-                    R3BTofiHitData* hitTofi = (R3BTofiHitData*)detHitTofi->At(ihitTofi);
+                    R3BTofiHitData* hitTofi = dynamic_cast<R3BTofiHitData*>(detHitTofi->At(ihitTofi));
                     x1[det] = hitTofi->GetX(); // cm
                     y1[det] = hitTofi->GetY(); // cm
                     z1[det] = 0.;
@@ -1459,7 +1459,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
             for (Int_t ihit33 = 0; ihit33 < nHits33; ihit33++)
             {
                 det = fi33;
-                R3BFiberMAPMTHitData* hit33 = (R3BFiberMAPMTHitData*)detHit33->At(ihit33);
+                R3BFiberMAPMTHitData* hit33 = dynamic_cast<R3BFiberMAPMTHitData*>(detHit33->At(ihit33));
                 x1[det] = hit33->GetX(); // cm
                 y1[det] = hit33->GetY(); // cm
                 q1[det] = hit33->GetEloss();
@@ -1500,7 +1500,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
             for (Int_t ihit31 = 0; ihit31 < nHits31; ihit31++)
             {
                 det = fi31;
-                R3BFiberMAPMTHitData* hit31 = (R3BFiberMAPMTHitData*)detHit31->At(ihit31);
+                R3BFiberMAPMTHitData* hit31 = dynamic_cast<R3BFiberMAPMTHitData*>(detHit31->At(ihit31));
                 x1[det] = hit31->GetX(); // cm
                 y1[det] = hit31->GetY(); // cm
                 q1[det] = hit31->GetEloss();
@@ -1541,7 +1541,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
             for (Int_t ihit30 = 0; ihit30 < nHits30; ihit30++)
             {
                 det = fi30;
-                R3BFiberMAPMTHitData* hit30 = (R3BFiberMAPMTHitData*)detHit30->At(ihit30);
+                R3BFiberMAPMTHitData* hit30 = dynamic_cast<R3BFiberMAPMTHitData*>(detHit30->At(ihit30));
                 x1[det] = hit30->GetX(); // cm
                 y1[det] = hit30->GetY(); // cm
                 q1[det] = hit30->GetEloss();
@@ -1582,7 +1582,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
             for (Int_t ihit32 = 0; ihit32 < nHits32; ihit32++)
             {
                 det = fi32;
-                R3BFiberMAPMTHitData* hit32 = (R3BFiberMAPMTHitData*)detHit32->At(ihit32);
+                R3BFiberMAPMTHitData* hit32 = dynamic_cast<R3BFiberMAPMTHitData*>(detHit32->At(ihit32));
                 x1[det] = hit32->GetX(); // cm
                 y1[det] = hit32->GetY(); // cm
                 q1[det] = hit32->GetEloss();
@@ -1623,7 +1623,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
             for (Int_t ihit23a = 0; ihit23a < nHits23a; ihit23a++)
             {
                 det = fi23a;
-                R3BFiberMAPMTHitData* hit23a = (R3BFiberMAPMTHitData*)detHit23a->At(ihit23a);
+                R3BFiberMAPMTHitData* hit23a = dynamic_cast<R3BFiberMAPMTHitData*>(detHit23a->At(ihit23a));
                 x1[det] = hit23a->GetX(); // cm
                 y1[det] = hit23a->GetY(); // cm
                 q1[det] = hit23a->GetEloss();
@@ -1664,7 +1664,7 @@ void R3BOnlineSpectraFibvsToFDS494::Exec(Option_t* option)
             for (Int_t ihit23b = 0; ihit23b < nHits23b; ihit23b++)
             {
                 det = fi23b;
-                R3BFiberMAPMTHitData* hit23b = (R3BFiberMAPMTHitData*)detHit23b->At(ihit23b);
+                R3BFiberMAPMTHitData* hit23b = dynamic_cast<R3BFiberMAPMTHitData*>(detHit23b->At(ihit23b));
                 x1[det] = hit23b->GetX(); // cm
                 y1[det] = hit23b->GetY(); // cm
                 q1[det] = hit23b->GetEloss();

--- a/analysis/online/R3BOnlineSpectraLosVsSci2.cxx
+++ b/analysis/online/R3BOnlineSpectraLosVsSci2.cxx
@@ -124,9 +124,9 @@ InitStatus R3BOnlineSpectraLosVsSci2::Init()
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     FairRunOnline* run = FairRunOnline::Instance();
 
@@ -635,7 +635,7 @@ void R3BOnlineSpectraLosVsSci2::Exec(Option_t* option)
         Int_t nHits = fHitItemsMus->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMusicHitData* hit = (R3BMusicHitData*)fHitItemsMus->At(ihit);
+            R3BMusicHitData* hit = dynamic_cast<R3BMusicHitData*>(fHitItemsMus->At(ihit));
             if (!hit)
                 continue;
             Zmusic = hit->GetZcharge();
@@ -734,7 +734,7 @@ void R3BOnlineSpectraLosVsSci2::Exec(Option_t* option)
         Int_t nHitsSamp = det->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHitsSamp; ihit++)
         {
-            auto hit = (R3BSamplerMappedData*)det->At(ihit);
+            auto hit = dynamic_cast<R3BSamplerMappedData*>(det->At(ihit));
             // time is in steps of 10 ns
             // is is a 34 bit number, so max 1073741823
             samplerCurr = hit->GetTime();
@@ -850,7 +850,7 @@ void R3BOnlineSpectraLosVsSci2::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BLosMappedData* hit = (R3BLosMappedData*)det->At(ihit);
+            R3BLosMappedData* hit = dynamic_cast<R3BLosMappedData*>(det->At(ihit));
             if (!hit)
                 continue;
 
@@ -877,7 +877,7 @@ void R3BOnlineSpectraLosVsSci2::Exec(Option_t* option)
             /*
              * nPart is the number of particle passing through LOS detector in one event
              */
-            R3BLosCalData* calData = (R3BLosCalData*)det->At(iPart);
+            R3BLosCalData* calData = dynamic_cast<R3BLosCalData*>(det->At(iPart));
             iDet = calData->GetDetector();
 
             Double_t sumvtemp = 0, sumltemp = 0, sumttemp = 0;

--- a/analysis/online/R3BOnlineSpectraPdc.cxx
+++ b/analysis/online/R3BOnlineSpectraPdc.cxx
@@ -108,9 +108,9 @@ InitStatus R3BOnlineSpectraPdc::Init()
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
 
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     if (!header)
-        header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
 
     FairRunOnline* run = FairRunOnline::Instance();
 

--- a/analysis/online/R3BOnlineSpectraSfib.cxx
+++ b/analysis/online/R3BOnlineSpectraSfib.cxx
@@ -109,9 +109,9 @@ InitStatus R3BOnlineSpectraSfib::Init()
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
 
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     if (!header)
-        header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
 
     FairRunOnline* run = FairRunOnline::Instance();
 

--- a/analysis/online/R3BOnlineSpectraToFD_S494.cxx
+++ b/analysis/online/R3BOnlineSpectraToFD_S494.cxx
@@ -103,11 +103,11 @@ InitStatus R3BOnlineSpectraToFD_S494::Init()
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
     {
         LOG(WARNING) << "R3BOnlineSpectraToFD_S494::Init() EventHeader. not found";
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     }
     else
         LOG(INFO) << "R3BOnlineSpectraToFD_S494::Init() EventHeader. found";
@@ -620,12 +620,12 @@ void R3BOnlineSpectraToFD_S494::Exec(Option_t* option)
     Float_t losTime = 0.0;
     Float_t losTriggerTime = 0.0;
 
-    R3BLosCalData* losHit = (R3BLosCalData*)fLosCalDataItems->At(0);
+    R3BLosCalData* losHit = dynamic_cast<R3BLosCalData*>(fLosCalDataItems->At(0));
     Int_t losChannel = losHit->GetDetector();
     // std::cout<<"LOS Time : "<<losHit->GetTimeT_ns(losChannel)<<std::endl;
     losTime = losHit->GetTimeT_ns(losChannel);
 
-    R3BLosCalData* losTriggerHit = (R3BLosCalData*)fLosTriggerCalDataItems->At(0);
+    R3BLosCalData* losTriggerHit = dynamic_cast<R3BLosCalData*>(fLosTriggerCalDataItems->At(0));
     Int_t losChannelTrigger = losTriggerHit->GetDetector();
     // std::cout<<"LOS Time (Trigger) :
     // "<<losTriggerHit->Ge(losHit->GetTime()-losCalTriggerHits->GetTimeL_ns(channelLos)tTimeL_ns(0)<<"
@@ -669,7 +669,7 @@ void R3BOnlineSpectraToFD_S494::Exec(Option_t* option)
         //   puts("Event");
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto* hit = (R3BTofdCalData*)det->At(ihit);
+            auto* hit = dynamic_cast<R3BTofdCalData*>(det->At(ihit));
             size_t idx = hit->GetDetectorId() * fPaddlesPerPlane * hit->GetBarId();
 
             auto ret = bar_map.insert(std::pair<size_t, Entry>(idx, Entry()));
@@ -683,7 +683,7 @@ void R3BOnlineSpectraToFD_S494::Exec(Option_t* option)
         std::vector<R3BTofdCalData*> trig_map;
         for (int i = 0; i < fCalTriggerItems->GetEntries(); ++i)
         {
-            auto trig = (R3BTofdCalData*)fCalTriggerItems->At(i);
+            auto trig = dynamic_cast<R3BTofdCalData*>(fCalTriggerItems->At(i));
             if (trig_map.size() < trig->GetBarId())
             {
                 trig_map.resize(trig->GetBarId());
@@ -966,7 +966,7 @@ void R3BOnlineSpectraToFD_S494::Exec(Option_t* option)
         Int_t nMulti[N_PLANE_MAX_TOFD_S494] = { 0 }, iCounts[N_PLANE_MAX_TOFD_S494] = { 0 };
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BTofdHitData* hitTofd = (R3BTofdHitData*)detTofd->At(ihit);
+            R3BTofdHitData* hitTofd = dynamic_cast<R3BTofdHitData*>(detTofd->At(ihit));
 
             if (IS_NAN(hitTofd->GetTime()))
                 continue;

--- a/analysis/online/R3BOnlineSpectraToFI_S494.cxx
+++ b/analysis/online/R3BOnlineSpectraToFI_S494.cxx
@@ -100,7 +100,7 @@ InitStatus R3BOnlineSpectraToFI_S494::Init()
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
 
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     FairRunOnline* run = FairRunOnline::Instance();
     run->GetHttpServer()->Register("/Tasks", this);
 
@@ -550,7 +550,7 @@ void R3BOnlineSpectraToFI_S494::Exec(Option_t* option)
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
 
-            auto* hit = (R3BTofiCalData*)det->At(ihit);
+            auto* hit = dynamic_cast<R3BTofiCalData*>(det->At(ihit));
             size_t idx = hit->GetDetectorId() * fPaddlesPerPlane * hit->GetBarId();
 
             auto ret = bar_map.insert(std::pair<size_t, Entry>(idx, Entry()));
@@ -567,7 +567,7 @@ void R3BOnlineSpectraToFI_S494::Exec(Option_t* option)
         std::vector<R3BTofiCalData*> trig_map;
         for (int i = 0; i < fCalTriggerItems->GetEntries(); ++i)
         {
-            auto trig = (R3BTofiCalData*)fCalTriggerItems->At(i);
+            auto trig = dynamic_cast<R3BTofiCalData*>(fCalTriggerItems->At(i));
             if (trig_map.size() < trig->GetBarId())
             {
                 trig_map.resize(trig->GetBarId());
@@ -885,7 +885,7 @@ void R3BOnlineSpectraToFI_S494::Exec(Option_t* option)
         Int_t nMulti[N_PLANE_MAX_TOFI] = { 0 }, iCounts[N_PLANE_MAX_TOFI] = { 0 };
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BTofiHitData* hitTofi = (R3BTofiHitData*)detTofi->At(ihit);
+            R3BTofiHitData* hitTofi = dynamic_cast<R3BTofiHitData*>(detTofi->At(ihit));
 
             if (IS_NAN(hitTofi->GetTime()))
                 continue;

--- a/analysis/online/R3BOnlineSpillAnalysis.cxx
+++ b/analysis/online/R3BOnlineSpillAnalysis.cxx
@@ -93,11 +93,11 @@ InitStatus R3BOnlineSpillAnalysis::Init()
         LOG(fatal) << "FairRootManager not found";
 
     // Look for the R3BEventHeader
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
     {
         LOG(WARNING) << "R3BOnlineSpillAnalysis::Init() EventHeader. not found";
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     }
     else
         LOG(INFO) << "R3BOnlineSpillAnalysis::Init() EventHeader. found";
@@ -415,7 +415,7 @@ void R3BOnlineSpillAnalysis::Exec(Option_t* option)
         // cout << "Hits sampler: " << nHitsSamp << endl;
         for (Int_t ihit = 0; ihit < nHitsSamp; ihit++)
         {
-            auto hit = (R3BSamplerMappedData*)det->At(ihit);
+            auto hit = dynamic_cast<R3BSamplerMappedData*>(det->At(ihit));
             // time is in steps of 10 ns
             // is is a 34 bit number, so max 1073741823
             samplerCurr = hit->GetTime();

--- a/analysis/online/R3BTwimvsFootOnlineSpectra.cxx
+++ b/analysis/online/R3BTwimvsFootOnlineSpectra.cxx
@@ -85,11 +85,11 @@ InitStatus R3BTwimvsFootOnlineSpectra::Init()
     run->GetHttpServer()->Register("", this);
 
     // Look for the R3BEventHeader
-    fEventHeader = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!fEventHeader)
     {
         R3BLOG(WARNING, "EventHeader. not found");
-        fEventHeader = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        fEventHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     }
     else
         R3BLOG(INFO, "EventHeader. found");
@@ -237,7 +237,7 @@ void R3BTwimvsFootOnlineSpectra::Exec(Option_t* option)
         {
             if (fMusli)
             {
-                auto hit = (R3BMusliHitData*)fHitItemsTwim->At(ihit);
+                auto hit = dynamic_cast<R3BMusliHitData*>(fHitItemsTwim->At(ihit));
                 if (!hit)
                     continue;
                 etwim = hit->GetZcharge();
@@ -245,7 +245,7 @@ void R3BTwimvsFootOnlineSpectra::Exec(Option_t* option)
             }
             else
             {
-                auto hit = (R3BTwimHitData*)fHitItemsTwim->At(ihit);
+                auto hit = dynamic_cast<R3BTwimHitData*>(fHitItemsTwim->At(ihit));
                 if (!hit)
                     continue;
                 etwim = hit->GetZcharge();
@@ -265,7 +265,7 @@ void R3BTwimvsFootOnlineSpectra::Exec(Option_t* option)
         Int_t nHits1 = fHitItemsFoot->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits1; ihit++)
         {
-            auto hit = (R3BFootHitData*)fHitItemsFoot->At(ihit);
+            auto hit = dynamic_cast<R3BFootHitData*>(fHitItemsFoot->At(ihit));
             if (!hit)
                 continue;
 

--- a/califa/ana/R3BCalifaCrystalCalDataAnalysis.cxx
+++ b/califa/ana/R3BCalifaCrystalCalDataAnalysis.cxx
@@ -41,7 +41,7 @@ void R3BCalifaCrystalCalDataAnalysis::Exec(Option_t* option)
     R3BCalifaCrystalCalData* hit;
     for (Int_t i = 0; i < nHits; i++)
     {
-        hit = (R3BCalifaCrystalCalData*)fCrystalData->At(i);
+        hit = dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalData->At(i));
         thCrystalID->Fill(hit->GetCrystalId());
         thEnergy->Fill(hit->GetEnergy());
         thNf->Fill(hit->GetNf());

--- a/califa/calibration/R3BCalifaCrystalCal2Hit.cxx
+++ b/califa/calibration/R3BCalifaCrystalCal2Hit.cxx
@@ -71,8 +71,8 @@ void R3BCalifaCrystalCal2Hit::SetParContainers()
     // Load CALIFA and target positions from containers
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
 
-    fCalifaGeoPar = (R3BTGeoPar*)rtdb->getContainer("CalifaGeoPar");
-    fTargetGeoPar = (R3BTGeoPar*)rtdb->getContainer("TargetGeoPar");
+    fCalifaGeoPar = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer("CalifaGeoPar"));
+    fTargetGeoPar = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer("TargetGeoPar"));
     if (!fCalifaGeoPar || !fTargetGeoPar)
     {
         R3BLOG_IF(WARNING, !fCalifaGeoPar, "Could not get access to CalifaGeoPar container.");

--- a/califa/calibration/R3BCalifaCrystalCal2TotCalPar.cxx
+++ b/califa/calibration/R3BCalifaCrystalCal2TotCalPar.cxx
@@ -70,7 +70,7 @@ void R3BCalifaCrystalCal2TotCalPar::SetParContainers()
     {
         LOG(ERROR) << "FairRuntimeDb not opened!";
     }
-    fMap_Par = (R3BCalifaMappingPar*)rtdb->getContainer("califaMappingPar");
+    fMap_Par = dynamic_cast<R3BCalifaMappingPar*>(rtdb->getContainer("califaMappingPar"));
     if (!fMap_Par)
     {
         LOG(ERROR) << "R3BCalifaCrystalCal2TotCalPar::Init() Couldn't get handle on califamappingpar container";
@@ -118,7 +118,7 @@ InitStatus R3BCalifaCrystalCal2TotCalPar::Init()
         return kFATAL;
     }
 
-    fTotCal_Par = (R3BCalifaTotCalPar*)rtdb->getContainer("CalifaTotCalPar");
+    fTotCal_Par = dynamic_cast<R3BCalifaTotCalPar*>(rtdb->getContainer("CalifaTotCalPar"));
     if (!fTotCal_Par)
 
     {
@@ -175,7 +175,7 @@ void R3BCalifaCrystalCal2TotCalPar::Exec(Option_t* opt)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        CalHit[i] = (R3BCalifaCrystalCalData*)(fCrystalCalDataCA->At(i));
+        CalHit[i] = dynamic_cast<R3BCalifaCrystalCalData*>((fCrystalCalDataCA->At(i)));
         crystalId = CalHit[i]->GetCrystalId();
         // Fill histograms
         if (CalHit[i]->GetEnergy() > fThreshold)

--- a/califa/calibration/R3BCalifaMapped2CrystalCal.cxx
+++ b/califa/calibration/R3BCalifaMapped2CrystalCal.cxx
@@ -55,7 +55,7 @@ void R3BCalifaMapped2CrystalCal::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(FATAL, !rtdb, "FairRuntimeDb not found");
 
-    fCal_Par = (R3BCalifaCrystalCalPar*)rtdb->getContainer("califaCrystalCalPar");
+    fCal_Par = dynamic_cast<R3BCalifaCrystalCalPar*>(rtdb->getContainer("califaCrystalCalPar"));
     if (!fCal_Par)
     {
         R3BLOG(ERROR, "Couldn't get handle on califaCrystalCalPar container");
@@ -65,7 +65,7 @@ void R3BCalifaMapped2CrystalCal::SetParContainers()
         R3BLOG(INFO, "califaCrystalCalPar container opened");
     }
 
-    fTotCal_Par = (R3BCalifaTotCalPar*)rtdb->getContainer("CalifaTotCalPar");
+    fTotCal_Par = dynamic_cast<R3BCalifaTotCalPar*>(rtdb->getContainer("CalifaTotCalPar"));
     if (!fTotCal_Par)
     {
         R3BLOG(WARNING, "Couldn't get handle on CalifaTotCalPar container");
@@ -225,7 +225,7 @@ void R3BCalifaMapped2CrystalCal::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BCalifaMappedData*)(fCalifaMappedDataCA->At(i));
+        mappedData[i] = dynamic_cast<R3BCalifaMappedData*>((fCalifaMappedDataCA->At(i)));
         auto crystalId = mappedData[i]->GetCrystalId();
         auto wrts = mappedData[i]->GetWrts();
         auto ov = mappedData[i]->GetOverFlow();

--- a/califa/calibration/R3BCalifaMapped2CrystalCalPar.cxx
+++ b/califa/calibration/R3BCalifaMapped2CrystalCalPar.cxx
@@ -80,7 +80,7 @@ void R3BCalifaMapped2CrystalCalPar::SetParContainers()
         LOG(ERROR) << "FairRuntimeDb not opened!";
     }
 
-    fMap_Par = (R3BCalifaMappingPar*)rtdb->getContainer("califaMappingPar");
+    fMap_Par = dynamic_cast<R3BCalifaMappingPar*>(rtdb->getContainer("califaMappingPar"));
     if (!fMap_Par)
     {
         LOG(ERROR) << "R3BCalifaMapped2CrystalCalPar::Init() Couldn't get handle on califaMappingPar container";
@@ -134,7 +134,7 @@ InitStatus R3BCalifaMapped2CrystalCalPar::Init()
         return kFATAL;
     }
 
-    fCal_Par = (R3BCalifaCrystalCalPar*)rtdb->getContainer("califaCrystalCalPar");
+    fCal_Par = dynamic_cast<R3BCalifaCrystalCalPar*>(rtdb->getContainer("califaCrystalCalPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BCalifaMapped2CrystalCalPar::Init() Couldn't get handle on califaCrystalCalPar container";
@@ -189,7 +189,7 @@ void R3BCalifaMapped2CrystalCalPar::Exec(Option_t* opt)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        MapHit[i] = (R3BCalifaMappedData*)(fCalifaMappedDataCA->At(i));
+        MapHit[i] = dynamic_cast<R3BCalifaMappedData*>((fCalifaMappedDataCA->At(i)));
         crystalId = MapHit[i]->GetCrystalId();
         // Fill histograms
         if (fMap_Par->GetInUse(crystalId) == 1)

--- a/califa/online/R3BCalifaDemoOnlineSpectra.cxx
+++ b/califa/online/R3BCalifaDemoOnlineSpectra.cxx
@@ -109,7 +109,7 @@ InitStatus R3BCalifaDemoOnlineSpectra::Init()
     }
     Int_t BinsChannelFebex = 65535;
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     FairRunOnline* run = FairRunOnline::Instance();
 
     run->GetHttpServer()->Register("", this);
@@ -1076,7 +1076,7 @@ void R3BCalifaDemoOnlineSpectra::Exec(Option_t* option)
         Int_t nHits = fWRItemsCalifa->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BWRData* hit = (R3BWRData*)fWRItemsCalifa->At(ihit);
+            R3BWRData* hit = dynamic_cast<R3BWRData*>(fWRItemsCalifa->At(ihit));
             if (!hit)
                 continue;
             wrc = hit->GetTimeStamp();
@@ -1088,7 +1088,7 @@ void R3BCalifaDemoOnlineSpectra::Exec(Option_t* option)
         Int_t nHits = fWRItemsMaster->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BWRData* hit = (R3BWRData*)fWRItemsMaster->At(ihit);
+            R3BWRData* hit = dynamic_cast<R3BWRData*>(fWRItemsMaster->At(ihit));
             if (!hit)
                 continue;
             wrm = hit->GetTimeStamp();
@@ -1111,7 +1111,7 @@ void R3BCalifaDemoOnlineSpectra::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BCalifaMappedData* hit = (R3BCalifaMappedData*)fMappedItemsCalifa->At(ihit);
+            R3BCalifaMappedData* hit = dynamic_cast<R3BCalifaMappedData*>(fMappedItemsCalifa->At(ihit));
             if (!hit)
                 continue;
 
@@ -1151,7 +1151,7 @@ void R3BCalifaDemoOnlineSpectra::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BCalifaCrystalCalData* hit = (R3BCalifaCrystalCalData*)fCalItemsCalifa->At(ihit);
+            R3BCalifaCrystalCalData* hit = dynamic_cast<R3BCalifaCrystalCalData*>(fCalItemsCalifa->At(ihit));
             if (!hit)
                 continue;
 
@@ -1210,7 +1210,7 @@ void R3BCalifaDemoOnlineSpectra::Exec(Option_t* option)
         Double_t theta = 0., phi = 0.;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BCalifaHitData* hit = (R3BCalifaHitData*)fHitItemsCalifa->At(ihit);
+            R3BCalifaHitData* hit = dynamic_cast<R3BCalifaHitData*>(fHitItemsCalifa->At(ihit));
             if (!hit)
                 continue;
             theta = hit->GetTheta() / TMath::Pi() * 180.;

--- a/califa/online/R3BCalifaJulichOnlineSpectra.cxx
+++ b/califa/online/R3BCalifaJulichOnlineSpectra.cxx
@@ -194,7 +194,7 @@ void R3BCalifaJulichOnlineSpectra::Exec(Option_t* option)
         auto nHits = fMappedItemsSi->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BAmsMappedData* hit = (R3BAmsMappedData*)fMappedItemsSi->At(ihit);
+            R3BAmsMappedData* hit = dynamic_cast<R3BAmsMappedData*>(fMappedItemsSi->At(ihit));
             if (!hit)
                 continue;
             fh2_EnergyVsStrip[hit->GetDetectorId() - 1]->Fill(hit->GetStripId(), hit->GetEnergy());

--- a/califa/online/R3BCalifaOnlineSpectra.cxx
+++ b/califa/online/R3BCalifaOnlineSpectra.cxx
@@ -128,7 +128,7 @@ void R3BCalifaOnlineSpectra::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(FATAL, !rtdb, "FairRuntimeDb not found");
 
-    fMap_Par = (R3BCalifaMappingPar*)rtdb->getContainer("califaMappingPar");
+    fMap_Par = dynamic_cast<R3BCalifaMappingPar*>(rtdb->getContainer("califaMappingPar"));
     if (!fMap_Par)
     {
         R3BLOG(ERROR, "Couldn't get handle on califaMappingPar container");
@@ -182,7 +182,7 @@ InitStatus R3BCalifaOnlineSpectra::Init()
 
     R3BLOG_IF(FATAL, NULL == mgr, "FairRootManager not found");
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
 
     FairRunOnline* run = FairRunOnline::Instance();
     run->GetHttpServer()->Register("", this);
@@ -1344,7 +1344,7 @@ void R3BCalifaOnlineSpectra::Exec(Option_t* option)
         Int_t nHits = fWRItemsCalifa->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BWRData* hit = (R3BWRData*)fWRItemsCalifa->At(ihit);
+            R3BWRData* hit = dynamic_cast<R3BWRData*>(fWRItemsCalifa->At(ihit));
             if (!hit)
                 continue;
             wr[ihit] = hit->GetTimeStamp();
@@ -1358,7 +1358,7 @@ void R3BCalifaOnlineSpectra::Exec(Option_t* option)
             nHits = fWRItemsMaster->GetEntriesFast();
             for (Int_t ihit = 0; ihit < nHits; ihit++)
             {
-                R3BWRData* hit = (R3BWRData*)fWRItemsMaster->At(ihit);
+                R3BWRData* hit = dynamic_cast<R3BWRData*>(fWRItemsMaster->At(ihit));
                 if (!hit)
                     continue;
                 wrm = hit->GetTimeStamp();
@@ -1375,7 +1375,7 @@ void R3BCalifaOnlineSpectra::Exec(Option_t* option)
         e[1] = 0.;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto hit = (R3BCalifaMappedData*)fTrigMappedItemsCalifa->At(ihit);
+            auto hit = dynamic_cast<R3BCalifaMappedData*>(fTrigMappedItemsCalifa->At(ihit));
             if (!hit)
                 continue;
             Int_t ch = hit->GetCrystalId() - 1;
@@ -1400,7 +1400,7 @@ void R3BCalifaOnlineSpectra::Exec(Option_t* option)
         Int_t Crymult = 0;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto hit = (R3BCalifaMappedData*)fMappedItemsCalifa->At(ihit);
+            auto hit = dynamic_cast<R3BCalifaMappedData*>(fMappedItemsCalifa->At(ihit));
             if (!hit)
                 continue;
 
@@ -1458,7 +1458,7 @@ void R3BCalifaOnlineSpectra::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto hit = (R3BCalifaCrystalCalData*)fCalItemsCalifa->At(ihit);
+            auto hit = dynamic_cast<R3BCalifaCrystalCalData*>(fCalItemsCalifa->At(ihit));
             if (!hit)
                 continue;
 
@@ -1491,7 +1491,7 @@ void R3BCalifaOnlineSpectra::Exec(Option_t* option)
         Double_t califa_e[nHits];
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto hit = (R3BCalifaHitData*)fHitItemsCalifa->At(ihit);
+            auto hit = dynamic_cast<R3BCalifaHitData*>(fHitItemsCalifa->At(ihit));
             if (!hit)
                 continue;
             theta = hit->GetTheta() * TMath::RadToDeg();

--- a/califa/sim/R3BCalifa.cxx
+++ b/califa/sim/R3BCalifa.cxx
@@ -212,7 +212,7 @@ Bool_t R3BCalifa::ProcessHits(FairVolume* vol)
                  gMC->CurrentEvent());
 
         // Increment number of CalifaPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kCALIFA);
         ResetParameters();
     }
@@ -262,7 +262,7 @@ void R3BCalifa::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BCalifaPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BCalifaPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BCalifaPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BCalifaPoint(*oldpoint);

--- a/califa/sim/R3BCalifaDigitizer.cxx
+++ b/califa/sim/R3BCalifaDigitizer.cxx
@@ -122,7 +122,7 @@ void R3BCalifaDigitizer::Exec(Option_t* option)
     R3BCalifaPoint** pointData = NULL;
     pointData = new R3BCalifaPoint*[nHits];
     for (Int_t i = 0; i < nHits; i++)
-        pointData[i] = (R3BCalifaPoint*)(fCalifaPointDataCA->At(i));
+        pointData[i] = dynamic_cast<R3BCalifaPoint*>((fCalifaPointDataCA->At(i)));
 
     Int_t crystalId;
     Double_t Nf;
@@ -146,14 +146,15 @@ void R3BCalifaDigitizer::Exec(Option_t* option)
         {
             for (Int_t j = 0; j < nCrystalCals; j++)
             {
-                if (((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(j)))->GetCrystalId() == crystalId)
+              auto cccd=dynamic_cast<R3BCalifaCrystalCalData*>(fCalifaCryCalDataCA->At(j));
+                if (cccd->GetCrystalId() == crystalId)
                 {
-                    ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(j)))->AddMoreEnergy(NUSmearing(energy));
-                    ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(j)))->AddMoreNf(Nf);
-                    ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(j)))->AddMoreNs(Ns);
-                    if (((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(j)))->GetTime() > time)
+                    cccd->AddMoreEnergy(NUSmearing(energy));
+                    cccd->AddMoreNf(Nf);
+                    cccd->AddMoreNs(Ns);
+                    if (cccd->GetTime() > time)
                     {
-                        ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(j)))->SetTime(time);
+                        cccd->SetTime(time);
                     }
                     existHit = 1; // to avoid the creation of a new CrystalHit
 
@@ -182,12 +183,12 @@ void R3BCalifaDigitizer::Exec(Option_t* option)
     for (Int_t i = 0; i < nCrystalCals; i++)
     {
 
-        tempCryID = ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(i)))->GetCrystalId();
+        tempCryID = (dynamic_cast<R3BCalifaCrystalCalData*>((fCalifaCryCalDataCA->At(i))))->GetCrystalId();
 
         if (!fRealConfig)
         {
 
-            temp = ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(i)))->GetEnergy();
+            temp = (dynamic_cast<R3BCalifaCrystalCalData*>((fCalifaCryCalDataCA->At(i))))->GetEnergy();
             if (temp < fThreshold)
             {
                 fCalifaCryCalDataCA->RemoveAt(i);
@@ -198,13 +199,13 @@ void R3BCalifaDigitizer::Exec(Option_t* option)
             }
 
             if (fResolution > 0)
-                ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(i)))->SetEnergy(ExpResSmearing(temp));
+                (dynamic_cast<R3BCalifaCrystalCalData*>((fCalifaCryCalDataCA->At(i))))->SetEnergy(ExpResSmearing(temp));
             if (fComponentRes > 0)
             {
-                temp = ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(i)))->GetNf();
-                ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(i)))->SetNf(CompSmearing(temp));
-                temp = ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(i)))->GetNs();
-                ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(i)))->SetNs(CompSmearing(temp));
+                temp = (dynamic_cast<R3BCalifaCrystalCalData*>((fCalifaCryCalDataCA->At(i))))->GetNf();
+                (dynamic_cast<R3BCalifaCrystalCalData*>((fCalifaCryCalDataCA->At(i))))->SetNf(CompSmearing(temp));
+                temp = (dynamic_cast<R3BCalifaCrystalCalData*>((fCalifaCryCalDataCA->At(i))))->GetNs();
+                (dynamic_cast<R3BCalifaCrystalCalData*>((fCalifaCryCalDataCA->At(i))))->SetNs(CompSmearing(temp));
             }
         }
 
@@ -213,7 +214,7 @@ void R3BCalifaDigitizer::Exec(Option_t* option)
         else
         {
 
-            temp = ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(i)))->GetEnergy();
+            temp = (dynamic_cast<R3BCalifaCrystalCalData*>((fCalifaCryCalDataCA->At(i))))->GetEnergy();
 
             inUse = fSim_Par->GetInUse(tempCryID - 1);
             fResolution = fSim_Par->GetResolution(tempCryID - 1);
@@ -222,14 +223,14 @@ void R3BCalifaDigitizer::Exec(Option_t* option)
             if (inUse && parThres < temp * 1000000)
             { // Thresholds are in KeV!!
 
-                ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(i)))->SetEnergy(ExpResSmearing(temp));
+                (dynamic_cast<R3BCalifaCrystalCalData*>((fCalifaCryCalDataCA->At(i))))->SetEnergy(ExpResSmearing(temp));
 
                 if (fComponentRes > 0)
                 {
-                    temp = ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(i)))->GetNf();
-                    ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(i)))->SetNf(CompSmearing(temp));
-                    temp = ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(i)))->GetNs();
-                    ((R3BCalifaCrystalCalData*)(fCalifaCryCalDataCA->At(i)))->SetNs(CompSmearing(temp));
+                    temp = (dynamic_cast<R3BCalifaCrystalCalData*>((fCalifaCryCalDataCA->At(i))))->GetNf();
+                    (dynamic_cast<R3BCalifaCrystalCalData*>((fCalifaCryCalDataCA->At(i))))->SetNf(CompSmearing(temp));
+                    temp = (dynamic_cast<R3BCalifaCrystalCalData*>((fCalifaCryCalDataCA->At(i))))->GetNs();
+                    (dynamic_cast<R3BCalifaCrystalCalData*>((fCalifaCryCalDataCA->At(i))))->SetNs(CompSmearing(temp));
                 }
             }
 

--- a/dch/R3BDch.cxx
+++ b/dch/R3BDch.cxx
@@ -280,7 +280,7 @@ void R3BDch::RecordFullMcHit()
         AddFullHit(trackId, mod, layer, cell, pos, lpos, mom, lmom, time, length, eLoss);
 
         // Increment number of DCH Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kDCH);
 
         ResetParameters();
@@ -421,7 +421,7 @@ void R3BDch::RecordPartialMcHit()
                fELoss);
 
         // Increment number of DCH Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kDCH);
 
         ResetParameters();
@@ -623,7 +623,7 @@ void R3BDch::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
         R3BDchFullPoint* oldpoint = NULL;
         for (Int_t i = 0; i < nEntries; i++)
         {
-            oldpoint = (R3BDchFullPoint*)cl1->At(i);
+            oldpoint = dynamic_cast<R3BDchFullPoint*>(cl1->At(i));
             Int_t index = oldpoint->GetTrackID() + offset;
             oldpoint->SetTrackID(index);
             new (clref[fPosIndex]) R3BDchFullPoint(*oldpoint);
@@ -635,7 +635,7 @@ void R3BDch::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
         R3BDchPoint* oldpoint = NULL;
         for (Int_t i = 0; i < nEntries; i++)
         {
-            oldpoint = (R3BDchPoint*)cl1->At(i);
+            oldpoint = dynamic_cast<R3BDchPoint*>(cl1->At(i));
             Int_t index = oldpoint->GetTrackID() + offset;
             oldpoint->SetTrackID(index);
             new (clref[fPosIndex]) R3BDchPoint(*oldpoint);

--- a/dch/R3BDch2pDigitizer.cxx
+++ b/dch/R3BDch2pDigitizer.cxx
@@ -174,7 +174,7 @@ void R3BDch2pDigitizer::Exec(Option_t* opt)
     for (Int_t l = 0; l < nentriesDch; l++)
     {
 
-        R3BDchPoint* dch2p_obj = (R3BDchPoint*)fDch2pPoints->At(l);
+        R3BDchPoint* dch2p_obj = dynamic_cast<R3BDchPoint*>(fDch2pPoints->At(l));
 
         Int_t DetID = dch2p_obj->GetDetectorID();
 
@@ -196,7 +196,7 @@ void R3BDch2pDigitizer::Exec(Option_t* opt)
     for (Int_t l = 0; l < nentriesDch; l++)
     {
 
-        R3BDchPoint* dch2p_obj = (R3BDchPoint*)fDch2pPoints->At(l);
+        R3BDchPoint* dch2p_obj = dynamic_cast<R3BDchPoint*>(fDch2pPoints->At(l));
 
         Int_t DetID = dch2p_obj->GetDetectorID();
         //     Double_t fPx = dch2p_obj->GetPx();
@@ -215,7 +215,7 @@ void R3BDch2pDigitizer::Exec(Option_t* opt)
         //     Double_t fY_Global_Out = dch2p_obj->GetYOut();
         //     Double_t fZ_Global_Out = dch2p_obj->GetZOut();
         TrackId = dch2p_obj->GetTrackID();
-        R3BMCTrack* aTrack = (R3BMCTrack*)fDch2pMCTrack->At(TrackId);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fDch2pMCTrack->At(TrackId));
         Int_t PID = aTrack->GetPdgCode();
         Int_t mother = aTrack->GetMotherId();
         //     Double_t fPx_track = aTrack->GetPx();

--- a/dch/R3BDchContFact.cxx
+++ b/dch/R3BDchContFact.cxx
@@ -101,11 +101,11 @@ void R3BDchContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BDchParRootFileIo* p=new R3BDchParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BDchParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BDchParAsciiFileIo* p=new R3BDchParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BDchParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/dch/R3BDchDigitizer.cxx
+++ b/dch/R3BDchDigitizer.cxx
@@ -113,7 +113,7 @@ void R3BDchDigitizer::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "SetParContainers: No runtime database";
 
-    fDchDigiPar = (R3BDchDigiPar*)(rtdb->getContainer("R3BDchDigiPar"));
+    fDchDigiPar = dynamic_cast<R3BDchDigiPar*>((rtdb->getContainer("R3BDchDigiPar")));
 
     if (fDchDigiPar)
     {
@@ -231,7 +231,7 @@ void R3BDchDigitizer::Exec(Option_t* opt)
     for (Int_t l = 0; l < nentriesDch; l++)
     {
 
-        R3BDchPoint* dch_obj = (R3BDchPoint*)fDchPoints->At(l);
+        R3BDchPoint* dch_obj = dynamic_cast<R3BDchPoint*>(fDchPoints->At(l));
 
         Int_t DetID = dch_obj->GetDetectorID();
 
@@ -255,7 +255,7 @@ void R3BDchDigitizer::Exec(Option_t* opt)
     for (Int_t l = 0; l < nentriesDch; l++)
     {
 
-        R3BDchPoint* dch_obj = (R3BDchPoint*)fDchPoints->At(l);
+        R3BDchPoint* dch_obj = dynamic_cast<R3BDchPoint*>(fDchPoints->At(l));
 
         Int_t DetID = dch_obj->GetDetectorID();
         Double_t fPx = dch_obj->GetPx();
@@ -274,7 +274,7 @@ void R3BDchDigitizer::Exec(Option_t* opt)
         //     Double_t fY_Global_Out = dch_obj->GetYOut();
         //     Double_t fZ_Global_Out = dch_obj->GetZOut();
         TrackId = dch_obj->GetTrackID();
-        R3BMCTrack* aTrack = (R3BMCTrack*)fDchMCTrack->At(TrackId);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fDchMCTrack->At(TrackId));
         Int_t PID = aTrack->GetPdgCode();
         Int_t mother = aTrack->GetMotherId();
         Double_t fPx_track = aTrack->GetPx();

--- a/epics/R3BChannelAccessEPICS.cxx
+++ b/epics/R3BChannelAccessEPICS.cxx
@@ -64,7 +64,7 @@ bool R3BChannelAccessGroupEPICS::Commit()
     ret &= Search();
     for (Int_t i = 0; i < fChannelArray.GetEntriesFast(); ++i)
     {
-        auto ca = (R3BChannelAccessEPICS*)fChannelArray[i];
+        auto ca = dynamic_cast<R3BChannelAccessEPICS*>(fChannelArray[i]);
         ca_put(ca->GetType(), ca->GetID(), ca->GetPointer());
     }
     ret &= PendIO("get");
@@ -77,7 +77,7 @@ bool R3BChannelAccessGroupEPICS::Fetch()
     ret &= Search();
     for (Int_t i = 0; i < fChannelArray.GetEntriesFast(); ++i)
     {
-        auto ca = (R3BChannelAccessEPICS*)fChannelArray[i];
+        auto ca = dynamic_cast<R3BChannelAccessEPICS*>(fChannelArray[i]);
         ca_get(ca->GetType(), ca->GetID(), ca->GetPointer());
     }
     ret &= PendIO("get");

--- a/evtvis/R3BCalifaEventDisplay.cxx
+++ b/evtvis/R3BCalifaEventDisplay.cxx
@@ -168,7 +168,7 @@ void R3BCalifaEventDisplay::Exec(Option_t* opt)
         // Loop in Crystal Hits
         for (Int_t i = 0; i < crystalHits; i++)
         {
-            crystalHit = (R3BCalifaCrystalCalData*)fCrystalHitCA->At(i);
+            crystalHit = dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalHitCA->At(i));
             GetAngles(fGeometryVersion, crystalHit->GetCrystalId(), &theta, &phi, &rho);
         }
 

--- a/evtvis/R3BCalifaHitEventDisplay.cxx
+++ b/evtvis/R3BCalifaHitEventDisplay.cxx
@@ -164,7 +164,7 @@ void R3BCalifaHitEventDisplay::Exec(Option_t* opt)
         {
 
             Int_t binx = -1, biny = -1;
-            caloHit = (R3BCalifaHitData*)fCaloHitCA->At(i);
+            caloHit = dynamic_cast<R3BCalifaHitData*>(fCaloHitCA->At(i));
             theta = caloHit->GetTheta();
             phi = caloHit->GetPhi();
 

--- a/evtvis/R3BEventManager.cxx
+++ b/evtvis/R3BEventManager.cxx
@@ -48,7 +48,7 @@ void R3BEventManager::AddParticlesToPdgDataBase(Int_t pdgCode)
         bool particleRecognised = true;
         char name[20];
 
-        particleRecognised = ((R3BIonName*)fIonName)->GetIonName(element, name);
+        particleRecognised = (dynamic_cast<R3BIonName*>(fIonName)->GetIonName(element, name));
 
         if (particleRecognised)
         {

--- a/evtvis/R3BEventManagerEditor.cxx
+++ b/evtvis/R3BEventManagerEditor.cxx
@@ -190,7 +190,7 @@ void R3BEventManagerEditor::SetModel(TObject* obj) { fObject = obj; }
 void R3BEventManagerEditor::DoScaleE()
 {
     if (fScaleE->IsOn())
-        ((R3BEventManager*)fManager)->SetScaleByEnergy(kTRUE);
+        (dynamic_cast<R3BEventManager*>(fManager)->SetScaleByEnergy(kTRUE));
     else
-        ((R3BEventManager*)fManager)->SetScaleByEnergy(kFALSE);
+        (dynamic_cast<R3BEventManager*>(fManager)->SetScaleByEnergy(kFALSE));
 }

--- a/evtvis/R3BMCTracks.cxx
+++ b/evtvis/R3BMCTracks.cxx
@@ -132,7 +132,7 @@ void R3BMCTracks::Exec(Option_t* option)
             if ((PEnergy < fEventManager->GetMinEnergy()) || (PEnergy > fEventManager->GetMaxEnergy()))
                 continue;
 
-            ((R3BEventManager*)fEventManager)->AddParticlesToPdgDataBase(tr->GetPDG());
+            dynamic_cast<R3BEventManager*>(fEventManager)->AddParticlesToPdgDataBase(tr->GetPDG());
             if (fVerbose > 3)
                 cout << "Particle with PDG " << tr->GetPDG() << " added to DataBase " << endl;
             if (fVerbose > 3)
@@ -168,7 +168,7 @@ void R3BMCTracks::Exec(Option_t* option)
             track->SetTitle(title);
 
             // Set the line width depending on energy
-            if (((R3BEventManager*)fEventManager)->IsScaleByEnergy())
+            if (dynamic_cast<R3BEventManager*>(fEventManager)->IsScaleByEnergy())
             {
                 Int_t lineWidth =
                     (Int_t)(PEnergy / TMath::Min(fEventManager->GetMaxEnergy(), (Float_t)MaxEnergyLimit) * 15.0);

--- a/fiber/bunched/R3BBunchedFiberCal2Hit.cxx
+++ b/fiber/bunched/R3BBunchedFiberCal2Hit.cxx
@@ -143,9 +143,9 @@ InitStatus R3BBunchedFiberCal2Hit::Init()
     auto mgr = FairRootManager::Instance();
     R3BLOG_IF(FATAL, !mgr, "FairRootManager not found.");
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     auto name = fName + "Cal";
     fCalItems = (TClonesArray*)mgr->GetObject(name);
@@ -179,7 +179,7 @@ InitStatus R3BBunchedFiberCal2Hit::Init()
     {
         // Get calibration parameters if we're not a calibrator.
         auto container = fName + "HitPar";
-        fHitPar = (R3BBunchedFiberHitPar*)FairRuntimeDb::instance()->getContainer(container);
+        fHitPar = dynamic_cast<R3BBunchedFiberHitPar*>(FairRuntimeDb::instance()->getContainer(container));
 
         if (!fHitPar)
         {
@@ -300,7 +300,7 @@ InitStatus R3BBunchedFiberCal2Hit::ReInit()
 
 void R3BBunchedFiberCal2Hit::SetParContainers()
 {
-    fMapPar = (R3BFiberMappingPar*)FairRuntimeDb::instance()->getContainer(fName + "MappingPar");
+    fMapPar = dynamic_cast<R3BFiberMappingPar*>(FairRuntimeDb::instance()->getContainer(fName + "MappingPar"));
     if (!fMapPar)
     {
         R3BLOG(ERROR, "Couldn't get " << fName << "MappingPar");
@@ -315,7 +315,7 @@ void R3BBunchedFiberCal2Hit::SetParContainers()
         R3BLOG(INFO, "Nb of fibers for " << fName << ": " << fNumFibers);
     }
 
-    fCalPar = (R3BBunchedFiberHitPar*)FairRuntimeDb::instance()->getContainer(fName + "HitPar");
+    fCalPar = dynamic_cast<R3BBunchedFiberHitPar*>(FairRuntimeDb::instance()->getContainer(fName + "HitPar"));
     R3BLOG_IF(ERROR, !fCalPar, "Couldn't get " << fName << "HitPar.");
 }
 

--- a/fiber/bunched/R3BBunchedFiberCal2Hit_s494.cxx
+++ b/fiber/bunched/R3BBunchedFiberCal2Hit_s494.cxx
@@ -134,7 +134,7 @@ InitStatus R3BBunchedFiberCal2Hit_s494::Init()
     {
         // Get calibration parameters if we're not a calibrator.
         auto container = fName + "HitPar";
-        fHitPar = (R3BBunchedFiberHitPar*)FairRuntimeDb::instance()->getContainer(container);
+        fHitPar = dynamic_cast<R3BBunchedFiberHitPar*>(FairRuntimeDb::instance()->getContainer(container));
         if (!fHitPar)
         {
             LOG(ERROR) << "Could not get " << container << " container.";
@@ -219,7 +219,7 @@ void R3BBunchedFiberCal2Hit_s494::SetParContainers()
 {
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-    fCalPar = (R3BBunchedFiberHitPar*)FairRuntimeDb::instance()->getContainer(fName + "HitPar");
+    fCalPar = dynamic_cast<R3BBunchedFiberHitPar*>(FairRuntimeDb::instance()->getContainer(fName + "HitPar"));
     if (!fCalPar)
     {
         LOG(ERROR) << "R3BFiberCal2Hit_s494::Init() Couldn't get " << fName << "HitPar. ";

--- a/fiber/bunched/R3BBunchedFiberMapped2Cal.cxx
+++ b/fiber/bunched/R3BBunchedFiberMapped2Cal.cxx
@@ -126,7 +126,7 @@ void R3BBunchedFiberMapped2Cal::SetParContainers()
     do                                                                         \
     {                                                                          \
         auto name = fName + #NAME "TCalPar";                                   \
-        f##NAME##TCalPar = (R3BTCalPar*)rtdb->getContainer(name);              \
+        f##NAME##TCalPar = dynamic_cast<R3BTCalPar*>(rtdb->getContainer(name));              \
         if (!f##NAME##TCalPar)                                                 \
         {                                                                      \
             R3BLOG(ERROR, "Could not get access to " << name << " container"); \
@@ -165,7 +165,7 @@ void R3BBunchedFiberMapped2Cal::Exec(Option_t* option)
 
     for (auto i = 0; i < mapped_num; i++)
     {
-        auto mapped = (R3BFiberMappedData*)fMappedItems->At(i);
+        auto mapped = dynamic_cast<R3BFiberMappedData*>(fMappedItems->At(i));
         auto channel = mapped->GetChannel();
         R3BLOG(DEBUG, "Channel=" << channel << ":Edge=" << (mapped->IsLeading() ? "Leading" : "Trailing") << '.');
 

--- a/fiber/bunched/R3BBunchedFiberMapped2CalPar.cxx
+++ b/fiber/bunched/R3BBunchedFiberMapped2CalPar.cxx
@@ -61,7 +61,7 @@ InitStatus R3BBunchedFiberMapped2CalPar::Init()
     do                                                                                 \
     {                                                                                  \
         auto name = fName + #NAME "TCalPar";                                           \
-        f##NAME##TCalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer(name); \
+        f##NAME##TCalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer(name)); \
         if (!f##NAME##TCalPar)                                                         \
         {                                                                              \
             R3BLOG(ERROR, "Could not get " << name);                                   \
@@ -89,7 +89,7 @@ void R3BBunchedFiberMapped2CalPar::Exec(Option_t* option)
     auto mapped_num = fMapped->GetEntriesFast();
     for (auto i = 0; i < mapped_num; i++)
     {
-        auto mapped = (R3BFiberMappedData*)fMapped->At(i);
+        auto mapped = dynamic_cast<R3BFiberMappedData*>(fMapped->At(i));
         assert(mapped);
         auto channel = mapped->GetChannel();
         if (mapped->IsMAPMT())

--- a/fiber/bunched/R3BBunchedFiberSPMTTrigMapped2Cal.cxx
+++ b/fiber/bunched/R3BBunchedFiberSPMTTrigMapped2Cal.cxx
@@ -71,7 +71,7 @@ InitStatus R3BBunchedFiberSPMTTrigMapped2Cal::Init()
 void R3BBunchedFiberSPMTTrigMapped2Cal::SetParContainers()
 {
     auto name = "BunchedFiberSPMTTrigTCalPar";
-    fTCalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer(name);
+    fTCalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer(name));
     if (!fTCalPar)
     {
         LOG(ERROR) << "Could not get access to " << name << " container.";
@@ -90,9 +90,9 @@ void R3BBunchedFiberSPMTTrigMapped2Cal::Exec(Option_t* option)
     LOG(DEBUG) << "R3BBunchedFiberSPMTTrigMapped2Cal::Exec:fMappedItems=" << fMappedItems->GetName() << '.';
     for (auto i = 0; i < mapped_num; i++)
     {
-        auto mapped = (R3BFiberMappedData*)fMappedItems->At(i);
+        auto mapped = dynamic_cast<R3BFiberMappedData*>(fMappedItems->At(i));
         auto channel = mapped->GetChannel();
-        auto par = (R3BTCalModulePar*)fTCalPar->GetModuleParAt(1, channel, 1);
+        auto par = dynamic_cast<R3BTCalModulePar*>(fTCalPar->GetModuleParAt(1, channel, 1));
         if (!par)
         {
             LOG(WARNING) << "R3BBunchedFiberSPMTTrigMapped2Cal::Exec (" << fName << "): Channel=" << channel

--- a/fiber/bunched/R3BBunchedFiberSPMTTrigMapped2CalPar.cxx
+++ b/fiber/bunched/R3BBunchedFiberSPMTTrigMapped2CalPar.cxx
@@ -50,7 +50,7 @@ InitStatus R3BBunchedFiberSPMTTrigMapped2CalPar::Init()
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakeLists.txt in the detector directory.
     auto name = "BunchedFiberSPMTTrigTCalPar";
-    fTCalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer(name);
+    fTCalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer(name));
     if (!fTCalPar)
     {
         R3BLOG(ERROR, "Could not get " << name);
@@ -66,7 +66,7 @@ void R3BBunchedFiberSPMTTrigMapped2CalPar::Exec(Option_t* option)
     auto mapped_num = fMapped->GetEntriesFast();
     for (auto i = 0; i < mapped_num; i++)
     {
-        auto mapped = (R3BFiberMappedData*)fMapped->At(i);
+        auto mapped = dynamic_cast<R3BFiberMappedData*>(fMapped->At(i));
         fEngine->Fill(1, mapped->GetChannel(), 1, mapped->GetFine());
     }
 }

--- a/fiber/digi/R3BFiberDigitizer.cxx
+++ b/fiber/digi/R3BFiberDigitizer.cxx
@@ -68,7 +68,7 @@ void R3BFiberDigitizer::SetYPositionResolution(Double_t y) { ysigma = y; }
 void R3BFiberDigitizer::SetParContainers()
 {
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
-    fFiGeoPar = (R3BTGeoPar*)rtdb->getContainer(fName + "GeoPar");
+    fFiGeoPar = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer(fName + "GeoPar"));
     if (!fFiGeoPar)
     {
         R3BLOG(ERROR, "R3BFiberDigitizer::SetParContainers() : Could not get access to " + fName + "GeoPar container.");
@@ -135,10 +135,10 @@ void R3BFiberDigitizer::Exec(Option_t* opt)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        pointData[i] = (R3BFibPoint*)(fFiPoints->At(i));
+        pointData[i] = dynamic_cast<R3BFibPoint*>((fFiPoints->At(i)));
         TrackId = pointData[i]->GetTrackID();
 
-        R3BMCTrack* Track = (R3BMCTrack*)fMCTrack->At(TrackId);
+        R3BMCTrack* Track = dynamic_cast<R3BMCTrack*>(fMCTrack->At(TrackId));
         PID = Track->GetPdgCode();
         // mother = Track->GetMotherId();
 

--- a/fiber/mapmt/R3BFiberMAPMTCal2Hit.cxx
+++ b/fiber/mapmt/R3BFiberMAPMTCal2Hit.cxx
@@ -116,7 +116,7 @@ InitStatus R3BFiberMAPMTCal2Hit::Init()
     auto mgr = FairRootManager::Instance();
     R3BLOG_IF(FATAL, !mgr, "FairRootManager not found.");
 
-    fHeader = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    fHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     R3BLOG_IF(fatal, NULL == fHeader, "EventHeader. not found");
 
     auto name = fName + "Cal";
@@ -234,7 +234,7 @@ InitStatus R3BFiberMAPMTCal2Hit::ReInit()
 
 void R3BFiberMAPMTCal2Hit::SetParContainers()
 {
-    fMapPar = (R3BFiberMappingPar*)FairRuntimeDb::instance()->getContainer(fName + "MappingPar");
+    fMapPar = dynamic_cast<R3BFiberMappingPar*>(FairRuntimeDb::instance()->getContainer(fName + "MappingPar"));
     if (!fMapPar)
     {
         R3BLOG(ERROR, "Couldn't get " << fName << "MappingPar");
@@ -246,7 +246,7 @@ void R3BFiberMAPMTCal2Hit::SetParContainers()
     }
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-    fCalPar = (R3BFiberMAPMTHitPar*)FairRuntimeDb::instance()->getContainer(fName + "HitPar");
+    fCalPar = dynamic_cast<R3BFiberMAPMTHitPar*>(FairRuntimeDb::instance()->getContainer(fName + "HitPar"));
     R3BLOG_IF(INFO, fCalPar, "Container " << fName << "HitPar initialized");
     R3BLOG_IF(ERROR, !fCalPar, "Couldn't get " << fName << "HitPar");
 
@@ -254,7 +254,7 @@ void R3BFiberMAPMTCal2Hit::SetParContainers()
     {
         // Get calibration parameters if we're not a calibrator.
         auto container = fName + "HitPar";
-        fHitPar = (R3BFiberMAPMTHitPar*)FairRuntimeDb::instance()->getContainer(container);
+        fHitPar = dynamic_cast<R3BFiberMAPMTHitPar*>(FairRuntimeDb::instance()->getContainer(container));
         R3BLOG_IF(ERROR, !fHitPar, "Could not get " << container << " container.");
     }
 }
@@ -279,7 +279,7 @@ void R3BFiberMAPMTCal2Hit::Exec(Option_t* option)
     Double_t tl, tt; // lead and trile times of the trigger
     for (UInt_t j = 0; j < cal_num_trig; ++j)
     {
-        auto cur_cal = (R3BFiberMAPMTCalData*)fCalTriggerItems->At(j);
+        auto cur_cal = dynamic_cast<R3BFiberMAPMTCalData*>(fCalTriggerItems->At(j));
         auto ch = cur_cal->GetChannel() - 1;
         tl = cur_cal->GetTime_ns();
         trig_time[ch] = tl;

--- a/fiber/mapmt/R3BFiberMAPMTMapped2Cal.cxx
+++ b/fiber/mapmt/R3BFiberMAPMTMapped2Cal.cxx
@@ -76,7 +76,7 @@ void R3BFiberMAPMTMapped2Cal::SetParContainers()
     do                                                                                 \
     {                                                                                  \
         auto name = fName + #NAME "TCalPar";                                           \
-        f##NAME##TCalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer(name); \
+        f##NAME##TCalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer(name)); \
         if (!f##NAME##TCalPar)                                                         \
         {                                                                              \
             R3BLOG(ERROR, "Could not get access to " << name << " container.");        \
@@ -103,7 +103,7 @@ void R3BFiberMAPMTMapped2Cal::Exec(Option_t* option)
 
     for (auto i = 0; i < mapped_num; i++)
     {
-        auto mapped = (R3BFiberMappedData*)fMappedItems->At(i);
+        auto mapped = dynamic_cast<R3BFiberMappedData*>(fMappedItems->At(i));
         assert(mapped);
 
         auto channel = mapped->GetChannel();

--- a/fiber/mapmt/R3BFiberMAPMTMapped2CalPar.cxx
+++ b/fiber/mapmt/R3BFiberMAPMTMapped2CalPar.cxx
@@ -63,7 +63,7 @@ InitStatus R3BFiberMAPMTMapped2CalPar::Init()
     do                                                                                 \
     {                                                                                  \
         auto name = fName + #NAME "TCalPar";                                           \
-        f##NAME##TCalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer(name); \
+        f##NAME##TCalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer(name)); \
         if (!f##NAME##TCalPar)                                                         \
         {                                                                              \
             R3BLOG(ERROR, "Could not find " << name);                                  \
@@ -83,7 +83,7 @@ void R3BFiberMAPMTMapped2CalPar::Exec(Option_t* option)
     auto mapped_num = fMapped->GetEntriesFast();
     for (auto i = 0; i < mapped_num; i++)
     {
-        auto mapped = (R3BFiberMappedData*)fMapped->At(i);
+        auto mapped = dynamic_cast<R3BFiberMappedData*>(fMapped->At(i));
         assert(mapped);
         if (!mapped->IsTrigger())
         {

--- a/fiber/obsolete/fi10/R3BFi10.cxx
+++ b/fiber/obsolete/fi10/R3BFi10.cxx
@@ -213,7 +213,7 @@ Bool_t R3BFi10::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi10Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI10);
 
         ResetParameters();
@@ -275,7 +275,7 @@ void R3BFi10::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi10/R3BFi10ContFact.cxx
+++ b/fiber/obsolete/fi10/R3BFi10ContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi10ContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi10/R3BFi10Digitizer.cxx
+++ b/fiber/obsolete/fi10/R3BFi10Digitizer.cxx
@@ -139,7 +139,7 @@ void R3BFi10Digitizer::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(),
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi10/R3BFi10DigitizerCal.cxx
+++ b/fiber/obsolete/fi10/R3BFi10DigitizerCal.cxx
@@ -129,7 +129,7 @@ void R3BFi10DigitizerCal::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(), // fiber nummer
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi11/R3BFi11.cxx
+++ b/fiber/obsolete/fi11/R3BFi11.cxx
@@ -213,7 +213,7 @@ Bool_t R3BFi11::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi11Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI11);
         ResetParameters();
     }
@@ -274,7 +274,7 @@ void R3BFi11::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi11/R3BFi11ContFact.cxx
+++ b/fiber/obsolete/fi11/R3BFi11ContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi11ContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi11/R3BFi11Digitizer.cxx
+++ b/fiber/obsolete/fi11/R3BFi11Digitizer.cxx
@@ -139,7 +139,7 @@ void R3BFi11Digitizer::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(),
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi11/R3BFi11DigitizerCal.cxx
+++ b/fiber/obsolete/fi11/R3BFi11DigitizerCal.cxx
@@ -129,7 +129,7 @@ void R3BFi11DigitizerCal::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(), // fiber nummer
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi12/R3BFi12.cxx
+++ b/fiber/obsolete/fi12/R3BFi12.cxx
@@ -213,7 +213,7 @@ Bool_t R3BFi12::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi12Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI12);
 
         ResetParameters();
@@ -275,7 +275,7 @@ void R3BFi12::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi12/R3BFi12ContFact.cxx
+++ b/fiber/obsolete/fi12/R3BFi12ContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi12ContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi12/R3BFi12Digitizer.cxx
+++ b/fiber/obsolete/fi12/R3BFi12Digitizer.cxx
@@ -139,7 +139,7 @@ void R3BFi12Digitizer::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(),
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi12/R3BFi12DigitizerCal.cxx
+++ b/fiber/obsolete/fi12/R3BFi12DigitizerCal.cxx
@@ -129,7 +129,7 @@ void R3BFi12DigitizerCal::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(), // fiber nummer
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi13/R3BFi13.cxx
+++ b/fiber/obsolete/fi13/R3BFi13.cxx
@@ -213,7 +213,7 @@ Bool_t R3BFi13::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi13Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI13);
 
         ResetParameters();
@@ -275,7 +275,7 @@ void R3BFi13::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi13/R3BFi13ContFact.cxx
+++ b/fiber/obsolete/fi13/R3BFi13ContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi13ContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi13/R3BFi13Digitizer.cxx
+++ b/fiber/obsolete/fi13/R3BFi13Digitizer.cxx
@@ -140,7 +140,7 @@ void R3BFi13Digitizer::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(),
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi13/R3BFi13DigitizerCal.cxx
+++ b/fiber/obsolete/fi13/R3BFi13DigitizerCal.cxx
@@ -129,7 +129,7 @@ void R3BFi13DigitizerCal::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(), // fiber nummer
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi23a/R3BFi23a.cxx
+++ b/fiber/obsolete/fi23a/R3BFi23a.cxx
@@ -210,7 +210,7 @@ Bool_t R3BFi23a::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi23aPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI23a);
 
         ResetParameters();
@@ -272,7 +272,7 @@ void R3BFi23a::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi23a/R3BFi23aContFact.cxx
+++ b/fiber/obsolete/fi23a/R3BFi23aContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi23aContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi23a/R3BFi23aDigitizer.cxx
+++ b/fiber/obsolete/fi23a/R3BFi23aDigitizer.cxx
@@ -139,7 +139,7 @@ void R3BFi23aDigitizer::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(),
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi23a/R3BFi23aDigitizerCal.cxx
+++ b/fiber/obsolete/fi23a/R3BFi23aDigitizerCal.cxx
@@ -131,7 +131,7 @@ void R3BFi23aDigitizerCal::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
             // cout << "Hit: " << data_element->GetDetectorID() << endl;
             TempHits.push_back(TempHit(data_element->GetDetectorID(), // fiber nummer
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi23b/R3BFi23b.cxx
+++ b/fiber/obsolete/fi23b/R3BFi23b.cxx
@@ -213,7 +213,7 @@ Bool_t R3BFi23b::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi23bPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI23b);
 
         ResetParameters();
@@ -275,7 +275,7 @@ void R3BFi23b::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi23b/R3BFi23bContFact.cxx
+++ b/fiber/obsolete/fi23b/R3BFi23bContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi23bContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi23b/R3BFi23bDigitizer.cxx
+++ b/fiber/obsolete/fi23b/R3BFi23bDigitizer.cxx
@@ -139,7 +139,7 @@ void R3BFi23bDigitizer::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(),
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi23b/R3BFi23bDigitizerCal.cxx
+++ b/fiber/obsolete/fi23b/R3BFi23bDigitizerCal.cxx
@@ -129,7 +129,7 @@ void R3BFi23bDigitizerCal::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(), // fiber nummer
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi30/R3BFi30.cxx
+++ b/fiber/obsolete/fi30/R3BFi30.cxx
@@ -213,7 +213,7 @@ Bool_t R3BFi30::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi30Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI30);
 
         ResetParameters();
@@ -275,7 +275,7 @@ void R3BFi30::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi30/R3BFi30ContFact.cxx
+++ b/fiber/obsolete/fi30/R3BFi30ContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi30ContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi30/R3BFi30Digitizer.cxx
+++ b/fiber/obsolete/fi30/R3BFi30Digitizer.cxx
@@ -139,7 +139,7 @@ void R3BFi30Digitizer::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(),
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi30/R3BFi30DigitizerCal.cxx
+++ b/fiber/obsolete/fi30/R3BFi30DigitizerCal.cxx
@@ -129,7 +129,7 @@ void R3BFi30DigitizerCal::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(), // fiber nummer
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi31/R3BFi31.cxx
+++ b/fiber/obsolete/fi31/R3BFi31.cxx
@@ -213,7 +213,7 @@ Bool_t R3BFi31::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi31Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI31);
 
         ResetParameters();
@@ -275,7 +275,7 @@ void R3BFi31::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi31/R3BFi31ContFact.cxx
+++ b/fiber/obsolete/fi31/R3BFi31ContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi31ContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi31/R3BFi31Digitizer.cxx
+++ b/fiber/obsolete/fi31/R3BFi31Digitizer.cxx
@@ -139,7 +139,7 @@ void R3BFi31Digitizer::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(),
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi31/R3BFi31DigitizerCal.cxx
+++ b/fiber/obsolete/fi31/R3BFi31DigitizerCal.cxx
@@ -129,7 +129,7 @@ void R3BFi31DigitizerCal::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(), // fiber nummer
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi32/R3BFi32.cxx
+++ b/fiber/obsolete/fi32/R3BFi32.cxx
@@ -213,7 +213,7 @@ Bool_t R3BFi32::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi32Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI32);
 
         ResetParameters();
@@ -275,7 +275,7 @@ void R3BFi32::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi32/R3BFi32ContFact.cxx
+++ b/fiber/obsolete/fi32/R3BFi32ContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi32ContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi32/R3BFi32Digitizer.cxx
+++ b/fiber/obsolete/fi32/R3BFi32Digitizer.cxx
@@ -139,7 +139,7 @@ void R3BFi32Digitizer::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(),
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi32/R3BFi32DigitizerCal.cxx
+++ b/fiber/obsolete/fi32/R3BFi32DigitizerCal.cxx
@@ -129,7 +129,7 @@ void R3BFi32DigitizerCal::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(), // fiber nummer
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi33/R3BFi33.cxx
+++ b/fiber/obsolete/fi33/R3BFi33.cxx
@@ -213,7 +213,7 @@ Bool_t R3BFi33::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi33Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI33);
 
         ResetParameters();
@@ -275,7 +275,7 @@ void R3BFi33::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi33/R3BFi33ContFact.cxx
+++ b/fiber/obsolete/fi33/R3BFi33ContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi33ContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi33/R3BFi33Digitizer.cxx
+++ b/fiber/obsolete/fi33/R3BFi33Digitizer.cxx
@@ -139,7 +139,7 @@ void R3BFi33Digitizer::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(),
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi33/R3BFi33DigitizerCal.cxx
+++ b/fiber/obsolete/fi33/R3BFi33DigitizerCal.cxx
@@ -129,7 +129,7 @@ void R3BFi33DigitizerCal::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(), // fiber nummer
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi3a/R3BFi3a.cxx
+++ b/fiber/obsolete/fi3a/R3BFi3a.cxx
@@ -213,7 +213,7 @@ Bool_t R3BFi3a::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi3aPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI3a);
 
         ResetParameters();
@@ -275,7 +275,7 @@ void R3BFi3a::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi3a/R3BFi3aContFact.cxx
+++ b/fiber/obsolete/fi3a/R3BFi3aContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi3aContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi3a/R3BFi3aDigitizer.cxx
+++ b/fiber/obsolete/fi3a/R3BFi3aDigitizer.cxx
@@ -139,7 +139,7 @@ void R3BFi3aDigitizer::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(),
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi3a/R3BFi3aDigitizerCal.cxx
+++ b/fiber/obsolete/fi3a/R3BFi3aDigitizerCal.cxx
@@ -131,7 +131,7 @@ void R3BFi3aDigitizerCal::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
             // cout << "Hit: " << data_element->GetDetectorID() << endl;
             TempHits.push_back(TempHit(data_element->GetDetectorID(), // fiber nummer
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi3b/R3BFi3b.cxx
+++ b/fiber/obsolete/fi3b/R3BFi3b.cxx
@@ -213,7 +213,7 @@ Bool_t R3BFi3b::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi3bPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI3b);
 
         ResetParameters();
@@ -275,7 +275,7 @@ void R3BFi3b::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi3b/R3BFi3bContFact.cxx
+++ b/fiber/obsolete/fi3b/R3BFi3bContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi3bContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi3b/R3BFi3bDigitizer.cxx
+++ b/fiber/obsolete/fi3b/R3BFi3bDigitizer.cxx
@@ -139,7 +139,7 @@ void R3BFi3bDigitizer::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(),
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi3b/R3BFi3bDigitizerCal.cxx
+++ b/fiber/obsolete/fi3b/R3BFi3bDigitizerCal.cxx
@@ -129,7 +129,7 @@ void R3BFi3bDigitizerCal::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(), // fiber nummer
                                        data_element->GetEnergyLoss(),

--- a/fiber/obsolete/fi4/R3BFi4.cxx
+++ b/fiber/obsolete/fi4/R3BFi4.cxx
@@ -213,7 +213,7 @@ Bool_t R3BFi4::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi4Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI4);
 
         ResetParameters();

--- a/fiber/obsolete/fi4/R3BFi4ContFact.cxx
+++ b/fiber/obsolete/fi4/R3BFi4ContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi4ContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi5/R3BFi5.cxx
+++ b/fiber/obsolete/fi5/R3BFi5.cxx
@@ -213,7 +213,7 @@ Bool_t R3BFi5::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi5Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI5);
 
         ResetParameters();
@@ -275,7 +275,7 @@ void R3BFi5::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi5/R3BFi5ContFact.cxx
+++ b/fiber/obsolete/fi5/R3BFi5ContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi5ContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi6/R3BFi6.cxx
+++ b/fiber/obsolete/fi6/R3BFi6.cxx
@@ -212,7 +212,7 @@ Bool_t R3BFi6::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi6Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI6);
 
         ResetParameters();
@@ -274,7 +274,7 @@ void R3BFi6::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi6/R3BFi6ContFact.cxx
+++ b/fiber/obsolete/fi6/R3BFi6ContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi6ContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi6/R3BFi6Mapped2CalPar.cxx
+++ b/fiber/obsolete/fi6/R3BFi6Mapped2CalPar.cxx
@@ -79,7 +79,7 @@ InitStatus R3BFi6Mapped2CalPar::Init()
 
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-    fCal_Par = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("Fi6TCalPar");
+    fCal_Par = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("Fi6TCalPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BFi6Mapped2CalPar::Init() Couldn't get handle on Fi6TCalPar. ";
@@ -102,7 +102,7 @@ void R3BFi6Mapped2CalPar::Exec(Option_t* option)
     for (Int_t i = 0; i < nHits; i++)
     {
 
-        R3BFibMappedData* hit = (R3BFibMappedData*)fMapped->At(i);
+        R3BFibMappedData* hit = dynamic_cast<R3BFibMappedData*>(fMapped->At(i));
         if (!hit)
             continue; // should not happen
 

--- a/fiber/obsolete/fi7/R3BFi7.cxx
+++ b/fiber/obsolete/fi7/R3BFi7.cxx
@@ -213,7 +213,7 @@ Bool_t R3BFi7::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi7Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI7);
 
         ResetParameters();
@@ -275,7 +275,7 @@ void R3BFi7::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi7/R3BFi7ContFact.cxx
+++ b/fiber/obsolete/fi7/R3BFi7ContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi7ContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi7/R3BFi7Digitizer.cxx
+++ b/fiber/obsolete/fi7/R3BFi7Digitizer.cxx
@@ -124,7 +124,7 @@ void R3BFi7Digitizer::Exec(Option_t* opt)
         Double_t fZ_In = Fi7_obj->GetZIn();
         Double_t fZ_Out = Fi7_obj->GetZOut();
         TrackIdFi7 = Fi7_obj->GetTrackID();
-        R3BMCTrack* aTrack = (R3BMCTrack*)fFi7MCTrack->At(TrackIdFi7);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fFi7MCTrack->At(TrackIdFi7));
         Int_t PID = aTrack->GetPdgCode();
         Int_t mother = aTrack->GetMotherId();
 

--- a/fiber/obsolete/fi8/R3BFi8.cxx
+++ b/fiber/obsolete/fi8/R3BFi8.cxx
@@ -213,7 +213,7 @@ Bool_t R3BFi8::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi8Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kFI8);
 
         ResetParameters();
@@ -275,7 +275,7 @@ void R3BFi8::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/fiber/obsolete/fi8/R3BFi8ContFact.cxx
+++ b/fiber/obsolete/fi8/R3BFi8ContFact.cxx
@@ -109,11 +109,11 @@ void R3BFi8ContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/fiber/obsolete/fi8/R3BFi8Digitizer.cxx
+++ b/fiber/obsolete/fi8/R3BFi8Digitizer.cxx
@@ -124,7 +124,7 @@ void R3BFi8Digitizer::Exec(Option_t* opt)
         Double_t fZ_In = Fi8_obj->GetZIn();
         Double_t fZ_Out = Fi8_obj->GetZOut();
         TrackIdFi8 = Fi8_obj->GetTrackID();
-        R3BMCTrack* aTrack = (R3BMCTrack*)fFi8MCTrack->At(TrackIdFi8);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fFi8MCTrack->At(TrackIdFi8));
         Int_t PID = aTrack->GetPdgCode();
         Int_t mother = aTrack->GetMotherId();
 

--- a/fiber/obsolete/fi9/R3BFi9DigitizerCal.cxx
+++ b/fiber/obsolete/fi9/R3BFi9DigitizerCal.cxx
@@ -126,7 +126,7 @@ void R3BFi9DigitizerCal::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BFibPoint* data_element = (R3BFibPoint*)Points->At(i);
+            R3BFibPoint* data_element = dynamic_cast<R3BFibPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(), // fiber nummer
                                        data_element->GetEnergyLoss(),

--- a/fiber/online/R3BFiberMAPMTCorrelationOnlineSpectra.cxx
+++ b/fiber/online/R3BFiberMAPMTCorrelationOnlineSpectra.cxx
@@ -72,7 +72,7 @@ R3BFiberMAPMTCorrelationOnlineSpectra::~R3BFiberMAPMTCorrelationOnlineSpectra()
 
 void R3BFiberMAPMTCorrelationOnlineSpectra::SetParContainers()
 {
-    fMapPar1 = (R3BFiberMappingPar*)FairRuntimeDb::instance()->getContainer(fName1 + "MappingPar");
+    fMapPar1 = dynamic_cast<R3BFiberMappingPar*>(FairRuntimeDb::instance()->getContainer(fName1 + "MappingPar"));
     R3BLOG_IF(ERROR, !fMapPar1, "Couldn't get " << fName1 << "MappingPar");
     if (fMapPar1)
     {
@@ -80,7 +80,7 @@ void R3BFiberMAPMTCorrelationOnlineSpectra::SetParContainers()
         R3BLOG(INFO, fName1 << "MappingPar found with " << fNbfibers1 << " fibers");
     }
 
-    fMapPar2 = (R3BFiberMappingPar*)FairRuntimeDb::instance()->getContainer(fName2 + "MappingPar");
+    fMapPar2 = dynamic_cast<R3BFiberMappingPar*>(FairRuntimeDb::instance()->getContainer(fName2 + "MappingPar"));
     R3BLOG_IF(ERROR, !fMapPar2, "Couldn't get " << fName2 << "MappingPar");
     if (fMapPar2)
     {
@@ -102,11 +102,11 @@ InitStatus R3BFiberMAPMTCorrelationOnlineSpectra::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     R3BLOG_IF(fatal, NULL == mgr, "FairRootManager not found");
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
     {
         R3BLOG(WARNING, "EventHeader. not found");
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     }
     else
         R3BLOG(INFO, " EventHeader. found");
@@ -233,7 +233,7 @@ void R3BFiberMAPMTCorrelationOnlineSpectra::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits1; ihit++)
         {
-            auto hit = (R3BFiberMAPMTHitData*)fHitItems1->At(ihit);
+            auto hit = dynamic_cast<R3BFiberMAPMTHitData*>(fHitItems1->At(ihit));
             if (!hit)
                 continue;
             // Looking for the maximum
@@ -248,7 +248,7 @@ void R3BFiberMAPMTCorrelationOnlineSpectra::Exec(Option_t* option)
         Int_t nHits2 = fHitItems2->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits2; ihit++)
         {
-            auto hit = (R3BFiberMAPMTHitData*)fHitItems2->At(ihit);
+            auto hit = dynamic_cast<R3BFiberMAPMTHitData*>(fHitItems2->At(ihit));
             if (!hit)
                 continue;
             // Looking for the maximum

--- a/fiber/online/R3BFiberMAPMTOnlineSpectra.cxx
+++ b/fiber/online/R3BFiberMAPMTOnlineSpectra.cxx
@@ -111,7 +111,7 @@ R3BFiberMAPMTOnlineSpectra::~R3BFiberMAPMTOnlineSpectra()
 
 void R3BFiberMAPMTOnlineSpectra::SetParContainers()
 {
-    fMapPar = (R3BFiberMappingPar*)FairRuntimeDb::instance()->getContainer(fName + "MappingPar");
+    fMapPar = dynamic_cast<R3BFiberMappingPar*>(FairRuntimeDb::instance()->getContainer(fName + "MappingPar"));
     R3BLOG_IF(ERROR, !fMapPar, "Couldn't get " << fName << "MappingPar");
     if (fMapPar)
     {
@@ -138,11 +138,11 @@ InitStatus R3BFiberMAPMTOnlineSpectra::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     R3BLOG_IF(fatal, NULL == mgr, "FairRootManager not found");
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
     {
         R3BLOG(WARNING, "EventHeader. not found");
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     }
     else
         R3BLOG(INFO, " EventHeader. found");
@@ -627,7 +627,7 @@ void R3BFiberMAPMTOnlineSpectra::Exec(Option_t* option)
             Double_t tDown = 0. / 0.;
             Double_t tUp = 0. / 0.;
 
-            auto hit = (R3BFiberMAPMTHitData*)fHitItems->At(ihit);
+            auto hit = dynamic_cast<R3BFiberMAPMTHitData*>(fHitItems->At(ihit));
             if (!hit)
                 continue;
 

--- a/fiber/pars/R3BBunchedFiberHitPar.cxx
+++ b/fiber/pars/R3BBunchedFiberHitPar.cxx
@@ -67,7 +67,7 @@ void R3BBunchedFiberHitPar::printParams()
     LOG(INFO) << " Number of HIT Parameters " << fHitParams->GetEntries();
     for (Int_t i = 0; i < fHitParams->GetEntries(); i++)
     {
-        R3BBunchedFiberHitModulePar* t_par = (R3BBunchedFiberHitModulePar*)fHitParams->At(i);
+        R3BBunchedFiberHitModulePar* t_par = dynamic_cast<R3BBunchedFiberHitModulePar*>(fHitParams->At(i));
         LOG(INFO) << "----------------------------------------------------------------------";
         if (t_par)
         {
@@ -86,7 +86,7 @@ R3BBunchedFiberHitModulePar* R3BBunchedFiberHitPar::GetModuleParAt(Int_t fiber)
         Int_t index;
         for (Int_t i = 0; i < fHitParams->GetEntries(); i++)
         {
-            par = (R3BBunchedFiberHitModulePar*)fHitParams->At(i);
+            par = dynamic_cast<R3BBunchedFiberHitModulePar*>(fHitParams->At(i));
             if (NULL == par)
             {
                 continue;
@@ -121,7 +121,7 @@ R3BBunchedFiberHitModulePar* R3BBunchedFiberHitPar::GetModuleParAt(Int_t fiber)
         return NULL;
     }
     Int_t arind = fIndexMap[index];
-    R3BBunchedFiberHitModulePar* par = (R3BBunchedFiberHitModulePar*)fHitParams->At(arind);
+    R3BBunchedFiberHitModulePar* par = dynamic_cast<R3BBunchedFiberHitModulePar*>(fHitParams->At(arind));
     return par;
 }
 

--- a/fiber/pars/R3BFiberMAPMTHitPar.cxx
+++ b/fiber/pars/R3BFiberMAPMTHitPar.cxx
@@ -67,7 +67,7 @@ void R3BFiberMAPMTHitPar::printParams()
     LOG(INFO) << " Number of HIT Parameters " << fHitParams->GetEntries();
     for (Int_t i = 0; i < fHitParams->GetEntries(); i++)
     {
-        R3BFiberMAPMTHitModulePar* t_par = (R3BFiberMAPMTHitModulePar*)fHitParams->At(i);
+        R3BFiberMAPMTHitModulePar* t_par = dynamic_cast<R3BFiberMAPMTHitModulePar*>(fHitParams->At(i));
         LOG(INFO) << "----------------------------------------------------------------------";
         if (t_par)
         {
@@ -86,7 +86,7 @@ R3BFiberMAPMTHitModulePar* R3BFiberMAPMTHitPar::GetModuleParAt(Int_t fiber)
         Int_t index;
         for (Int_t i = 0; i < fHitParams->GetEntries(); i++)
         {
-            par = (R3BFiberMAPMTHitModulePar*)fHitParams->At(i);
+            par = dynamic_cast<R3BFiberMAPMTHitModulePar*>(fHitParams->At(i));
             if (NULL == par)
             {
                 continue;
@@ -121,7 +121,7 @@ R3BFiberMAPMTHitModulePar* R3BFiberMAPMTHitPar::GetModuleParAt(Int_t fiber)
         return NULL;
     }
     Int_t arind = fIndexMap[index];
-    R3BFiberMAPMTHitModulePar* par = (R3BFiberMAPMTHitModulePar*)fHitParams->At(arind);
+    R3BFiberMAPMTHitModulePar* par = dynamic_cast<R3BFiberMAPMTHitModulePar*>(fHitParams->At(arind));
     return par;
 }
 

--- a/fiber/sim/R3BFiber.cxx
+++ b/fiber/sim/R3BFiber.cxx
@@ -165,7 +165,7 @@ Bool_t R3BFiber::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of Fi30Points for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(fDetId);
 
         ResetParameters();
@@ -228,7 +228,7 @@ void R3BFiber::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BFibPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BFibPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BFibPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BFibPoint(*oldpoint);

--- a/field/R3BFieldCreator.cxx
+++ b/field/R3BFieldCreator.cxx
@@ -40,7 +40,7 @@ void R3BFieldCreator::SetParm()
 {
     FairRunAna* Run = FairRunAna::Instance();
     FairRuntimeDb* RunDB = Run->GetRuntimeDb();
-    fFieldPar = (R3BFieldPar*)RunDB->getContainer("R3BFieldPar");
+    fFieldPar = dynamic_cast<R3BFieldPar*>(RunDB->getContainer("R3BFieldPar"));
 }
 
 FairField* R3BFieldCreator::createFairField()

--- a/field/R3BFieldPar.cxx
+++ b/field/R3BFieldPar.cxx
@@ -182,7 +182,7 @@ void R3BFieldPar::SetParameters(FairField* field)
 
     if (fType == 0)
     { // constant field
-        R3BFieldConst* fieldConst = (R3BFieldConst*)field;
+        R3BFieldConst* fieldConst = dynamic_cast<R3BFieldConst*>(field);
         fBx = fieldConst->GetBx();
         fBy = fieldConst->GetBy();
         fBz = fieldConst->GetBz();
@@ -200,21 +200,20 @@ void R3BFieldPar::SetParameters(FairField* field)
     else if (fType >= 1 && fType <= kMaxFieldMapType)
     { // field map
         // to be implemented for the  case of R3B
-        R3BFieldMap* fieldMap = (R3BFieldMap*)field;
         fBx = fBy = fBz = 0.;
         fXmin = fXmax = fYmin = fYmax = fZmin = fZmax = 0.;
 
         fMapName = field->GetName();
-        fScale = fieldMap->GetScale();
-
+        fScale=NAN;
         if (1 == fType)
         {
-            R3BAladinFieldMap* aladinFieldMap = (R3BAladinFieldMap*)field;
+            R3BAladinFieldMap* aladinFieldMap = dynamic_cast<R3BAladinFieldMap*>(field);
             fCurrent = aladinFieldMap->GetCurrent();
+            fScale = aladinFieldMap->GetScale();
         }
         else if (2 == fType)//proper GLAD field
         {
-            R3BGladFieldMap* gladFieldMap = (R3BGladFieldMap*)field;
+            R3BGladFieldMap* gladFieldMap = dynamic_cast<R3BGladFieldMap*>(field);
             fMapFileName = gladFieldMap->GetFileName();
             fPosX   = gladFieldMap->GetPositionX();
             fPosY   = gladFieldMap->GetPositionY();
@@ -228,6 +227,7 @@ void R3BFieldPar::SetParameters(FairField* field)
             fYmax   = gladFieldMap->GetYmax();
             fZmin   = gladFieldMap->GetZmin();
             fZmax   = gladFieldMap->GetZmax();
+            fScale =  gladFieldMap->GetScale();
         }
     }
 

--- a/gfi/R3BGfi.cxx
+++ b/gfi/R3BGfi.cxx
@@ -240,7 +240,7 @@ Bool_t R3BGfi::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of GfiPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kGFI);
 
         ResetParameters();
@@ -310,7 +310,7 @@ void R3BGfi::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BGfiPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BGfiPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BGfiPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BGfiPoint(*oldpoint);

--- a/gfi/R3BGfiContFact.cxx
+++ b/gfi/R3BGfiContFact.cxx
@@ -101,11 +101,11 @@ void R3BGfiContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BGfiParRootFileIo* p=new R3BGfiParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BGfiParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BGfiParAsciiFileIo* p=new R3BGfiParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BGfiParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/gfi/R3BGfiDigitizer.cxx
+++ b/gfi/R3BGfiDigitizer.cxx
@@ -62,7 +62,7 @@ void R3BGfiDigitizer::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "SetParContainers: No runtime database";
 
-    fGfiDigiPar = (R3BGfiDigiPar*)(rtdb->getContainer("R3BGfiDigiPar"));
+    fGfiDigiPar = dynamic_cast<R3BGfiDigiPar*>((rtdb->getContainer("R3BGfiDigiPar")));
 
     if (fGfiDigiPar)
     {
@@ -117,7 +117,7 @@ void R3BGfiDigitizer::Exec(Option_t* opt)
     {
         //   cout<<"entries "<<l<<endl;
 
-        R3BGfiPoint* Gfi_obj = (R3BGfiPoint*)fGfiPoints->At(l);
+        R3BGfiPoint* Gfi_obj = dynamic_cast<R3BGfiPoint*>(fGfiPoints->At(l));
 
         //     Int_t DetID = Gfi_obj->GetDetectorID();
         Double_t fX_In = Gfi_obj->GetXIn();
@@ -125,7 +125,7 @@ void R3BGfiDigitizer::Exec(Option_t* opt)
         Double_t fZ_In = Gfi_obj->GetZIn();
         Double_t fZ_Out = Gfi_obj->GetZOut();
         TrackIdGfi = Gfi_obj->GetTrackID();
-        R3BMCTrack* aTrack = (R3BMCTrack*)fGfiMCTrack->At(TrackIdGfi);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fGfiMCTrack->At(TrackIdGfi));
         Int_t PID = aTrack->GetPdgCode();
         Int_t mother = aTrack->GetMotherId();
 

--- a/land/R3BLand.cxx
+++ b/land/R3BLand.cxx
@@ -135,7 +135,7 @@ void R3BLand::Initialize()
         maxPaddle = (Int_t)(maxPlane * ((Int_t)(box->GetDX() / box->GetDY())));
     }
     FairRuntimeDb* rtdb = FairRun::Instance()->GetRuntimeDb();
-    R3BLandDigiPar* par = (R3BLandDigiPar*)(rtdb->getContainer("R3BLandDigiPar"));
+    R3BLandDigiPar* par = dynamic_cast<R3BLandDigiPar*>((rtdb->getContainer("R3BLandDigiPar")));
     par->SetGeometryFileName(GetGeometryFileName());
     par->SetMaxPaddle(maxPaddle);
     par->SetMaxPlane(maxPlane);
@@ -289,7 +289,7 @@ Bool_t R3BLand::ProcessHits(FairVolume* vol)
                fLightYield);
 
         // Increment number of LandPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kLAND);
 
         ResetParameters();
@@ -400,7 +400,7 @@ void R3BLand::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BLandPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BLandPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BLandPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BLandPoint(*oldpoint);

--- a/land/R3BLandContFact.cxx
+++ b/land/R3BLandContFact.cxx
@@ -88,11 +88,11 @@ void R3BLandContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BLandParRootFileIo* p=new R3BLandParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BLandParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BLandParAsciiFileIo* p=new R3BLandParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BLandParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/land/R3BLandDigitizer.cxx
+++ b/land/R3BLandDigitizer.cxx
@@ -97,7 +97,7 @@ void R3BLandDigitizer::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "SetParContainers: No runtime database";
 
-    fLandDigiPar = (R3BLandDigiPar*)(rtdb->getContainer("R3BLandDigiPar"));
+    fLandDigiPar = dynamic_cast<R3BLandDigiPar*>((rtdb->getContainer("R3BLandDigiPar")));
 
     if (fVerbose && fLandDigiPar)
     {
@@ -245,7 +245,7 @@ void R3BLandDigitizer::Exec(Option_t* opt)
 
     for (Int_t l = 0; l < nentries; l++)
     {
-        R3BLandPoint* land_obj = (R3BLandPoint*)fLandPoints->At(l);
+        R3BLandPoint* land_obj = dynamic_cast<R3BLandPoint*>(fLandPoints->At(l));
 
         Int_t paddle = int(land_obj->GetSector()) - 1; // note that paddle starts at 1
         Int_t scint = int(land_obj->GetPaddleNb());

--- a/land/R3BLandDigitizerQA.cxx
+++ b/land/R3BLandDigitizerQA.cxx
@@ -103,7 +103,7 @@ void R3BLandDigitizerQA::Exec(Option_t* option)
     Int_t pdg;
     for (Int_t i = 0; i < nPoints; i++)
     {
-        point = (R3BLandPoint*)fPoints->At(i);
+        point = dynamic_cast<R3BLandPoint*>(fPoints->At(i));
         eloss = point->GetEnergyLoss() * 1000.;
         media = Int_t(point->GetPaddleType());
         light = point->GetLightYield() * 1000.;
@@ -112,7 +112,7 @@ void R3BLandDigitizerQA::Exec(Option_t* option)
             totEnergy += eloss;
             totEnergyLee += light;
             time = point->GetTime();
-            pdg = ((R3BMCTrack*)fTracks->At(point->GetTrackID()))->GetPdgCode();
+            pdg = (dynamic_cast<R3BMCTrack*>(fTracks->At(point->GetTrackID()))->GetPdgCode());
             fhElossPdg->Fill(pdg, eloss);
         }
     }
@@ -130,7 +130,7 @@ void R3BLandDigitizerQA::Exec(Option_t* option)
     Double_t qdc_first;
     for (Int_t i = 0; i < nDigis; i++)
     {
-        digi = (R3BLandDigi*)fDigis->At(i);
+        digi = dynamic_cast<R3BLandDigi*>(fDigis->At(i));
         qdc = digi->GetQdc();
         fhPaddleE->Fill(qdc);
         fhElossTime->Fill(tdc, qdc);

--- a/land/R3BNeuLandClusterFinder.cxx
+++ b/land/R3BNeuLandClusterFinder.cxx
@@ -127,7 +127,7 @@ void R3BNeuLandClusterFinder::Exec(Option_t* option)
     R3BLandDigi* digi1;
     for (Int_t i = 0; i < nDigis; i++)
     {
-        digi1 = (R3BLandDigi*)fArrayDigi->At(i);
+        digi1 = dynamic_cast<R3BLandDigi*>(fArrayDigi->At(i));
         fVectorDigi.push_back(digi1);
     } // loop over entries
 
@@ -203,7 +203,7 @@ void R3BNeuLandClusterFinder::Exec(Option_t* option)
                             clusNo = belongsToCluster[i];
                             belongsToCluster[k] = nClusters - 1;
                             // Get pointer to the current cluster
-                            cluster = (R3BNeuLandCluster*)fArrayCluster->At(clusNo);
+                            cluster = dynamic_cast<R3BNeuLandCluster*>(fArrayCluster->At(clusNo));
                             // Update information of the cluster
                             cluster->SetE(cluster->GetE() + digi2->GetQdc());
                             cluster->SetSize(cluster->GetSize() + 1);
@@ -239,7 +239,7 @@ void R3BNeuLandClusterFinder::Exec(Option_t* option)
         Int_t totalSize = 0;
         for (Int_t i = 0; i < nClusters; i++)
         {
-            cluster = (R3BNeuLandCluster*)fArrayCluster->At(i);
+            cluster = dynamic_cast<R3BNeuLandCluster*>(fArrayCluster->At(i));
             fhClusterSize->Fill(cluster->GetSize());
             fhClusterEnergy->Fill(cluster->GetE());
             totalSize += cluster->GetSize();

--- a/land/R3BNeutronCalibr2D.cxx
+++ b/land/R3BNeutronCalibr2D.cxx
@@ -74,7 +74,7 @@ void R3BNeutronCalibr2D::Exec(Option_t* opt)
     R3BLandDigi* digi;
     for (Int_t id = 0; id < fArrayDigi->GetEntries(); id++)
     {
-        digi = (R3BLandDigi*)fArrayDigi->At(id);
+        digi = dynamic_cast<R3BLandDigi*>(fArrayDigi->At(id));
         eTot += digi->GetQdc();
     }
 

--- a/land/R3BNeutronTracker.cxx
+++ b/land/R3BNeutronTracker.cxx
@@ -65,7 +65,7 @@ void R3BNeutronTracker::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "SetParContainers: No runtime database";
 
-    fLandDigiPar = (R3BLandDigiPar*)(rtdb->getContainer("R3BLandDigiPar"));
+    fLandDigiPar = dynamic_cast<R3BLandDigiPar*>((rtdb->getContainer("R3BLandDigiPar")));
 
     if (fLandDigiPar)
     {
@@ -283,7 +283,7 @@ void R3BNeutronTracker::Exec(Option_t* opt)
     // Get parameter from original neutrons and fragment
     // Access to Monte Carlo Info
     //  get object from the TclonesArray at index=TrackID
-    R3BMCTrack* aTrack1 = (R3BMCTrack*)fLandMCTrack->At(0);
+    R3BMCTrack* aTrack1 = dynamic_cast<R3BMCTrack*>(fLandMCTrack->At(0));
     Int_t prim = aTrack1->GetMotherId();
 
     while (prim < 0)
@@ -408,7 +408,7 @@ void R3BNeutronTracker::Exec(Option_t* opt)
         }
 
         nPrim = nPrim + 1;
-        aTrack1 = (R3BMCTrack*)fLandMCTrack->At(nPrim);
+        aTrack1 = dynamic_cast<R3BMCTrack*>(fLandMCTrack->At(nPrim));
         if (aTrack1 != 0)
             prim = aTrack1->GetMotherId();
         else
@@ -420,7 +420,7 @@ void R3BNeutronTracker::Exec(Option_t* opt)
     {
         // cout<<"loop over entries "<<l<<endl;
         // Get the Land Object in array
-        R3BLandDigi* land_obj = (R3BLandDigi*)fLandDigi->At(l);
+        R3BLandDigi* land_obj = dynamic_cast<R3BLandDigi*>(fLandDigi->At(l));
 
         temp[l][0] = int(land_obj->GetPaddleNr()) - 1; // note that paddle starts at 1
         temp[l][1] = land_obj->GetTdcL();
@@ -443,7 +443,7 @@ void R3BNeutronTracker::Exec(Option_t* opt)
     //   Int_t nentr = fLandFirstHits->GetEntries();
 
     //   cout<<"entries: "<<nentr<<endl;
-    R3BLandFirstHits* land_obj1 = (R3BLandFirstHits*)fLandFirstHits->At(0);
+    R3BLandFirstHits* land_obj1 = dynamic_cast<R3BLandFirstHits*>(fLandFirstHits->At(0));
 
     firstHitX[0] = land_obj1->GetX0();
     firstHitY[0] = land_obj1->GetY0();

--- a/land/R3BNeutronTracker2D.cxx
+++ b/land/R3BNeutronTracker2D.cxx
@@ -79,7 +79,7 @@ void R3BNeutronTracker2D::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "SetParContainers: No runtime database";
 
-    fLandDigiPar = (R3BLandDigiPar*)(rtdb->getContainer("R3BLandDigiPar"));
+    fLandDigiPar = dynamic_cast<R3BLandDigiPar*>((rtdb->getContainer("R3BLandDigiPar")));
 
     if (fLandDigiPar)
     {
@@ -183,7 +183,7 @@ void R3BNeutronTracker2D::Exec(Option_t* opt)
     Int_t particleID;
     for (Int_t it = 0; it < fLandMCTrack->GetEntriesFast(); it++)
     {
-        aTrack1 = (R3BMCTrack*)fLandMCTrack->At(it);
+        aTrack1 = dynamic_cast<R3BMCTrack*>(fLandMCTrack->At(it));
 
         prim = aTrack1->GetMotherId();
         if (-1 != prim)
@@ -264,7 +264,7 @@ void R3BNeutronTracker2D::Exec(Option_t* opt)
     R3BLandDigi* digi;
     for (Int_t id = 0; id < fLandDigi->GetEntries(); id++)
     {
-        digi = (R3BLandDigi*)fLandDigi->At(id);
+        digi = dynamic_cast<R3BLandDigi*>(fLandDigi->At(id));
         fEtot += digi->GetQdc();
         sumTotalEnergy += digi->GetQdc();
     }
@@ -354,7 +354,7 @@ Int_t R3BNeutronTracker2D::AdvancedMethod()
     for (Int_t ic = 0; ic < fNofClusters; ic++)
     {
         // Get pointer to the cluster
-        cluster = (R3BNeuLandCluster*)fArrayCluster->At(ic);
+        cluster = dynamic_cast<R3BNeuLandCluster*>(fArrayCluster->At(ic));
         // Process starting from this cluster
         NextIteration(ic, cluster);
     } // clusters
@@ -444,7 +444,7 @@ void R3BNeutronTracker2D::SortClustersBeta()
     R3BNeuLandCluster* cluster;
     for (Int_t ic = 1; ic < fNofClusters; ic++)
     {
-        cluster = (R3BNeuLandCluster*)fArrayCluster->At(ic);
+        cluster = dynamic_cast<R3BNeuLandCluster*>(fArrayCluster->At(ic));
         if (cluster->IsMarked())
         {
             continue;
@@ -458,7 +458,7 @@ void R3BNeutronTracker2D::SortClustersBeta()
         std::sort(fVectorCluster.begin(), fVectorCluster.end(), AuxSortClustersBeta);
     }
 
-    cluster = (R3BNeuLandCluster*)fArrayCluster->At(0);
+    cluster = dynamic_cast<R3BNeuLandCluster*>(fArrayCluster->At(0));
     fVectorCluster.insert(fVectorCluster.begin(), cluster);
     fNofClusters1 = fVectorCluster.size();
 }
@@ -476,7 +476,7 @@ void R3BNeutronTracker2D::NextIteration(Int_t curIndex, R3BNeuLandCluster* curCl
     R3BNeuLandCluster* cluster;
     for (Int_t ic = (curIndex + 1); ic < fNofClusters; ic++)
     {
-        cluster = (R3BNeuLandCluster*)fArrayCluster->At(ic);
+        cluster = dynamic_cast<R3BNeuLandCluster*>(fArrayCluster->At(ic));
         // Check if elastic scattering
         if (IsElastic(curClus, cluster))
         {
@@ -840,7 +840,7 @@ Bool_t R3BNeutronTracker2D::IsElastic(R3BNeuLandCluster* c1, R3BNeuLandCluster* 
 // -----------------------------------------------------------------------------
 void R3BNeutronTracker2D::CalculateMassInv()
 {
-    R3BLandFirstHits* fh = (R3BLandFirstHits*)fLandFirstHits->At(0);
+    R3BLandFirstHits* fh = dynamic_cast<R3BLandFirstHits*>(fLandFirstHits->At(0));
     TVector3 fhv[6];
     fhv[0].SetXYZ(fh->GetX0(), fh->GetY0(), fh->GetZ0());
     fhv[1].SetXYZ(fh->GetX1(), fh->GetY1(), fh->GetZ1());
@@ -903,7 +903,7 @@ void R3BNeutronTracker2D::CalculateMassInv()
         // add up momentum of neutrons
         // neutron: beta is calculated with position and time of first hit
 
-        hit = (R3BNeutHit*)fNeutHits->At(i);
+        hit = dynamic_cast<R3BNeutHit*>(fNeutHits->At(i));
 
         Double_t momentumT = hit->GetP();
         Double_t momentumZ =
@@ -926,7 +926,7 @@ void R3BNeutronTracker2D::CalculateMassInv()
         Double_t dmin = 1e6;
         for (Int_t ip = 0; ip < fLandPoints->GetEntriesFast(); ip++)
         {
-            point = (R3BLandPoint*)fLandPoints->At(ip);
+            point = dynamic_cast<R3BLandPoint*>(fLandPoints->At(ip));
             point->PositionIn(posPoint);
             d = TMath::Sqrt(TMath::Power(hit->GetX() - posPoint.X(), 2) + TMath::Power(hit->GetY() - posPoint.Y(), 2) +
                             TMath::Power(hit->GetZ() - posPoint.Z(), 2));
@@ -937,14 +937,14 @@ void R3BNeutronTracker2D::CalculateMassInv()
             }
         }
         assert(index != -1);
-        point = (R3BLandPoint*)fLandPoints->At(index);
+        point = dynamic_cast<R3BLandPoint*>(fLandPoints->At(index));
         Int_t trackID = point->GetTrackID();
-        R3BMCTrack* track = (R3BMCTrack*)fLandMCTrack->At(trackID);
+        R3BMCTrack* track = dynamic_cast<R3BMCTrack*>(fLandMCTrack->At(trackID));
         Int_t mothID = track->GetMotherId();
         Int_t ind;
         while (-1 != mothID)
         {
-            track = (R3BMCTrack*)fLandMCTrack->At(mothID);
+            track = dynamic_cast<R3BMCTrack*>(fLandMCTrack->At(mothID));
             ind = mothID;
             mothID = track->GetMotherId();
         }

--- a/los/R3BLosProvideTStart.cxx
+++ b/los/R3BLosProvideTStart.cxx
@@ -37,10 +37,10 @@ InitStatus R3BLosProvideTStart::Init()
         throw std::runtime_error("R3BLosProvideTStart: No FairRootManager");
     }
 
-    fEventHeader = (R3BEventHeader*)ioman->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(ioman->GetObject("EventHeader."));
     if (fEventHeader == nullptr)
     {
-        fEventHeader = (R3BEventHeader*)ioman->GetObject("R3BEventHeader");
+        fEventHeader = dynamic_cast<R3BEventHeader*>(ioman->GetObject("R3BEventHeader"));
         R3BLOG(WARNING, "R3BEventHeader was found instead of EventHeader.");
     }
     // Definition of a time stich object to correlate times coming from different systems

--- a/los/calib/R3BLosCal2Hit.cxx
+++ b/los/calib/R3BLosCal2Hit.cxx
@@ -278,7 +278,7 @@ void R3BLosCal2Hit::SetParContainers()
     {
         LOG(ERROR) << "FairRuntimeDb not opened!";
     }
-    fLosHit_Par = (R3BLosHitPar*)rtdb->getContainer("LosHitPar");
+    fLosHit_Par = dynamic_cast<R3BLosHitPar*>(rtdb->getContainer("LosHitPar"));
     if (!fLosHit_Par)
     {
         LOG(ERROR) << "R3BLosTcal2Hit:: Couldn't get handle on R3BLosHitPar container";
@@ -308,9 +308,9 @@ InitStatus R3BLosCal2Hit::Init()
     if (NULL == mgr)
         LOG(ERROR) << "FairRootManager not found";
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     fCalItems = (TClonesArray*)mgr->GetObject("LosCal");
     if (NULL == fCalItems)
@@ -508,7 +508,7 @@ void R3BLosCal2Hit::Exec(Option_t* option)
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
 
-        auto calItem = (R3BLosCalData*)(fCalItems->At(ihit));
+        auto calItem = dynamic_cast<R3BLosCalData*>((fCalItems->At(ihit)));
 
         nDet = calItem->GetDetector();
 

--- a/los/calib/R3BLosMapped2Cal.cxx
+++ b/los/calib/R3BLosMapped2Cal.cxx
@@ -93,9 +93,9 @@ InitStatus R3BLosMapped2Cal::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     // get access to Mapped data
     fMappedItems = (TClonesArray*)mgr->GetObject("LosMapped");
@@ -125,7 +125,7 @@ InitStatus R3BLosMapped2Cal::Init()
 // Note that the container may still be empty at this point.
 void R3BLosMapped2Cal::SetParContainers()
 {
-    fTcalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("LosTCalPar");
+    fTcalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("LosTCalPar"));
     if (!fTcalPar)
     {
         R3BLOG(FATAL, "Could not get access to LosTCalPar-Container.");
@@ -159,7 +159,7 @@ void R3BLosMapped2Cal::Exec(Option_t* option)
         Double_t times_ns = 0. / 0.;
         Double_t times_raw_ns = 0. / 0.;
 
-        R3BLosMappedData* hit = (R3BLosMappedData*)fMappedItems->At(ihit);
+        R3BLosMappedData* hit = dynamic_cast<R3BLosMappedData*>(fMappedItems->At(ihit));
         if (!hit)
             continue;
 
@@ -253,7 +253,7 @@ void R3BLosMapped2Cal::Exec(Option_t* option)
         int iCal;
         for (iCal = 0; iCal < fNofCalItems; iCal++)
         {
-            R3BLosCalData* aCalItem = (R3BLosCalData*)fCalItems->At(iCal);
+            R3BLosCalData* aCalItem = dynamic_cast<R3BLosCalData*>(fCalItems->At(iCal));
 
             //       cout<<"aCalItem->GetDetector() "<<aCalItem->GetDetector()<<"; "<<iDet<<endl;
 

--- a/los/calib/R3BLosMapped2TCal.cxx
+++ b/los/calib/R3BLosMapped2TCal.cxx
@@ -89,9 +89,9 @@ InitStatus R3BLosMapped2TCal::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     // get access to Mapped data
     fMappedItems = (TClonesArray*)mgr->GetObject("LosMapped");
@@ -121,7 +121,7 @@ InitStatus R3BLosMapped2TCal::Init()
 // Note that the container may still be empty at this point.
 void R3BLosMapped2TCal::SetParContainers()
 {
-    fTcalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("LosTCalPar");
+    fTcalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("LosTCalPar"));
     if (!fTcalPar)
     {
         R3BLOG(FATAL, "Could not get access to LosTCalPar-Container.");
@@ -154,7 +154,7 @@ void R3BLosMapped2TCal::Exec(Option_t* option)
         Double_t times_ns = 0. / 0.;
         Double_t times_raw_ns = 0. / 0.;
 
-        R3BLosMappedData* hit = (R3BLosMappedData*)fMappedItems->At(ihit);
+        R3BLosMappedData* hit = dynamic_cast<R3BLosMappedData*>(fMappedItems->At(ihit));
         if (!hit)
             continue;
 

--- a/los/online/R3BLosOnlineSpectra.cxx
+++ b/los/online/R3BLosOnlineSpectra.cxx
@@ -78,9 +78,9 @@ InitStatus R3BLosOnlineSpectra::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     R3BLOG_IF(fatal, NULL == mgr, "FairRootManager not found");
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     FairRunOnline* run = FairRunOnline::Instance();
     run->GetHttpServer()->Register("", this);
@@ -451,7 +451,7 @@ void R3BLosOnlineSpectra::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BLosMappedData* hit = (R3BLosMappedData*)det->At(ihit);
+            R3BLosMappedData* hit = dynamic_cast<R3BLosMappedData*>(det->At(ihit));
             if (!hit)
                 continue;
 
@@ -478,7 +478,7 @@ void R3BLosOnlineSpectra::Exec(Option_t* option)
             /*
              * nPart is the number of particle passing through LOS detector in one event
              */
-            R3BLosCalData* calData = (R3BLosCalData*)det->At(iPart);
+            R3BLosCalData* calData = dynamic_cast<R3BLosCalData*>(det->At(iPart));
             iDet = calData->GetDetector();
 
             Double_t sumvtemp = 0, sumltemp = 0, sumttemp = 0;

--- a/los/params/R3BLosCal2HitPar.cxx
+++ b/los/params/R3BLosCal2HitPar.cxx
@@ -123,7 +123,7 @@ InitStatus R3BLosCal2HitPar::Init()
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
 
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     fCalItems = (TClonesArray*)mgr->GetObject("LosCal");
     if (NULL == fCalItems)
         LOG(ERROR) << "Branch LosCal not found";
@@ -216,7 +216,7 @@ void R3BLosCal2HitPar::Exec(Option_t* option)
             /*
              * nPart is the number of particle passing through LOS detector in one event
              */
-            R3BLosCalData* calData = (R3BLosCalData*)fCalItems->At(iPart);
+            R3BLosCalData* calData = dynamic_cast<R3BLosCalData*>(fCalItems->At(iPart));
 
             iDet = calData->GetDetector();
 

--- a/los/params/R3BLosMapped2CalPar.cxx
+++ b/los/params/R3BLosMapped2CalPar.cxx
@@ -106,12 +106,12 @@ InitStatus R3BLosMapped2CalPar::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rm->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("EventHeader."));
     // may be = NULL!
     if (!header)
     {
         R3BLOG(WARNING, "EventHeader. not found");
-        header = (R3BEventHeader*)rm->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(rm->GetObject("R3BEventHeader"));
     }
     else
         R3BLOG(INFO, "EventHeader. found");
@@ -127,7 +127,7 @@ InitStatus R3BLosMapped2CalPar::Init()
     fMappedTriggerItems = (TClonesArray*)rm->GetObject("LosTriggerMapped");
     R3BLOG_IF(WARNING, !fMappedTriggerItems, "LosTriggerMapped not found");
 
-    fCal_Par = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("LosTCalPar");
+    fCal_Par = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("LosTCalPar"));
     fEngine = new R3BTCalEngine(fCal_Par, fMinStats);
 
     return kSUCCESS;
@@ -144,7 +144,7 @@ void R3BLosMapped2CalPar::Exec(Option_t* option)
     for (UInt_t i = 0; i < nHits; i++)
     {
 
-        R3BLosMappedData* hit = (R3BLosMappedData*)fMapped->At(i);
+        R3BLosMappedData* hit = dynamic_cast<R3BLosMappedData*>(fMapped->At(i));
         if (!hit)
         {
             continue; // should not happen

--- a/lumon/ELILuMon.cxx
+++ b/lumon/ELILuMon.cxx
@@ -170,7 +170,7 @@ Bool_t ELILuMon::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of LuMonPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kLUMON);
 
         ResetParameters();

--- a/lumon/ELILuMonContFact.cxx
+++ b/lumon/ELILuMonContFact.cxx
@@ -101,11 +101,11 @@ void ELILuMonContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      ELILuMonParRootFileIo* p=new ELILuMonParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new ELILuMonParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      ELILuMonParAsciiFileIo* p=new ELILuMonParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new ELILuMonParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/mfi/R3BMfi.cxx
+++ b/mfi/R3BMfi.cxx
@@ -172,7 +172,7 @@ Bool_t R3BMfi::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of MfiPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kMFI);
 
         ResetParameters();
@@ -234,7 +234,7 @@ void R3BMfi::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BMfiPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BMfiPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BMfiPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BMfiPoint(*oldpoint);

--- a/mfi/R3BMfiDigitizer.cxx
+++ b/mfi/R3BMfiDigitizer.cxx
@@ -106,7 +106,7 @@ void R3BMfiDigitizer::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "SetParContainers: No runtime database";
 
-    fMfiDigiPar = (R3BMfiDigiPar*)(rtdb->getContainer("R3BMfiDigiPar"));
+    fMfiDigiPar = dynamic_cast<R3BMfiDigiPar*>((rtdb->getContainer("R3BMfiDigiPar")));
 
     if (fMfiDigiPar)
     {
@@ -168,7 +168,7 @@ void R3BMfiDigitizer::Exec(Option_t* opt)
     {
         //   cout<<"entries "<<l<<endl;
 
-        R3BMfiPoint* Mfi_obj = (R3BMfiPoint*)fMfiPoints->At(l);
+        R3BMfiPoint* Mfi_obj = dynamic_cast<R3BMfiPoint*>(fMfiPoints->At(l));
 
         //     Int_t DetID = Mfi_obj->GetDetectorID();
         Double_t fX_In = Mfi_obj->GetXIn();
@@ -176,7 +176,7 @@ void R3BMfiDigitizer::Exec(Option_t* opt)
         Double_t fZ_In = Mfi_obj->GetZIn();
         Double_t fZ_Out = Mfi_obj->GetZOut();
         TrackIdMfi = Mfi_obj->GetTrackID();
-        R3BMCTrack* aTrack = (R3BMCTrack*)fMfiMCTrack->At(TrackIdMfi);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fMfiMCTrack->At(TrackIdMfi));
         Int_t PID = aTrack->GetPdgCode();
         //     Int_t mother = aTrack->GetMotherId();
 

--- a/mtof/R3BmTof.cxx
+++ b/mtof/R3BmTof.cxx
@@ -85,7 +85,7 @@ void R3BmTof::Initialize()
     LOG(INFO) << "R3BmTof: initialisation";
     LOG(DEBUG) << "R3BmTof: Sci. Vol. (McId) " << gMC->VolId("mTOFLog");
 
-    fTGeoPar = (R3BTGeoPar*)FairRuntimeDb::instance()->getContainer("mTofGeoPar");
+    fTGeoPar = dynamic_cast<R3BTGeoPar*>(FairRuntimeDb::instance()->getContainer("mTofGeoPar"));
 
     // Position and rotation
     TGeoNode* main_vol = gGeoManager->GetTopVolume()->FindNode("mTOF_0");
@@ -225,7 +225,7 @@ Bool_t R3BmTof::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of mTofPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kMTOF);
 
         ResetParameters();
@@ -309,7 +309,7 @@ void R3BmTof::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BmTofPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BmTofPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BmTofPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BmTofPoint(*oldpoint);

--- a/mtof/R3BmTofContFact.cxx
+++ b/mtof/R3BmTofContFact.cxx
@@ -103,11 +103,11 @@ void R3BmTofContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BmTofParRootFileIo* p=new R3BmTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BmTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BmTofParAsciiFileIo* p=new R3BmTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BmTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/mtof/R3BmTofDigitizer.cxx
+++ b/mtof/R3BmTofDigitizer.cxx
@@ -62,7 +62,7 @@ void R3BmTofDigitizer::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "SetParContainers: No runtime database";
 
-    fmTofDigiPar = (R3BmTofDigiPar*)(rtdb->getContainer("R3BmTofDigiPar"));
+    fmTofDigiPar = dynamic_cast<R3BmTofDigiPar*>((rtdb->getContainer("R3BmTofDigiPar")));
 
     if (fmTofDigiPar)
     {
@@ -141,10 +141,10 @@ void R3BmTofDigitizer::Exec(Option_t* opt)
     {
         //   cout<<"entries-mTof "<<l<<endl;
 
-        R3BmTofPoint* mtof_obj = (R3BmTofPoint*)fmTofPoints->At(l);
+        R3BmTofPoint* mtof_obj = dynamic_cast<R3BmTofPoint*>(fmTofPoints->At(l));
 
         TrackIdmTof = mtof_obj->GetTrackID();
-        R3BMCTrack* aTrack = (R3BMCTrack*)fmTofMCTrack->At(TrackIdmTof);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fmTofMCTrack->At(TrackIdmTof));
         Int_t PID = aTrack->GetPdgCode();
         Int_t mother = aTrack->GetMotherId();
 

--- a/music/calibration/R3BMusicCal2Hit.cxx
+++ b/music/calibration/R3BMusicCal2Hit.cxx
@@ -83,7 +83,7 @@ void R3BMusicCal2Hit::SetParContainers()
         LOG(ERROR) << "FairRuntimeDb not found";
     }
 
-    fCal_Par = (R3BMusicHitPar*)rtdb->getContainer("musicHitPar");
+    fCal_Par = dynamic_cast<R3BMusicHitPar*>(rtdb->getContainer("musicHitPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BMusicCal2HitPar::Init() Couldn't get handle on musicHitPar container";
@@ -214,7 +214,7 @@ void R3BMusicCal2Hit::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        CalDat[i] = (R3BMusicCalData*)(fMusicCalDataCA->At(i));
+        CalDat[i] = dynamic_cast<R3BMusicCalData*>((fMusicCalDataCA->At(i)));
         anodeId = CalDat[i]->GetAnodeID();
         energyperanode[anodeId] = CalDat[i]->GetEnergy();
         dt[anodeId] = CalDat[i]->GetDTime();
@@ -289,7 +289,7 @@ void R3BMusicCal2Hit::ExecSim(int nHits)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        CalDat[i] = (R3BMusicCalData*)(fMusicCalDataCA->At(i));
+        CalDat[i] = dynamic_cast<R3BMusicCalData*>((fMusicCalDataCA->At(i)));
         anodeId = CalDat[i]->GetAnodeID();
         energyperanode[anodeId] = CalDat[i]->GetEnergy();
         dt[anodeId] = CalDat[i]->GetDTime();

--- a/music/calibration/R3BMusicMapped2Cal.cxx
+++ b/music/calibration/R3BMusicMapped2Cal.cxx
@@ -79,7 +79,7 @@ void R3BMusicMapped2Cal::SetParContainers()
         LOG(ERROR) << "FairRuntimeDb not opened!";
     }
 
-    fCal_Par = (R3BMusicCalPar*)rtdb->getContainer("musicCalPar");
+    fCal_Par = dynamic_cast<R3BMusicCalPar*>(rtdb->getContainer("musicCalPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BMusicMapped2Cal::SetParContainers() Couldn't get handle on musicCalPar container";
@@ -187,7 +187,7 @@ void R3BMusicMapped2Cal::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BMusicMappedData*)(fMusicMappedDataCA->At(i));
+        mappedData[i] = dynamic_cast<R3BMusicMappedData*>((fMusicMappedDataCA->At(i)));
         anodeId = mappedData[i]->GetAnodeID();
 
         if (anodeId < fNumAnodes && fCal_Par->GetInUse(anodeId + 1) == 1)

--- a/music/online/R3BMusicOnlineSpectra.cxx
+++ b/music/online/R3BMusicOnlineSpectra.cxx
@@ -94,9 +94,9 @@ InitStatus R3BMusicOnlineSpectra::Init()
         LOG(FATAL) << "R3BMusicOnlineSpectra::Init FairRootManager not found";
         return kFATAL;
     }
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader."));
     if (!header)
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     FairRunOnline* run = FairRunOnline::Instance();
     run->GetHttpServer()->Register("", this);
@@ -511,7 +511,7 @@ void R3BMusicOnlineSpectra::Exec(Option_t* option)
         Int_t nHits = fMappedItemsMus->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMusicMappedData* hit = (R3BMusicMappedData*)fMappedItemsMus->At(ihit);
+            R3BMusicMappedData* hit = dynamic_cast<R3BMusicMappedData*>(fMappedItemsMus->At(ihit));
             if (!hit)
                 continue;
             multhit[hit->GetAnodeID()]++;
@@ -581,7 +581,7 @@ void R3BMusicOnlineSpectra::Exec(Option_t* option)
         Int_t nHits = fCalItemsMus->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMusicCalData* hit = (R3BMusicCalData*)fCalItemsMus->At(ihit);
+            R3BMusicCalData* hit = dynamic_cast<R3BMusicCalData*>(fCalItemsMus->At(ihit));
             if (!hit)
                 continue;
             fh1_Muscal_Pos[hit->GetAnodeID()]->Fill(hit->GetDTime());
@@ -594,7 +594,7 @@ void R3BMusicOnlineSpectra::Exec(Option_t* option)
         Int_t nHits = fHitItemsMus->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMusicHitData* hit = (R3BMusicHitData*)fHitItemsMus->At(ihit);
+            R3BMusicHitData* hit = dynamic_cast<R3BMusicHitData*>(fHitItemsMus->At(ihit));
             if (!hit)
                 continue;
             fh1_Mushit_z->Fill(hit->GetZcharge());

--- a/music/pars/R3BMusicMapped2CalPar.cxx
+++ b/music/pars/R3BMusicMapped2CalPar.cxx
@@ -128,7 +128,7 @@ InitStatus R3BMusicMapped2CalPar::Init()
         return kFATAL;
     }
 
-    fCal_Par = (R3BMusicCalPar*)rtdb->getContainer("musicCalPar");
+    fCal_Par = dynamic_cast<R3BMusicCalPar*>(rtdb->getContainer("musicCalPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BMusicMapped2CalPar:: Couldn't get handle on musicCalPar container";
@@ -175,14 +175,14 @@ void R3BMusicMapped2CalPar::Exec(Option_t* option)
     R3BMwpcHitData** hitMwAData = new R3BMwpcHitData*[nHitsA];
     for (Int_t i = 0; i < nHitsA; i++)
     {
-        hitMwAData[i] = (R3BMwpcHitData*)(fHitItemsDetA->At(i));
+        hitMwAData[i] = dynamic_cast<R3BMwpcHitData*>((fHitItemsDetA->At(i)));
         PosDetA.SetX(hitMwAData[i]->GetX());
         // LOG(INFO) <<hitMwAData[i]->GetX();
     }
     R3BMwpcHitData** hitMwBData = new R3BMwpcHitData*[nHitsB];
     for (Int_t i = 0; i < nHitsB; i++)
     {
-        hitMwBData[i] = (R3BMwpcHitData*)(fHitItemsDetB->At(i));
+        hitMwBData[i] = dynamic_cast<R3BMwpcHitData*>((fHitItemsDetB->At(i)));
         PosDetB.SetX(hitMwBData[i]->GetX());
         // LOG(INFO) <<hitMwBData[i]->GetX();
     }
@@ -202,7 +202,7 @@ void R3BMusicMapped2CalPar::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BMusicMappedData*)(fMusicMappedDataCA->At(i));
+        mappedData[i] = dynamic_cast<R3BMusicMappedData*>((fMusicMappedDataCA->At(i)));
         anodeId = mappedData[i]->GetAnodeID();
 
         if (anodeId < fNumAnodes)

--- a/music/pars/R3BMusicMapped2CalPar_S515.cxx
+++ b/music/pars/R3BMusicMapped2CalPar_S515.cxx
@@ -146,7 +146,7 @@ InitStatus R3BMusicMapped2CalPar_S515::Init()
         return kFATAL;
     }
 
-    fCal_Par = (R3BMusicCalPar*)rtdb->getContainer("musicCalPar");
+    fCal_Par = dynamic_cast<R3BMusicCalPar*>(rtdb->getContainer("musicCalPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BMusicMapped2CalPar_S515:: Couldn't get handle on musicCalPar container";
@@ -190,14 +190,14 @@ void R3BMusicMapped2CalPar_S515::Exec(Option_t* option)
     R3BMwpcHitData** hitMwAData = new R3BMwpcHitData*[nHitsA];
     for (Int_t i = 0; i < nHitsA; i++)
     {
-        hitMwAData[i] = (R3BMwpcHitData*)(fHitItemsMwpcA->At(i));
+        hitMwAData[i] = dynamic_cast<R3BMwpcHitData*>((fHitItemsMwpcA->At(i)));
         PosMwpcA.SetX(hitMwAData[i]->GetX());
         // LOG(INFO) <<hitMwAData[i]->GetX();
     }
     R3BLosHitData** hitLosData = new R3BLosHitData*[nHitsB];
     for (Int_t i = 0; i < nHitsB; i++)
     {
-        hitLosData[i] = (R3BLosHitData*)(fHitItemsLos->At(i));
+        hitLosData[i] = dynamic_cast<R3BLosHitData*>((fHitItemsLos->At(i)));
         PosLos.SetX(hitLosData[i]->GetX_cm());
         // LOG(INFO) <<hitMwBData[i]->GetX();
     }
@@ -217,7 +217,7 @@ void R3BMusicMapped2CalPar_S515::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BMusicMappedData*)(fMusicMappedDataCA->At(i));
+        mappedData[i] = dynamic_cast<R3BMusicMappedData*>((fMusicMappedDataCA->At(i)));
         anodeId = mappedData[i]->GetAnodeID();
 
         if (anodeId < fNumAnodes)

--- a/music/sim/R3BMusic.cxx
+++ b/music/sim/R3BMusic.cxx
@@ -138,7 +138,7 @@ Bool_t R3BMusic::ProcessHits(FairVolume* vol)
                      fELoss);
 
             // Increment number of MusicPoints for this track
-            R3BStack* stack = (R3BStack*)gMC->GetStack();
+            R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
             stack->AddPoint(kMUSIC);
 
             ResetParameters();
@@ -197,7 +197,7 @@ void R3BMusic::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BMusicPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BMusicPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BMusicPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BMusicPoint(*oldpoint);

--- a/music/sim/R3BMusicDigitizer.cxx
+++ b/music/sim/R3BMusicDigitizer.cxx
@@ -109,10 +109,10 @@ void R3BMusicDigitizer::Exec(Option_t* opt)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        pointData[i] = (R3BMusicPoint*)(fMusicPoints->At(i));
+        pointData[i] = dynamic_cast<R3BMusicPoint*>((fMusicPoints->At(i)));
         TrackId = pointData[i]->GetTrackID();
 
-        R3BMCTrack* Track = (R3BMCTrack*)fMCTrack->At(TrackId);
+        R3BMCTrack* Track = dynamic_cast<R3BMCTrack*>(fMCTrack->At(TrackId));
         PID = Track->GetPdgCode();
         anodeId = pointData[i]->GetDetCopyID();
         // std::cout<<anodeId<<std::endl;

--- a/musli/calibration/R3BMusliCal2Hit.cxx
+++ b/musli/calibration/R3BMusliCal2Hit.cxx
@@ -78,7 +78,7 @@ void R3BMusliCal2Hit::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(FATAL, !rtdb, "R3BMusliCal2Hit::SetParContainers(), FairRuntimeDb not found");
 
-    fHit_Par = (R3BMusliHitPar*)rtdb->getContainer("musliHitPar");
+    fHit_Par = dynamic_cast<R3BMusliHitPar*>(rtdb->getContainer("musliHitPar"));
     if (!fHit_Par)
     {
         R3BLOG(ERROR, "R3BMusliCal2Hit::SetParContainers() Couldn't get handle on musliHitPar container");
@@ -89,7 +89,7 @@ void R3BMusliCal2Hit::SetParContainers()
     }
 
     // Reading the TGeoPar from the FairRun
-    fMusliGeo_Par = (R3BTGeoPar*)rtdb->getContainer("MusliGeoPar");
+    fMusliGeo_Par = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer("MusliGeoPar"));
     R3BLOG_IF(ERROR, !fMusliGeo_Par, "R3BMusliCal2Hit::SetParContainers() Couldn´t access to MusliGeoPar container.");
 }
 
@@ -167,7 +167,7 @@ void R3BMusliCal2Hit::Exec(Option_t* option)
     Double_t beta = fDirectBeta;
     if (fFrsDataCA && fFrsDataCA->GetEntriesFast() == 1)
     {
-        R3BFrsData* hit = (R3BFrsData*)fFrsDataCA->At(0);
+        R3BFrsData* hit = dynamic_cast<R3BFrsData*>(fFrsDataCA->At(0));
         if (hit)
         {
             beta = hit->GetBeta();
@@ -196,7 +196,7 @@ void R3BMusliCal2Hit::Exec(Option_t* option)
     R3BMusliCalData** calData = new R3BMusliCalData*[nHits];
     for (Int_t i = 0; i < nHits; i++)
     {
-        calData[i] = (R3BMusliCalData*)(fMusliCalDataCA->At(i));
+        calData[i] = dynamic_cast<R3BMusliCalData*>((fMusliCalDataCA->At(i)));
         signal_cal = calData[i]->GetSignal() - 1;
         dt_cal[mult_cal[signal_cal]][signal_cal] = calData[i]->GetDT();
         e_cal[mult_cal[signal_cal]][signal_cal] = calData[i]->GetEnergy();

--- a/musli/calibration/R3BMusliMapped2Cal.cxx
+++ b/musli/calibration/R3BMusliMapped2Cal.cxx
@@ -72,7 +72,7 @@ void R3BMusliMapped2Cal::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(FATAL, !rtdb, "FairRuntimeDb not found");
 
-    fCal_Par = (R3BMusliCalPar*)rtdb->getContainer("musliCalPar");
+    fCal_Par = dynamic_cast<R3BMusliCalPar*>(rtdb->getContainer("musliCalPar"));
     if (!fCal_Par)
     {
         R3BLOG(ERROR, "R3BMusliMapped2Cal::SetParContainers() Couldn't get handle on musliCalPar container");
@@ -171,7 +171,7 @@ void R3BMusliMapped2Cal::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BMusliMappedData*)(fMusliMappedDataCA->At(i));
+        mappedData[i] = dynamic_cast<R3BMusliMappedData*>((fMusliMappedDataCA->At(i)));
         signalId = mappedData[i]->GetSignal() - 1;
 
         if (0 <= signalId && signalId < fNumSignals)

--- a/musli/calibration/R3BMusliMapped2CalPar.cxx
+++ b/musli/calibration/R3BMusliMapped2CalPar.cxx
@@ -78,16 +78,16 @@ void R3BMusliMapped2CalPar::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(FATAL, !rtdb, "R3BMusliMapped2CalPar::SetParContainers(), FairRuntimeDb not found");
 
-    fMusliGeo_Par = (R3BTGeoPar*)rtdb->getContainer("MusliGeoPar");
+    fMusliGeo_Par = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer("MusliGeoPar"));
     R3BLOG_IF(
         ERROR, !fMusliGeo_Par, "R3BMusliMapped2CalPar::SetParContainers() Couldn´t access to MusliGeoPar container.");
 
-    fMwAGeo_Par = (R3BTGeoPar*)rtdb->getContainer(fNameDetA + "GeoPar");
+    fMwAGeo_Par = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer(fNameDetA + "GeoPar"));
     R3BLOG_IF(ERROR,
               !fMwAGeo_Par,
               "R3BMusliMapped2CalPar::SetParContainers() Couldn´t access to " + fNameDetA + "GeoPar container.");
 
-    fMwBGeo_Par = (R3BTGeoPar*)rtdb->getContainer(fNameDetB + "GeoPar");
+    fMwBGeo_Par = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer(fNameDetB + "GeoPar"));
     R3BLOG_IF(ERROR,
               !fMwBGeo_Par,
               "R3BMusliMapped2CalPar::SetParContainers() Couldn´t access to " + fNameDetB + "GeoPar container.");
@@ -135,7 +135,7 @@ InitStatus R3BMusliMapped2CalPar::Init()
         return kFATAL;
     }
 
-    fCal_Par = (R3BMusliCalPar*)rtdb->getContainer("musliCalPar");
+    fCal_Par = dynamic_cast<R3BMusliCalPar*>(rtdb->getContainer("musliCalPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BMusliMapped2CalPar::Couldn't get handle on musliCalPar container";
@@ -183,7 +183,7 @@ void R3BMusliMapped2CalPar::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BMusliMappedData*)(fMusliMappedDataCA->At(i));
+        mappedData[i] = dynamic_cast<R3BMusliMappedData*>((fMusliMappedDataCA->At(i)));
         UInt_t signal_id = mappedData[i]->GetSignal() - 1; // signal_id is 0-based [0..17]
         if (multMap[signal_id] < fMaxMult)
         {
@@ -203,7 +203,7 @@ void R3BMusliMapped2CalPar::Exec(Option_t* option)
         return;
     else
     {
-        R3BMwpcHitData* hitDataMwA = (R3BMwpcHitData*)fMwAHitDataCA->At(0);
+        R3BMwpcHitData* hitDataMwA = dynamic_cast<R3BMwpcHitData*>(fMwAHitDataCA->At(0));
         fXA = hitDataMwA->GetX() + fMwAGeo_Par->GetPosX();
     }
 
@@ -213,7 +213,7 @@ void R3BMusliMapped2CalPar::Exec(Option_t* option)
         return;
     else
     {
-        R3BMwpcHitData* hitDataMwB = (R3BMwpcHitData*)fMwBHitDataCA->At(0);
+        R3BMwpcHitData* hitDataMwB = dynamic_cast<R3BMwpcHitData*>(fMwBHitDataCA->At(0));
         fXB = hitDataMwB->GetX() + fMwBGeo_Par->GetPosX();
     }
 

--- a/musli/online/R3BMusliOnlineSpectra.cxx
+++ b/musli/online/R3BMusliOnlineSpectra.cxx
@@ -81,7 +81,7 @@ InitStatus R3BMusliOnlineSpectra::Init()
         LOG(FATAL) << "R3BMusliOnlineSpectra::Init FairRootManager not found";
         return kFATAL;
     }
-    // header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    // header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     FairRunOnline* run = FairRunOnline::Instance();
     run->GetHttpServer()->Register("", this);
@@ -1270,7 +1270,7 @@ void R3BMusliOnlineSpectra::Exec(Option_t* option)
         nHits = fMapItemsMusli->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMusliMappedData* hit = (R3BMusliMappedData*)fMapItemsMusli->At(ihit);
+            R3BMusliMappedData* hit = dynamic_cast<R3BMusliMappedData*>(fMapItemsMusli->At(ihit));
             if (!hit)
                 continue;
             rank = hit->GetSignal() - 1;
@@ -1416,7 +1416,7 @@ void R3BMusliOnlineSpectra::Exec(Option_t* option)
         nHits = fCalItemsMusli->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMusliCalData* hit = (R3BMusliCalData*)fCalItemsMusli->At(ihit);
+            R3BMusliCalData* hit = dynamic_cast<R3BMusliCalData*>(fCalItemsMusli->At(ihit));
             if (!hit)
                 continue;
             rank = hit->GetSignal() - 1;
@@ -1459,7 +1459,7 @@ void R3BMusliOnlineSpectra::Exec(Option_t* option)
         nHits = fHitItemsMusli->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMusliHitData* hit = (R3BMusliHitData*)fHitItemsMusli->At(ihit);
+            R3BMusliHitData* hit = dynamic_cast<R3BMusliHitData*>(fHitItemsMusli->At(ihit));
             if (!hit)
                 continue;
             rank = hit->GetType() - 1;

--- a/musli/online/R3BMusliVsMwpcOnlineSpectra.cxx
+++ b/musli/online/R3BMusliVsMwpcOnlineSpectra.cxx
@@ -95,12 +95,12 @@ void R3BMusliVsMwpcOnlineSpectra::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(FATAL, !rtdb, "R3BMusliVsMwpcOnlineSpectra::SetParContainers(), FairRuntimeDb not found");
 
-    fMw1Geo_Par = (R3BTGeoPar*)rtdb->getContainer(fNameDet1 + "GeoPar");
+    fMw1Geo_Par = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer(fNameDet1 + "GeoPar"));
     R3BLOG_IF(ERROR,
               !fMw1Geo_Par,
               "R3BMusliVsMwpcOnlineSpectra::SetParContainers() Couldn´t access to " + fNameDet1 + "GeoPar container.");
 
-    fMw2Geo_Par = (R3BTGeoPar*)rtdb->getContainer(fNameDet2 + "GeoPar");
+    fMw2Geo_Par = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer(fNameDet2 + "GeoPar"));
     R3BLOG_IF(ERROR,
               !fMw2Geo_Par,
               "R3BMusliVsMwpcOnlineSpectra::SetParContainers() Couldn´t access to " + fNameDet2 + "GeoPar container.");
@@ -701,7 +701,7 @@ void R3BMusliVsMwpcOnlineSpectra::Exec(Option_t* option)
     Double_t fX1 = -100.;
     if (fHitMwpcDet1 && fHitMwpcDet1->GetEntriesFast() == 1)
     {
-        R3BMwpcHitData* hitDataMw1 = (R3BMwpcHitData*)fHitMwpcDet1->At(0);
+        R3BMwpcHitData* hitDataMw1 = dynamic_cast<R3BMwpcHitData*>(fHitMwpcDet1->At(0));
         fX1 = hitDataMw1->GetX() + fMw1Geo_Par->GetPosX();
     }
 
@@ -711,7 +711,7 @@ void R3BMusliVsMwpcOnlineSpectra::Exec(Option_t* option)
     Double_t fX2 = -100.;
     if (fHitMwpcDet2 && fHitMwpcDet2->GetEntriesFast() == 1)
     {
-        R3BMwpcHitData* hitDataMw2 = (R3BMwpcHitData*)fHitMwpcDet2->At(0);
+        R3BMwpcHitData* hitDataMw2 = dynamic_cast<R3BMwpcHitData*>(fHitMwpcDet2->At(0));
         fX2 = hitDataMw2->GetX() + fMw2Geo_Par->GetPosX();
     }
 
@@ -737,7 +737,7 @@ void R3BMusliVsMwpcOnlineSpectra::Exec(Option_t* option)
         nHits = fMapMusli->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMusliMappedData* hit = (R3BMusliMappedData*)fMapMusli->At(ihit);
+            R3BMusliMappedData* hit = dynamic_cast<R3BMusliMappedData*>(fMapMusli->At(ihit));
             if (!hit)
                 continue;
             rank = hit->GetSignal() - 1;
@@ -774,7 +774,7 @@ void R3BMusliVsMwpcOnlineSpectra::Exec(Option_t* option)
         nHits = fCalMusli->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMusliCalData* hit = (R3BMusliCalData*)fCalMusli->At(ihit);
+            R3BMusliCalData* hit = dynamic_cast<R3BMusliCalData*>(fCalMusli->At(ihit));
             if (!hit)
                 continue;
             rank = hit->GetSignal() - 1;
@@ -811,7 +811,7 @@ void R3BMusliVsMwpcOnlineSpectra::Exec(Option_t* option)
         nHits = fHitMusli->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMusliHitData* hit = (R3BMusliHitData*)fHitMusli->At(ihit);
+            R3BMusliHitData* hit = dynamic_cast<R3BMusliHitData*>(fHitMusli->At(ihit));
             if (!hit)
                 continue;
             rank = hit->GetType() - 1;

--- a/mwpc/digi/R3BMwpcDigitizer.cxx
+++ b/mwpc/digi/R3BMwpcDigitizer.cxx
@@ -65,7 +65,7 @@ void R3BMwpcDigitizer::SetParContainers()
 {
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
 
-    fMwpcGeoPar = (R3BTGeoPar*)rtdb->getContainer(fName + "GeoPar");
+    fMwpcGeoPar = dynamic_cast<R3BTGeoPar*>(rtdb->getContainer(fName + "GeoPar"));
     if (!fMwpcGeoPar)
     {
         R3BLOG(error, "Could not get access to " + fName + "GeoPar container.");
@@ -126,10 +126,10 @@ void R3BMwpcDigitizer::Exec(Option_t* opt)
     TVector3 vpos;
     for (Int_t i = 0; i < nHits; i++)
     {
-        pointData[i] = (R3BMwpcPoint*)(fMwpcPoints->At(i));
+        pointData[i] = dynamic_cast<R3BMwpcPoint*>((fMwpcPoints->At(i)));
         TrackId = pointData[i]->GetTrackID();
 
-        R3BMCTrack* Track = (R3BMCTrack*)fMCTrack->At(TrackId);
+        R3BMCTrack* Track = dynamic_cast<R3BMCTrack*>(fMCTrack->At(TrackId));
         PID = Track->GetPdgCode();
 
         if (PID > 1000080160) // Z=8 and A=16

--- a/mwpc/mwpc0/R3BMwpc0.cxx
+++ b/mwpc/mwpc0/R3BMwpc0.cxx
@@ -140,7 +140,7 @@ Bool_t R3BMwpc0::ProcessHits(FairVolume* vol)
                  fELoss);
 
         // Increment number of TraPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kSOFMWPC0);
 
         ResetParameters();
@@ -203,7 +203,7 @@ void R3BMwpc0::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BMwpcPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BMwpcPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BMwpcPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BMwpcPoint(*oldpoint);

--- a/mwpc/mwpc0/R3BMwpc0Cal2Hit.cxx
+++ b/mwpc/mwpc0/R3BMwpc0Cal2Hit.cxx
@@ -113,7 +113,7 @@ void R3BMwpc0Cal2Hit::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        calData[i] = (R3BMwpcCalData*)(fMwpcCalDataCA->At(i));
+        calData[i] = dynamic_cast<R3BMwpcCalData*>((fMwpcCalDataCA->At(i)));
         planeId = calData[i]->GetPlane();
         padId = calData[i]->GetPad() - 1;
         q = calData[i]->GetQ();

--- a/mwpc/mwpc0/R3BMwpc0ContFact.cxx
+++ b/mwpc/mwpc0/R3BMwpc0ContFact.cxx
@@ -82,11 +82,11 @@ void R3BMwpc0ContFact::activateParIo(FairParIo* io)
     // needed by the Mwpc0
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BMwpc0ParRootFileIo* p=new R3BMwpc0ParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BMwpc0ParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BMwpc0ParAsciiFileIo* p=new R3BMwpc0ParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BMwpc0ParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/mwpc/mwpc0/R3BMwpc0Mapped2Cal.cxx
+++ b/mwpc/mwpc0/R3BMwpc0Mapped2Cal.cxx
@@ -163,7 +163,7 @@ void R3BMwpc0Mapped2Cal::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BMwpcMappedData*)(fMwpcMappedDataCA->At(i));
+        mappedData[i] = dynamic_cast<R3BMwpcMappedData*>((fMwpcMappedDataCA->At(i)));
         planeId = mappedData[i]->GetPlane();
         padId = mappedData[i]->GetPad() - 1;
         if (planeId == 1)

--- a/mwpc/mwpc0/R3BMwpc0Mapped2CalPar.cxx
+++ b/mwpc/mwpc0/R3BMwpc0Mapped2CalPar.cxx
@@ -128,7 +128,7 @@ void R3BMwpc0Mapped2CalPar::Exec(Option_t* opt)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        MapHit = (R3BMwpcMappedData*)(fMwpcMappedDataCA->At(i));
+        MapHit = dynamic_cast<R3BMwpcMappedData*>((fMwpcMappedDataCA->At(i)));
         planeid = MapHit->GetPlane();
         padid = MapHit->GetPad() - 1;
 

--- a/mwpc/mwpc1/R3BMwpc1.cxx
+++ b/mwpc/mwpc1/R3BMwpc1.cxx
@@ -138,7 +138,7 @@ Bool_t R3BMwpc1::ProcessHits(FairVolume* vol)
                  fELoss);
 
         // Increment number of TraPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kSOFMWPC1);
 
         ResetParameters();
@@ -197,7 +197,7 @@ void R3BMwpc1::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BMwpcPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BMwpcPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BMwpcPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BMwpcPoint(*oldpoint);

--- a/mwpc/mwpc1/R3BMwpc1Cal2Hit.cxx
+++ b/mwpc/mwpc1/R3BMwpc1Cal2Hit.cxx
@@ -75,9 +75,9 @@ InitStatus R3BMwpc1Cal2Hit::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rootManager->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)rootManager->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("R3BEventHeader"));
 
     fMwpcCalDataCA = (TClonesArray*)rootManager->GetObject("Mwpc1CalData");
     if (!fMwpcCalDataCA)
@@ -169,7 +169,7 @@ void R3BMwpc1Cal2Hit::S467()
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        calData[i] = (R3BMwpcCalData*)(fMwpcCalDataCA->At(i));
+        calData[i] = dynamic_cast<R3BMwpcCalData*>((fMwpcCalDataCA->At(i)));
         planeId = calData[i]->GetPlane();
         padId = calData[i]->GetPad() - 1; // From 0 to 63 for X down and up
         q = calData[i]->GetQ();
@@ -253,7 +253,7 @@ void R3BMwpc1Cal2Hit::S455()
         fy[i] = 0;
     for (Int_t i = 0; i < nHits; i++)
     {
-        calData[i] = (R3BMwpcCalData*)(fMwpcCalDataCA->At(i));
+        calData[i] = dynamic_cast<R3BMwpcCalData*>((fMwpcCalDataCA->At(i)));
         planeId = calData[i]->GetPlane();
         padId = calData[i]->GetPad() - 1;
         q = calData[i]->GetQ();

--- a/mwpc/mwpc1/R3BMwpc1Mapped2Cal.cxx
+++ b/mwpc/mwpc1/R3BMwpc1Mapped2Cal.cxx
@@ -163,7 +163,7 @@ void R3BMwpc1Mapped2Cal::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BMwpcMappedData*)(fMwpcMappedDataCA->At(i));
+        mappedData[i] = dynamic_cast<R3BMwpcMappedData*>((fMwpcMappedDataCA->At(i)));
         planeId = mappedData[i]->GetPlane();
         padId = mappedData[i]->GetPad() - 1;
         if (planeId == 1) // X

--- a/mwpc/mwpc1/R3BMwpc1Mapped2CalPar.cxx
+++ b/mwpc/mwpc1/R3BMwpc1Mapped2CalPar.cxx
@@ -129,7 +129,7 @@ void R3BMwpc1Mapped2CalPar::Exec(Option_t* opt)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        MapHit = (R3BMwpcMappedData*)(fMwpcMappedDataCA->At(i));
+        MapHit = dynamic_cast<R3BMwpcMappedData*>((fMwpcMappedDataCA->At(i)));
         planeid = MapHit->GetPlane();
         padid = MapHit->GetPad() - 1;
 

--- a/mwpc/mwpc2/R3BMwpc2.cxx
+++ b/mwpc/mwpc2/R3BMwpc2.cxx
@@ -138,7 +138,7 @@ Bool_t R3BMwpc2::ProcessHits(FairVolume* vol)
                  fELoss);
 
         // Increment number of TraPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kSOFMWPC2);
 
         ResetParameters();
@@ -197,7 +197,7 @@ void R3BMwpc2::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BMwpcPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BMwpcPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BMwpcPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BMwpcPoint(*oldpoint);

--- a/mwpc/mwpc2/R3BMwpc2Cal2Hit.cxx
+++ b/mwpc/mwpc2/R3BMwpc2Cal2Hit.cxx
@@ -76,9 +76,9 @@ InitStatus R3BMwpc2Cal2Hit::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rootManager->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)rootManager->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("R3BEventHeader"));
 
     fMwpcCalDataCA = (TClonesArray*)rootManager->GetObject("Mwpc2CalData");
     if (!fMwpcCalDataCA)
@@ -174,7 +174,7 @@ void R3BMwpc2Cal2Hit::S467()
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        calData[i] = (R3BMwpcCalData*)(fMwpcCalDataCA->At(i));
+        calData[i] = dynamic_cast<R3BMwpcCalData*>((fMwpcCalDataCA->At(i)));
         planeId = calData[i]->GetPlane();
         padId = calData[i]->GetPad() - 1; // From 0 to 63 for X down and up
         q = calData[i]->GetQ();
@@ -257,7 +257,7 @@ void R3BMwpc2Cal2Hit::S455()
         fy[i] = 0;
     for (Int_t i = 0; i < nHits; i++)
     {
-        calData[i] = (R3BMwpcCalData*)(fMwpcCalDataCA->At(i));
+        calData[i] = dynamic_cast<R3BMwpcCalData*>((fMwpcCalDataCA->At(i)));
         planeId = calData[i]->GetPlane();
         padId = calData[i]->GetPad() - 1;
         q = calData[i]->GetQ();

--- a/mwpc/mwpc2/R3BMwpc2Mapped2Cal.cxx
+++ b/mwpc/mwpc2/R3BMwpc2Mapped2Cal.cxx
@@ -163,7 +163,7 @@ void R3BMwpc2Mapped2Cal::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BMwpcMappedData*)(fMwpcMappedDataCA->At(i));
+        mappedData[i] = dynamic_cast<R3BMwpcMappedData*>((fMwpcMappedDataCA->At(i)));
         planeId = mappedData[i]->GetPlane();
         padId = mappedData[i]->GetPad() - 1;
         if (planeId == 1) // X

--- a/mwpc/mwpc2/R3BMwpc2Mapped2CalPar.cxx
+++ b/mwpc/mwpc2/R3BMwpc2Mapped2CalPar.cxx
@@ -127,7 +127,7 @@ void R3BMwpc2Mapped2CalPar::Exec(Option_t* opt)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        MapHit = (R3BMwpcMappedData*)(fMwpcMappedDataCA->At(i));
+        MapHit = dynamic_cast<R3BMwpcMappedData*>((fMwpcMappedDataCA->At(i)));
         planeid = MapHit->GetPlane();
         padid = MapHit->GetPad() - 1;
 

--- a/mwpc/mwpc3/R3BMwpc3.cxx
+++ b/mwpc/mwpc3/R3BMwpc3.cxx
@@ -138,7 +138,7 @@ Bool_t R3BMwpc3::ProcessHits(FairVolume* vol)
                  fELoss);
 
         // Increment number of TraPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kSOFMWPC3);
 
         ResetParameters();
@@ -197,7 +197,7 @@ void R3BMwpc3::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BMwpcPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BMwpcPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BMwpcPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BMwpcPoint(*oldpoint);

--- a/mwpc/mwpc3/R3BMwpc3Cal2Hit.cxx
+++ b/mwpc/mwpc3/R3BMwpc3Cal2Hit.cxx
@@ -85,9 +85,9 @@ InitStatus R3BMwpc3Cal2Hit::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rootManager->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)rootManager->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("R3BEventHeader"));
 
     fMwpcCalDataCA = (TClonesArray*)rootManager->GetObject("Mwpc3CalData");
     if (!fMwpcCalDataCA)
@@ -173,7 +173,7 @@ void R3BMwpc3Cal2Hit::S467()
 
         for (Int_t i = 0; i < nHits; i++)
         {
-            calData[i] = (R3BMwpcCalData*)(fMwpcCalDataCA->At(i));
+            calData[i] = dynamic_cast<R3BMwpcCalData*>((fMwpcCalDataCA->At(i)));
             planeId = calData[i]->GetPlane();
             padId = calData[i]->GetPad() - 1;
             q = calData[i]->GetQ();
@@ -267,7 +267,7 @@ void R3BMwpc3Cal2Hit::S455()
             fy[i] = 0;
         for (Int_t i = 0; i < nHits; i++)
         {
-            calData[i] = (R3BMwpcCalData*)(fMwpcCalDataCA->At(i));
+            calData[i] = dynamic_cast<R3BMwpcCalData*>((fMwpcCalDataCA->At(i)));
             planeId = calData[i]->GetPlane();
             padId = calData[i]->GetPad() - 1;
             q = calData[i]->GetQ();
@@ -454,7 +454,7 @@ void R3BMwpc3Cal2Hit::ReconstructHitWithTofWallMatching()
     twY.clear();
     for (Int_t i = 0; i < twHits; i++)
     {
-        twHitData[i] = (R3BSofTofWHitData*)(fTofWallHitDataCA->At(i));
+        twHitData[i] = dynamic_cast<R3BSofTofWHitData*>((fTofWallHitDataCA->At(i)));
         twX.push_back(twHitData[i]->GetX());
         twY.push_back(twHitData[i]->GetY());
     }
@@ -485,7 +485,7 @@ void R3BMwpc3Cal2Hit::ReconstructHitWithTofWallMatching()
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        calData[i] = (R3BMwpcCalData*)(fMwpcCalDataCA->At(i));
+        calData[i] = dynamic_cast<R3BMwpcCalData*>((fMwpcCalDataCA->At(i)));
         planeId = calData[i]->GetPlane();
         padId = calData[i]->GetPad() - 1;
         q = calData[i]->GetQ();

--- a/mwpc/mwpc3/R3BMwpc3Mapped2Cal.cxx
+++ b/mwpc/mwpc3/R3BMwpc3Mapped2Cal.cxx
@@ -157,7 +157,7 @@ void R3BMwpc3Mapped2Cal::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BMwpcMappedData*)(fMwpcMappedDataCA->At(i));
+        mappedData[i] = dynamic_cast<R3BMwpcMappedData*>((fMwpcMappedDataCA->At(i)));
         planeId = mappedData[i]->GetPlane();
         padId = mappedData[i]->GetPad() - 1;
         if (planeId == 1)

--- a/mwpc/mwpc3/R3BMwpc3Mapped2CalPar.cxx
+++ b/mwpc/mwpc3/R3BMwpc3Mapped2CalPar.cxx
@@ -130,7 +130,7 @@ void R3BMwpc3Mapped2CalPar::Exec(Option_t* opt)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        MapHit = (R3BMwpcMappedData*)(fMwpcMappedDataCA->At(i));
+        MapHit = dynamic_cast<R3BMwpcMappedData*>((fMwpcMappedDataCA->At(i)));
         planeid = MapHit->GetPlane();
         padid = MapHit->GetPad() - 1;
 

--- a/mwpc/online/R3BMwpcCorrelationOnlineSpectra.cxx
+++ b/mwpc/online/R3BMwpcCorrelationOnlineSpectra.cxx
@@ -251,7 +251,7 @@ void R3BMwpcCorrelationOnlineSpectra::Exec(Option_t* option)
         Int_t maxpadx1 = -1, maxpady1 = -1, maxqx1 = 0, maxqy1 = 0;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMwpcCalData* hit = (R3BMwpcCalData*)fCalItemsMwpc1->At(ihit);
+            R3BMwpcCalData* hit = dynamic_cast<R3BMwpcCalData*>(fCalItemsMwpc1->At(ihit));
             if (!hit)
                 continue;
             if (hit->GetPlane() == 1 || hit->GetPlane() == 2)
@@ -276,7 +276,7 @@ void R3BMwpcCorrelationOnlineSpectra::Exec(Option_t* option)
         Int_t maxpadx2 = -1, maxpady2 = -1, maxqx2 = 0, maxqy2 = 0;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMwpcCalData* hit = (R3BMwpcCalData*)fCalItemsMwpc2->At(ihit);
+            R3BMwpcCalData* hit = dynamic_cast<R3BMwpcCalData*>(fCalItemsMwpc2->At(ihit));
             if (!hit)
                 continue;
             if (hit->GetPlane() == 1 || hit->GetPlane() == 2)
@@ -310,7 +310,7 @@ void R3BMwpcCorrelationOnlineSpectra::Exec(Option_t* option)
         Int_t nHits1 = fHitItemsMwpc1->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits1; ihit++)
         {
-            R3BMwpcHitData* hit = (R3BMwpcHitData*)fHitItemsMwpc1->At(ihit);
+            R3BMwpcHitData* hit = dynamic_cast<R3BMwpcHitData*>(fHitItemsMwpc1->At(ihit));
             if (!hit)
                 continue;
             mw1x = hit->GetX();
@@ -320,7 +320,7 @@ void R3BMwpcCorrelationOnlineSpectra::Exec(Option_t* option)
         Int_t nHits2 = fHitItemsMwpc2->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits2; ihit++)
         {
-            R3BMwpcHitData* hit = (R3BMwpcHitData*)fHitItemsMwpc2->At(ihit);
+            R3BMwpcHitData* hit = dynamic_cast<R3BMwpcHitData*>(fHitItemsMwpc2->At(ihit));
             if (!hit)
                 continue;
             mw2x = hit->GetX();

--- a/mwpc/online/R3BMwpcOnlineSpectra.cxx
+++ b/mwpc/online/R3BMwpcOnlineSpectra.cxx
@@ -91,7 +91,7 @@ InitStatus R3BMwpcOnlineSpectra::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     if (NULL == mgr)
         LOG(FATAL) << "R3B" + fNameDet + "OnlineSpectra::Init FairRootManager not found";
-    // header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    // header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     FairRunOnline* run = FairRunOnline::Instance();
     run->GetHttpServer()->Register("", this);
@@ -478,7 +478,7 @@ void R3BMwpcOnlineSpectra::Exec(Option_t* option)
         Int_t nHits = fMapItemsMwpc->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMwpcMappedData* hit = (R3BMwpcMappedData*)fMapItemsMwpc->At(ihit);
+            R3BMwpcMappedData* hit = dynamic_cast<R3BMwpcMappedData*>(fMapItemsMwpc->At(ihit));
             if (!hit)
                 continue;
             nPadsPerEvent[hit->GetPlane() - 1]++;
@@ -503,7 +503,7 @@ void R3BMwpcOnlineSpectra::Exec(Option_t* option)
         Int_t maxpadx = -1, maxpady = -1, maxqx = 0, maxqy = 0;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMwpcCalData* hit = (R3BMwpcCalData*)fCalItemsMwpc->At(ihit);
+            R3BMwpcCalData* hit = dynamic_cast<R3BMwpcCalData*>(fCalItemsMwpc->At(ihit));
             if (!hit)
                 continue;
             if (hit->GetPlane() == 1 || hit->GetPlane() == 2)
@@ -538,7 +538,7 @@ void R3BMwpcOnlineSpectra::Exec(Option_t* option)
         Int_t nHits = fHitItemsMwpc->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMwpcHitData* hit = (R3BMwpcHitData*)fHitItemsMwpc->At(ihit);
+            R3BMwpcHitData* hit = dynamic_cast<R3BMwpcHitData*>(fHitItemsMwpc->At(ihit));
             if (!hit)
                 continue;
             fh1_Xpos->Fill(hit->GetX());

--- a/neuland/calibration/R3BNeulandCal2Hit.cxx
+++ b/neuland/calibration/R3BNeulandCal2Hit.cxx
@@ -51,7 +51,7 @@ InitStatus R3BNeulandCal2Hit::Init()
         throw std::runtime_error("R3BNeulandCal2Hit: No FairRootManager");
     }
 
-    fEventHeader = (R3BEventHeader*)ioman->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(ioman->GetObject("EventHeader."));
     if (fEventHeader == nullptr)
     {
         throw std::runtime_error("R3BNeulandCal2Hit: No R3BEventHeader");
@@ -66,7 +66,7 @@ InitStatus R3BNeulandCal2Hit::Init()
 
 void R3BNeulandCal2Hit::SetParContainers()
 {
-    fPar = (R3BNeulandHitPar*)FairRuntimeDb::instance()->getContainer("NeulandHitPar");
+    fPar = dynamic_cast<R3BNeulandHitPar*>(FairRuntimeDb::instance()->getContainer("NeulandHitPar"));
 }
 
 void R3BNeulandCal2Hit::SetParameter()

--- a/neuland/calibration/R3BNeulandCalTest.cxx
+++ b/neuland/calibration/R3BNeulandCalTest.cxx
@@ -83,7 +83,7 @@ void R3BNeulandCalTest::Exec(Option_t* option)
         Bool_t seen[] = { kFALSE, kFALSE, kFALSE, kFALSE };
         for (Int_t i = 0; i < nLosHit; i++)
         {
-            losHit = (R3BLosHit*)fLosHit->At(i);
+            losHit = dynamic_cast<R3BLosHit*>(fLosHit->At(i));
             ch = losHit->GetChannel();
             if (ch > 3)
             {
@@ -123,7 +123,7 @@ void R3BNeulandCalTest::Exec(Option_t* option)
         Double_t time1, time2;
         for (Int_t i1 = 0; i1 < nLandPmt; i1++)
         {
-            pmt1 = (R3BNeulandCalData*)fLandPmt->At(i1);
+            pmt1 = dynamic_cast<R3BNeulandCalData*>(fLandPmt->At(i1));
             barId = pmt1->GetBarId();
             time1 = pmt1->GetTime();
             time1 += walk(pmt1->GetQdc());
@@ -134,7 +134,7 @@ void R3BNeulandCalTest::Exec(Option_t* option)
                 {
                     continue;
                 }
-                pmt2 = (R3BNeulandCalData*)fLandPmt->At(i2);
+                pmt2 = dynamic_cast<R3BNeulandCalData*>(fLandPmt->At(i2));
                 if (barId != pmt2->GetBarId())
                 {
                     continue;
@@ -167,7 +167,7 @@ void R3BNeulandCalTest::Exec(Option_t* option)
         Double_t time1, time2;
         for (Int_t i1 = 0; i1 < nNeulandPmt; i1++)
         {
-            pmt1 = (R3BNeulandPmt*)fNeulandPmt->At(i1);
+            pmt1 = dynamic_cast<R3BNeulandPmt*>(fNeulandPmt->At(i1));
             planeId = pmt1->GetPlaneId();
             barId = pmt1->GetBarId();
             time1 = pmt1->GetTime();
@@ -179,7 +179,7 @@ void R3BNeulandCalTest::Exec(Option_t* option)
                 {
                     continue;
                 }
-                pmt2 = (R3BNeulandPmt*)fNeulandPmt->At(i2);
+                pmt2 = dynamic_cast<R3BNeulandPmt*>(fNeulandPmt->At(i2));
                 if (barId != pmt2->GetBarId())
                 {
                     continue;

--- a/neuland/calibration/R3BNeulandHitHist.cxx
+++ b/neuland/calibration/R3BNeulandHitHist.cxx
@@ -68,7 +68,7 @@ void R3BNeulandHitHist::Exec(Option_t* option)
     if (!fLosHit || fLosHit->GetEntriesFast() == 0)
         return;
 
-    R3BLosHitData* losHit = (R3BLosHitData*)fLosHit->At(0);
+    R3BLosHitData* losHit = dynamic_cast<R3BLosHitData*>(fLosHit->At(0));
     // Double_t startTime = losHit->GetTime(); TODO
     Double_t startTime = 0;
     Int_t count = 0;
@@ -87,7 +87,7 @@ void R3BNeulandHitHist::Exec(Option_t* option)
 
         for (Int_t i = 0; i < nLandDigi; i++)
         {
-            digi = (R3BNeulandHit*)fLandDigi->At(i);
+            digi = dynamic_cast<R3BNeulandHit*>(fLandDigi->At(i));
 
             barId = digi->GetPaddle();
             time = digi->GetT();

--- a/neuland/calibration/R3BNeulandHitPar.cxx
+++ b/neuland/calibration/R3BNeulandHitPar.cxx
@@ -74,7 +74,7 @@ void R3BNeulandHitPar::printParams()
     LOG(INFO) << " Number of Parameters " << fParams->GetEntries();
     for (Int_t i = 0; i < fParams->GetEntries(); i++)
     {
-        R3BNeulandHitModulePar* t_par = (R3BNeulandHitModulePar*)fParams->At(i);
+        R3BNeulandHitModulePar* t_par = dynamic_cast<R3BNeulandHitModulePar*>(fParams->At(i));
         LOG(INFO) << "----------------------------------------------------------------------";
         if (t_par)
         {

--- a/neuland/calibration/R3BNeulandHitPar.h
+++ b/neuland/calibration/R3BNeulandHitPar.h
@@ -90,7 +90,7 @@ class R3BNeulandHitPar : public FairParGenericSet
      * @param idx an index of a module.
      * @return parameter container of this module.
      */
-    R3BNeulandHitModulePar* GetModuleParAt(Int_t idx) const { return (R3BNeulandHitModulePar*)fParams->At(idx); }
+    R3BNeulandHitModulePar* GetModuleParAt(Int_t idx) const { return dynamic_cast<R3BNeulandHitModulePar*>(fParams->At(idx)); }
 
     // Global time offset in ns
     inline Double_t GetGlobalTimeOffset() const { return fGlobalTimeOffset; }

--- a/neuland/calibration/R3BNeulandMapped2Cal.cxx
+++ b/neuland/calibration/R3BNeulandMapped2Cal.cxx
@@ -87,7 +87,7 @@ InitStatus R3BNeulandMapped2Cal::Init()
         LOG(FATAL) << "FairRootManager not found";
     }
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (NULL == header)
     {
         LOG(FATAL) << "Branch R3BEventHeader not found";
@@ -123,10 +123,10 @@ void R3BNeulandMapped2Cal::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(ERROR, !rtdb, "FairRuntimeDb not found");
 
-    fMapPar = (R3BNeulandMappingPar*)rtdb->getContainer("neulandMappingPar");
+    fMapPar = dynamic_cast<R3BNeulandMappingPar*>(rtdb->getContainer("neulandMappingPar"));
     R3BLOG_IF(WARNING, !fMapPar, "Could not get access to neulandMappingPar container");
 
-    fTcalPar = (R3BTCalPar*)rtdb->getContainer("LandTCalPar");
+    fTcalPar = dynamic_cast<R3BTCalPar*>(rtdb->getContainer("LandTCalPar"));
 
     if (!fTcalPar)
     {
@@ -200,7 +200,7 @@ void R3BNeulandMapped2Cal::MakeCal()
         nHits = fMappedTrigger->GetEntriesFast();
         for (int i = 0; i < nHits; ++i)
         {
-            auto* mapped = (R3BPaddleTamexMappedData*)fMappedTrigger->At(i);
+            auto* mapped = dynamic_cast<R3BPaddleTamexMappedData*>(fMappedTrigger->At(i));
             auto iBar = mapped->GetBarId();
             auto par = fTcalPar->GetModuleParAt(100, iBar, 10);
             if (!par)
@@ -221,7 +221,7 @@ void R3BNeulandMapped2Cal::MakeCal()
 
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        R3BPaddleTamexMappedData* hit = (R3BPaddleTamexMappedData*)fMapped->At(ihit);
+        R3BPaddleTamexMappedData* hit = dynamic_cast<R3BPaddleTamexMappedData*>(fMapped->At(ihit));
         if (NULL == hit)
         {
             continue;

--- a/neuland/calibration/R3BNeulandMapped2CalPar.cxx
+++ b/neuland/calibration/R3BNeulandMapped2CalPar.cxx
@@ -68,7 +68,7 @@ InitStatus R3BNeulandMapped2CalPar::Init()
     {
         return kFATAL;
     }
-    header = (R3BEventHeader*)rm->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("EventHeader."));
     if (!header)
     {
         return kFATAL;
@@ -86,7 +86,7 @@ InitStatus R3BNeulandMapped2CalPar::Init()
 
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the land directory)
-    fCal_Par = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("LandTCalPar");
+    fCal_Par = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("LandTCalPar"));
     fCal_Par->setChanged();
 
     fEngine = new R3BTCalEngine(fCal_Par, fMinStats);
@@ -133,7 +133,7 @@ void R3BNeulandMapped2CalPar::Exec(Option_t* option)
     // Loop over mapped hits
     for (Int_t i = 0; i < nHits; i++)
     {
-        auto hit = (R3BPaddleTamexMappedData*)fHits->At(i);
+        auto hit = dynamic_cast<R3BPaddleTamexMappedData*>(fHits->At(i));
         if (!hit)
         {
             continue;
@@ -192,7 +192,7 @@ void R3BNeulandMapped2CalPar::Exec(Option_t* option)
         nHits = fHitsTrigger->GetEntriesFast();
         for (Int_t i = 0; i < nHits; i++)
         {
-            auto hit = (R3BPaddleTamexMappedData*)fHitsTrigger->At(i);
+            auto hit = dynamic_cast<R3BPaddleTamexMappedData*>(fHitsTrigger->At(i));
             if (!hit)
             {
                 continue;

--- a/neuland/calibration/R3BNeulandMappedHist.cxx
+++ b/neuland/calibration/R3BNeulandMappedHist.cxx
@@ -50,7 +50,7 @@ R3BNeulandMappedHist::~R3BNeulandMappedHist() {}
 InitStatus R3BNeulandMappedHist::Init()
 {
     FairRootManager* fMan = FairRootManager::Instance();
-    fHeader = (R3BEventHeader*)fMan->GetObject("EventHeader.");
+    fHeader = dynamic_cast<R3BEventHeader*>(fMan->GetObject("EventHeader."));
     fLandMappedData = (TClonesArray*)fMan->GetObject("NeulandTacquilaMappedData");
     fLosMappedData = (TClonesArray*)fMan->GetObject("LosMapped");
     fNeulandTamexHitMapped = (TClonesArray*)fMan->GetObject("NeulandMappedData");
@@ -73,7 +73,7 @@ void R3BNeulandMappedHist::Exec(Option_t* option)
         R3BNeulandTacquilaMappedData* hitmapped;
         for (Int_t i = 0; i < nLandMapped; i++)
         {
-            hitmapped = (R3BNeulandTacquilaMappedData*)fLandMappedData->At(i);
+            hitmapped = dynamic_cast<R3BNeulandTacquilaMappedData*>(fLandMappedData->At(i));
             fh_land_mapped_barid->Fill((hitmapped->GetPlane() - 1) * 50 + hitmapped->GetPaddle());
             fh_land_mapped_side->Fill(hitmapped->GetSide());
             fh_land_mapped_clock->Fill(hitmapped->GetClock());
@@ -89,7 +89,7 @@ void R3BNeulandMappedHist::Exec(Option_t* option)
         R3BPaddleTamexMappedData* hitmapped;
         for (Int_t i = 0; i < nNeulandTamexHitsMapped; i++)
         {
-            hitmapped = (R3BPaddleTamexMappedData*)fNeulandTamexHitMapped->At(i);
+            hitmapped = dynamic_cast<R3BPaddleTamexMappedData*>(fNeulandTamexHitMapped->At(i));
             fh_neuland_mapped_is17->Fill(hitmapped->Is17());
             if (!hitmapped->Is17())
             {
@@ -117,7 +117,7 @@ void R3BNeulandMappedHist::Exec(Option_t* option)
         R3BLosMappedData* loshit;
         for (Int_t i = 0; i < nLosMapped; i++)
         {
-            loshit = (R3BLosMappedData*)fLosMappedData->At(i);
+            loshit = dynamic_cast<R3BLosMappedData*>(fLosMappedData->At(i));
             fh_los_det->Fill(loshit->GetDetector());
             fh_los_ch->Fill(loshit->GetChannel());
             fh_los_tcoarse->Fill(loshit->GetTimeCoarse());

--- a/neuland/calibration/R3BNeulandProvideTStart.cxx
+++ b/neuland/calibration/R3BNeulandProvideTStart.cxx
@@ -32,7 +32,7 @@ InitStatus R3BNeulandProvideTStart::Init()
         throw std::runtime_error("R3BNeulandProvideTStart: No FairRootManager");
     }
 
-    fEventHeader = (R3BEventHeader*)ioman->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(ioman->GetObject("EventHeader."));
     if (fEventHeader == nullptr)
     {
         throw std::runtime_error("R3BNeulandProvideTStart: No R3BEventHeader");

--- a/neuland/calibration/R3BNeulandTacquilaMapped2Cal.cxx
+++ b/neuland/calibration/R3BNeulandTacquilaMapped2Cal.cxx
@@ -107,7 +107,7 @@ InitStatus R3BNeulandTacquilaMapped2Cal::Init()
         LOG(fatal) << "FairRootManager not found";
     }
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (NULL == header)
     {
         LOG(fatal) << "Branch R3BEventHeader not found";
@@ -133,8 +133,8 @@ void R3BNeulandTacquilaMapped2Cal::SetParContainers()
 {
     FairRunAna* ana = FairRunAna::Instance();
     FairRuntimeDb* rtdb = ana->GetRuntimeDb();
-    fTcalPar = (R3BTCalPar*)(rtdb->getContainer("LandTCalPar"));
-    fQCalPar = (R3BNeulandQCalPar*)(rtdb->getContainer("NeulandQCalPar"));
+    fTcalPar = dynamic_cast<R3BTCalPar*>((rtdb->getContainer("LandTCalPar")));
+    fQCalPar = dynamic_cast<R3BNeulandQCalPar*>((rtdb->getContainer("NeulandQCalPar")));
 }
 
 void R3BNeulandTacquilaMapped2Cal::SetParameter()
@@ -199,7 +199,7 @@ void R3BNeulandTacquilaMapped2Cal::Exec(Option_t* option)
         Double_t time1 = nan("");
         for (Int_t i = 0; i < fNPmt; i++)
         {
-            pmt1 = (R3BNeulandCalData*)fPmt->At(i);
+            pmt1 = dynamic_cast<R3BNeulandCalData*>(fPmt->At(i));
             if (pmt1->GetBarId() == 2 && pmt1->GetSide() == 1)
             {
                 time1 = pmt1->GetTime();
@@ -208,7 +208,7 @@ void R3BNeulandTacquilaMapped2Cal::Exec(Option_t* option)
         }
         for (Int_t i = 0; i < fNPmt; i++)
         {
-            pmt1 = (R3BNeulandCalData*)fPmt->At(i);
+            pmt1 = dynamic_cast<R3BNeulandCalData*>(fPmt->At(i));
             if (pmt1->GetBarId() == 5 && pmt1->GetSide() == 1)
             {
                 fh_pulser_5_2->Fill(pmt1->GetTime() - time1);
@@ -238,7 +238,7 @@ void R3BNeulandTacquilaMapped2Cal::MakeCal()
 
     for (Int_t khit = 0; khit < nHits; khit++)
     {
-        hit2 = (R3BNeulandTacquilaMappedData*)fRawHit->At(khit);
+        hit2 = dynamic_cast<R3BNeulandTacquilaMappedData*>(fRawHit->At(khit));
         if (NULL == hit2)
         {
             continue;

--- a/neuland/calibration/R3BNeulandTacquilaMapped2CalPar.cxx
+++ b/neuland/calibration/R3BNeulandTacquilaMapped2CalPar.cxx
@@ -66,7 +66,7 @@ InitStatus R3BNeulandTacquilaMapped2CalPar::Init()
     {
         return kFATAL;
     }
-    header = (R3BEventHeader*)rm->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("EventHeader."));
     if (!header)
     {
         return kFATAL;
@@ -77,7 +77,7 @@ InitStatus R3BNeulandTacquilaMapped2CalPar::Init()
         return kFATAL;
     }
 
-    fCal_Par = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("LandTCalPar");
+    fCal_Par = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("LandTCalPar"));
     fCal_Par->setChanged();
 
     fEngine = new R3BTCalEngine(fCal_Par, fMinStats);
@@ -109,7 +109,7 @@ void R3BNeulandTacquilaMapped2CalPar::Exec(Option_t* option)
     // Loop over mapped hits
     for (Int_t i = 0; i < nHits; i++)
     {
-        hit = (R3BNeulandTacquilaMappedData*)fHits->At(i);
+        hit = dynamic_cast<R3BNeulandTacquilaMappedData*>(fHits->At(i));
         if (!hit)
         {
             continue;

--- a/neuland/calibration/R3BNeulandTacquilaMapped2QCalPar.cxx
+++ b/neuland/calibration/R3BNeulandTacquilaMapped2QCalPar.cxx
@@ -63,7 +63,7 @@ InitStatus R3BNeulandTacquilaMapped2QCalPar::Init()
         LOG(fatal) << " Branch: NeulandTacquilaMappedData not found in Tree.";
         return kFATAL;
     }
-    header = (R3BEventHeader*)fMan->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(fMan->GetObject("R3BEventHeader"));
     if (!header)
     {
         LOG(fatal) << " Branch: R3BEventHeader not found in Tree.";
@@ -89,7 +89,7 @@ InitStatus R3BNeulandTacquilaMapped2QCalPar::Init()
         }
         fData.push_back(v_plane);
     }
-    fPar = (R3BNeulandQCalPar*)FairRuntimeDb::instance()->getContainer("NeulandQCalPar");
+    fPar = dynamic_cast<R3BNeulandQCalPar*>(FairRuntimeDb::instance()->getContainer("NeulandQCalPar"));
 
     return kSUCCESS;
 }
@@ -107,7 +107,7 @@ void R3BNeulandTacquilaMapped2QCalPar::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        hit = (R3BNeulandTacquilaMappedData*)fHits->At(i);
+        hit = dynamic_cast<R3BNeulandTacquilaMappedData*>(fHits->At(i));
         if (!hit)
             continue;
 

--- a/neuland/online/R3BNeulandOnlineReconstruction.cxx
+++ b/neuland/online/R3BNeulandOnlineReconstruction.cxx
@@ -57,7 +57,7 @@ InitStatus R3BNeulandOnlineReconstruction::Init()
         throw std::runtime_error("R3BNeulandOnlineReconstruction: No FairRootManager");
     }
 
-    fEventHeader = (R3BEventHeader*)ioman->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(ioman->GetObject("EventHeader."));
     if (fEventHeader == nullptr)
     {
         throw std::runtime_error("R3BNeulandOnlineReconstruction: No R3BEventHeader");

--- a/neuland/online/R3BNeulandOnlineSpectra.cxx
+++ b/neuland/online/R3BNeulandOnlineSpectra.cxx
@@ -58,7 +58,7 @@ InitStatus R3BNeulandOnlineSpectra::Init()
         throw std::runtime_error("R3BNeulandOnlineSpectra: No FairRootManager");
     }
 
-    fEventHeader = (R3BEventHeader*)ioman->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(ioman->GetObject("EventHeader."));
     if (fEventHeader == nullptr)
       {
         throw std::runtime_error("R3BNeulandOnlineSpectra: No R3BEventHeader");

--- a/neuland/preexp/R3BNeulandCheckMapping.cxx
+++ b/neuland/preexp/R3BNeulandCheckMapping.cxx
@@ -52,7 +52,7 @@ InitStatus R3BNeulandCheckMapping::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rm->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("EventHeader."));
 
     fMapped = (TClonesArray*)rm->GetObject("NeulandMappedData");
     if (!fMapped)
@@ -219,7 +219,7 @@ void R3BNeulandCheckMapping::Exec(Option_t* option)
     for (Int_t i = 0; i < nHits; i++)
     {
 
-        R3BPaddleTamexMappedData* hit = (R3BPaddleTamexMappedData*)fMapped->At(i);
+        R3BPaddleTamexMappedData* hit = dynamic_cast<R3BPaddleTamexMappedData*>(fMapped->At(i));
 
         if (!hit)
             continue; // should not happen

--- a/neuland/preexp/R3BNeulandGainMatching.cxx
+++ b/neuland/preexp/R3BNeulandGainMatching.cxx
@@ -64,7 +64,7 @@ InitStatus R3BNeulandGainMatching::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rm->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("EventHeader."));
     if (!header)
     {
         return kFATAL;
@@ -169,7 +169,7 @@ void R3BNeulandGainMatching::Exec(Option_t* option)
     for (Int_t i = 0; i < nHits; i++)
     {
 
-        R3BNeulandCalData* hit = (R3BNeulandCalData*)fPmt->At(i);
+        R3BNeulandCalData* hit = dynamic_cast<R3BNeulandCalData*>(fPmt->At(i));
 
         if (!hit)
             continue; // should not happen

--- a/neuland/preexp/R3BNeulandTimeRes.cxx
+++ b/neuland/preexp/R3BNeulandTimeRes.cxx
@@ -50,7 +50,7 @@ InitStatus R3BNeulandTimeRes::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rm->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("EventHeader."));
     if (!header)
     {
         return kFATAL;
@@ -128,7 +128,7 @@ void R3BNeulandTimeRes::Exec(Option_t* option)
     for (Int_t i = 0; i < nHits; i++)
     {
 
-        R3BNeulandCalData* hit = (R3BNeulandCalData*)fPmt->At(i);
+        R3BNeulandCalData* hit = dynamic_cast<R3BNeulandCalData*>(fPmt->At(i));
 
         if (!hit)
             continue; // should not happen

--- a/neuland/reconstruction/R3BNeulandNeutronReconstructionMon.cxx
+++ b/neuland/reconstruction/R3BNeulandNeutronReconstructionMon.cxx
@@ -179,7 +179,7 @@ void R3BNeulandNeutronReconstructionMon::Exec(Option_t*)
     neutrons.reserve(nReconstructedNeutrons);
     for (Int_t i = 0; i < nReconstructedNeutrons; i++)
     {
-        neutrons.push_back(*((R3BNeulandNeutron*)fReconstructedNeutrons->At(i)));
+        neutrons.push_back(*(dynamic_cast<R3BNeulandNeutron*>(fReconstructedNeutrons->At(i))));
     }
 
     const Int_t nNPNIPS = fPrimaryNeutronInteractionPoints->GetEntries();
@@ -187,7 +187,7 @@ void R3BNeulandNeutronReconstructionMon::Exec(Option_t*)
     npnips.reserve(nReconstructedNeutrons);
     for (Int_t i = 0; i < nNPNIPS; i++)
     {
-        npnips.push_back(*((R3BNeulandPoint*)fPrimaryNeutronInteractionPoints->At(i)));
+        npnips.push_back(*(dynamic_cast<R3BNeulandPoint*>(fPrimaryNeutronInteractionPoints->At(i))));
     }
     fhCountN->Fill(nReconstructedNeutrons);
     fhCountNdiff->Fill((Int_t)nNPNIPS - (Int_t)nReconstructedNeutrons);
@@ -252,7 +252,7 @@ void R3BNeulandNeutronReconstructionMon::Exec(Option_t*)
         for (const auto& npnip : npnips)
         {
             // Workaround mom = 0
-            R3BMCTrack* MCTrack = (R3BMCTrack*)fMCTracks->At(npnip.GetTrackID());
+            R3BMCTrack* MCTrack = dynamic_cast<R3BMCTrack*>(fMCTracks->At(npnip.GetTrackID()));
             p4_npnips += TLorentzVector(MCTrack->GetPx() * 1000.,
                                         MCTrack->GetPy() * 1000.,
                                         MCTrack->GetPz() * 1000.,
@@ -264,7 +264,7 @@ void R3BNeulandNeutronReconstructionMon::Exec(Option_t*)
         const Int_t nMCTracks = fMCTracks->GetEntries();
         for (Int_t i = 0; i < nMCTracks; i++)
         {
-            MCTrack = (R3BMCTrack*)fMCTracks->At(i);
+            MCTrack = dynamic_cast<R3BMCTrack*>(fMCTracks->At(i));
             // We are only interested in primary particles, these should come first,
             // thus we can stop once the Mother Id != -1
             if (MCTrack->GetMotherId() != -1)

--- a/neuland/reconstruction/multiplicity/R3BNeulandMultiplicityBayes.cxx
+++ b/neuland/reconstruction/multiplicity/R3BNeulandMultiplicityBayes.cxx
@@ -43,7 +43,7 @@ void R3BNeulandMultiplicityBayes::SetParContainers()
         return;
     }
 
-    fPar = (R3BNeulandMultiplicityBayesPar*)rtdb->getContainer("R3BNeulandMultiplicityBayesPar");
+    fPar = dynamic_cast<R3BNeulandMultiplicityBayesPar*>(rtdb->getContainer("R3BNeulandMultiplicityBayesPar"));
     if (fPar == nullptr)
     {
         LOG(FATAL) << "R3BNeulandMultiplicityBayes::SetParContainers: No NeulandMultiplicityBayesPar!";

--- a/neuland/reconstruction/multiplicity/R3BNeulandMultiplicityBayesTrain.cxx
+++ b/neuland/reconstruction/multiplicity/R3BNeulandMultiplicityBayesTrain.cxx
@@ -33,7 +33,7 @@ void R3BNeulandMultiplicityBayesTrain::SetParContainers()
         return;
     }
 
-    fPar = (R3BNeulandMultiplicityBayesPar*)rtdb->getContainer("R3BNeulandMultiplicityBayesPar");
+    fPar = dynamic_cast<R3BNeulandMultiplicityBayesPar*>(rtdb->getContainer("R3BNeulandMultiplicityBayesPar"));
     if (fPar == nullptr)
     {
         LOG(FATAL) << "R3BNeulandMultiplicityBayesTrain::Init: No R3BNeulandMultiplicityBayesPar!";

--- a/neuland/reconstruction/multiplicity/R3BNeulandMultiplicityCalorimetric.cxx
+++ b/neuland/reconstruction/multiplicity/R3BNeulandMultiplicityCalorimetric.cxx
@@ -38,7 +38,7 @@ InitStatus R3BNeulandMultiplicityCalorimetric::Init()
         LOG(FATAL) << "R3BNeulandMultiplicityCalorimetric::Init: No FairRuntimeDb!";
         return kFATAL;
     }
-    fPar = (R3BNeulandMultiplicityCalorimetricPar*)rtdb->getContainer("R3BNeulandMultiplicityCalorimetricPar");
+    fPar = dynamic_cast<R3BNeulandMultiplicityCalorimetricPar*>(rtdb->getContainer("R3BNeulandMultiplicityCalorimetricPar"));
     if (fPar == nullptr)
     {
         LOG(FATAL) << "R3BNeulandMultiplicityCalorimetric::Init: No R3BNeulandMultiplicityCalorimetricPar!";

--- a/neuland/reconstruction/multiplicity/R3BNeulandMultiplicityCalorimetricTrain.cxx
+++ b/neuland/reconstruction/multiplicity/R3BNeulandMultiplicityCalorimetricTrain.cxx
@@ -70,7 +70,7 @@ InitStatus R3BNeulandMultiplicityCalorimetricTrain::Init()
         LOG(FATAL) << "R3BNeulandMultiplicityCalorimetricTrain::Init: No FairRuntimeDb!";
         return kFATAL;
     }
-    fPar = (R3BNeulandMultiplicityCalorimetricPar*)rtdb->getContainer("R3BNeulandMultiplicityCalorimetricPar");
+    fPar = dynamic_cast<R3BNeulandMultiplicityCalorimetricPar*>(rtdb->getContainer("R3BNeulandMultiplicityCalorimetricPar"));
     if (fPar == nullptr)
     {
         LOG(FATAL) << "R3BNeulandMultiplicityCalorimetricTrain::Init: No R3BNeulandMultiplicityCalorimetricPar!";

--- a/neuland/reconstruction/neutrons/R3BNeulandNeutronsKeras.cxx
+++ b/neuland/reconstruction/neutrons/R3BNeulandNeutronsKeras.cxx
@@ -94,7 +94,7 @@ void R3BNeulandNeutronsKeras::Exec(Option_t*)
     cwps.reserve(nClusters);
     for (int i = 0; i < nClusters; i++)
     {
-        cwps.emplace_back(ClusterWithProba{ (R3BNeulandCluster*)fClusters->At(i),
+        cwps.emplace_back(ClusterWithProba{  dynamic_cast<R3BNeulandCluster*>(fClusters->At(i)),
                                             (Double_t)TPython::Eval(TString::Format("keras_results[%d]", i)) });
     }
 

--- a/neuland/reconstruction/neutrons/R3BNeulandNeutronsScikit.cxx
+++ b/neuland/reconstruction/neutrons/R3BNeulandNeutronsScikit.cxx
@@ -103,7 +103,7 @@ void R3BNeulandNeutronsScikit::Exec(Option_t*)
     cwps.reserve(nClusters);
     for (int i = 0; i < nClusters; i++)
     {
-        cwps.emplace_back(ClusterWithProba{ (R3BNeulandCluster*)fClusters->At(i),
+        cwps.emplace_back(ClusterWithProba{  dynamic_cast<R3BNeulandCluster*>(fClusters->At(i)),
                                             (Double_t)TPython::Eval(TString::Format("results[%d]", i)) });
     }
 

--- a/neuland/simulation/R3BNeuland.cxx
+++ b/neuland/simulation/R3BNeuland.cxx
@@ -149,7 +149,7 @@ Bool_t R3BNeuland::ProcessHits(FairVolume*)
                                                       fLightYield);
 
         // Increment number of LandPoints for this track
-        auto stack = (R3BStack*)gMC->GetStack();
+        auto stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kNEULAND);
         ResetValues();
     }
@@ -208,7 +208,7 @@ void R3BNeuland::ResetValues()
 void R3BNeuland::WriteParameterFile()
 {
     FairRuntimeDb* rtdb = FairRun::Instance()->GetRuntimeDb();
-    fNeulandGeoPar = (R3BNeulandGeoPar*)rtdb->getContainer("R3BNeulandGeoPar");
+    fNeulandGeoPar = dynamic_cast<R3BNeulandGeoPar*>(rtdb->getContainer("R3BNeulandGeoPar"));
 
     // Really bad way to find the Neuland *node* (not the volume!)
     TGeoNode* geoNodeNeuland = nullptr;

--- a/neuland/test/calibration/testNeulandQcal.C
+++ b/neuland/test/calibration/testNeulandQcal.C
@@ -53,7 +53,7 @@ void testNeulandQcal()
     cout << endl << endl;
     cout << "Real time " << rtime << " s, CPU time " << ctime << "s" << endl << endl;
 
-    R3BNeulandQCalPar* par = (R3BNeulandQCalPar*)rtdb->getContainer("NeulandQCalPar");
+    R3BNeulandQCalPar* par = dynamic_cast<R3BNeulandQCalPar*>(rtdb->getContainer("NeulandQCalPar"));
     Bool_t failed = false;
 
     for (Int_t i = 0; i < 100; i++)

--- a/neuland/unpack/R3BNeulandTcal.cxx
+++ b/neuland/unpack/R3BNeulandTcal.cxx
@@ -82,7 +82,7 @@ InitStatus R3BNeulandTcal::Init()
         LOG(fatal) << "FairRootManager not found";
     }
     /*
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
         if (NULL == header)
         {
             FairLogger::GetLogger()->Fatal(MESSAGE_ORIGIN, "Branch R3BEventHeader not found");
@@ -103,7 +103,7 @@ void R3BNeulandTcal::SetParContainers()
 {
     FairRunAna* ana = FairRunAna::Instance();
     FairRuntimeDb* rtdb = ana->GetRuntimeDb();
-    fTcalPar = (R3BTCalPar*)(rtdb->getContainer("LandTCalPar"));
+    fTcalPar = dynamic_cast<R3BTCalPar*>((rtdb->getContainer("LandTCalPar")));
 }
 
 InitStatus R3BNeulandTcal::ReInit()
@@ -141,7 +141,7 @@ void R3BNeulandTcal::Exec(Option_t*)
 
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        hit = (R3BPaddleTamexMappedData*)fMappedHit->At(ihit);
+        hit = dynamic_cast<R3BPaddleTamexMappedData*>(fMappedHit->At(ihit));
         if (NULL == hit)
         {
             continue;

--- a/neuland/unpack/R3BNeulandTcalFill.cxx
+++ b/neuland/unpack/R3BNeulandTcalFill.cxx
@@ -76,7 +76,7 @@ InitStatus R3BNeulandTcalFill::Init()
     {
         return kFATAL;
     }
-    header = (R3BEventHeader*)rm->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("EventHeader."));
     /*   if (!header)
        {
            return kFATAL;
@@ -87,7 +87,7 @@ InitStatus R3BNeulandTcalFill::Init()
         return kFATAL;
     }
 
-    fCal_Par = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("LandTCalPar");
+    fCal_Par = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("LandTCalPar"));
     fCal_Par->setChanged();
 
     fEngine = new R3BTCalEngine(fCal_Par, fMinStats);
@@ -122,7 +122,7 @@ void R3BNeulandTcalFill::Exec(Option_t*)
     // Loop over mapped hits
     for (Int_t i = 0; i < nHits; i++)
     {
-        hit = (R3BPaddleTamexMappedData*)fHits->At(i);
+        hit = dynamic_cast<R3BPaddleTamexMappedData*>(fHits->At(i));
         if (!hit)
         {
             continue;

--- a/passive/R3BCave.cxx
+++ b/passive/R3BCave.cxx
@@ -70,7 +70,7 @@ void R3BCave::ConstructGeometry()
     FairRun* fRun = FairRun::Instance();
     FairRuntimeDb* rtdb = FairRun::Instance()->GetRuntimeDb();
 
-    R3BGeoPassivePar* par = (R3BGeoPassivePar*)(rtdb->getContainer("R3BGeoPassivePar"));
+    R3BGeoPassivePar* par = dynamic_cast<R3BGeoPassivePar*>((rtdb->getContainer("R3BGeoPassivePar")));
     TObjArray* fSensNodes = par->GetGeoSensitiveNodes();
     TObjArray* fPassNodes = par->GetGeoPassiveNodes();
 

--- a/pdc/R3BPdcCal2Hit.cxx
+++ b/pdc/R3BPdcCal2Hit.cxx
@@ -103,7 +103,7 @@ InitStatus R3BPdcCal2Hit::Init()
     pdc_trig_map_setup();
 
     /*
-        fHitPar = (R3BPdcHitPar*)FairRuntimeDb::instance()->getContainer("PdcHitPar");
+        fHitPar = dynamic_cast<R3BPdcHitPar*>(FairRuntimeDb::instance()->getContainer("PdcHitPar"));
         if (!fHitPar)
         {
             LOG(ERROR) << "Could not get access to PdcHitPar-Container.";
@@ -131,10 +131,10 @@ InitStatus R3BPdcCal2Hit::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     R3BLOG_IF(fatal, NULL == mgr, "FairRootManager not found");
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (header == nullptr)
     {
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
         R3BLOG(WARNING, "R3BEventHeader was found instead of EventHeader.");
     }
 
@@ -156,7 +156,7 @@ InitStatus R3BPdcCal2Hit::Init()
 void R3BPdcCal2Hit::SetParContainers()
 {
     /*
-        fHitPar = (R3BPdcHitPar*)FairRuntimeDb::instance()->getContainer("PdcHitPar");
+        fHitPar = dynamic_cast<R3BPdcHitPar*>(FairRuntimeDb::instance()->getContainer("PdcHitPar"));
         if (!fHitPar)
         {
             LOG(ERROR) << "Could not get access to PdcHitPar-Container.";

--- a/pdc/R3BPdcContFact.cxx
+++ b/pdc/R3BPdcContFact.cxx
@@ -103,11 +103,11 @@ void R3BPdcContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BPdcParRootFileIo* p=new R3BPdcParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BPdcParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BPdcParAsciiFileIo* p=new R3BPdcParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BPdcParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/pdc/R3BPdcMapped2Cal.cxx
+++ b/pdc/R3BPdcMapped2Cal.cxx
@@ -97,7 +97,7 @@ InitStatus R3BPdcMapped2Cal::Init()
 // Note that the container may still be empty at this point.
 void R3BPdcMapped2Cal::SetParContainers()
 {
-    fTcalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("PdcTCalPar");
+    fTcalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("PdcTCalPar"));
     if (!fTcalPar)
     {
         LOG(ERROR) << "Could not get access to PdcTCalPar-Container.";
@@ -117,7 +117,7 @@ void R3BPdcMapped2Cal::Exec(Option_t* option)
     LOG(DEBUG) << "R3BPdcMapped2Cal::Exec:fMappedItems=" << fMappedItems->GetName() << '.';
     for (auto i = 0; i < mapped_num; i++)
     {
-        auto mapped = (R3BPdcMappedData*)fMappedItems->At(i);
+        auto mapped = dynamic_cast<R3BPdcMappedData*>(fMappedItems->At(i));
         assert(mapped);
 
         auto wire = mapped->GetWireId();

--- a/pdc/R3BPdcMapped2CalPar.cxx
+++ b/pdc/R3BPdcMapped2CalPar.cxx
@@ -68,7 +68,7 @@ InitStatus R3BPdcMapped2CalPar::Init()
 
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-    fCalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("PdcTCalPar");
+    fCalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("PdcTCalPar"));
     if (!fCalPar)
     {
         LOG(ERROR) << "R3BPdcMapped2CalPar::Init() Couldn't get handle on PdcTCalPar. ";

--- a/psp/R3BPsp.cxx
+++ b/psp/R3BPsp.cxx
@@ -226,7 +226,7 @@ Bool_t R3BPsp::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of PspPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kPSP);
 
         ResetParameters();
@@ -288,7 +288,7 @@ void R3BPsp::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BPspPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BPspPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BPspPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BPspPoint(*oldpoint);

--- a/psp/R3BPspDigitizer.cxx
+++ b/psp/R3BPspDigitizer.cxx
@@ -62,7 +62,7 @@ void R3BPspDigitizer::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "SetParContainers: No runtime database";
 
-    fPspDigiPar = (R3BPspDigiPar*)(rtdb->getContainer("R3BPspDigiPar"));
+    fPspDigiPar = dynamic_cast<R3BPspDigiPar*>((rtdb->getContainer("R3BPspDigiPar")));
 
     if (fPspDigiPar)
     {
@@ -119,10 +119,10 @@ void R3BPspDigitizer::Exec(Option_t* opt)
     {
         //   cout<<"entries-Psp "<<l<<endl;
 
-        R3BPspPoint* psp_obj = (R3BPspPoint*)fPspPoints->At(l);
+        R3BPspPoint* psp_obj = dynamic_cast<R3BPspPoint*>(fPspPoints->At(l));
 
         TrackIdPsp = psp_obj->GetTrackID();
-        R3BMCTrack* aTrack = (R3BMCTrack*)fPspMCTrack->At(TrackIdPsp);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fPspMCTrack->At(TrackIdPsp));
         Int_t PID = aTrack->GetPdgCode();
         //     Int_t mother = aTrack->GetMotherId();
 

--- a/psp/R3BPspxCal2Hit.cxx
+++ b/psp/R3BPspxCal2Hit.cxx
@@ -119,7 +119,7 @@ InitStatus R3BPspxCal2Hit::Init()
     }
 
     // R3BEventHeader for trigger information, if needed!
-    fHeader = (R3BEventHeader*)fMan->GetObject("R3BEventHeader");
+    fHeader = dynamic_cast<R3BEventHeader*>(fMan->GetObject("R3BEventHeader"));
 
     const char xy[2] = { 'x', 'y' }; // orientation of detector face
     // Figure out how many detectors were registered by the reader
@@ -176,7 +176,7 @@ void R3BPspxCal2Hit::SetParContainers()
         LOG(INFO) << "R3BPspxCal2Hit::SetParContainers()";
     }
 
-    fHitPar = (R3BPspxHitPar*)rtdb->getContainer("R3BPspxHitPar");
+    fHitPar = dynamic_cast<R3BPspxHitPar*>(rtdb->getContainer("R3BPspxHitPar"));
     if (!fHitPar)
     {
         LOG(ERROR) << "R3BPspxCal2Hit::Could not get access to R3BPspxHitPar-Container.";
@@ -193,7 +193,7 @@ InitStatus R3BPspxCal2Hit::ReInit()
 {
     LOG(INFO) << " R3BPspxCal2Hit :: ReInit() ";
     /*
-        fHitPar = (R3BPspxHitPar*)FairRuntimeDb::instance()->getContainer("R3BPspxHitPar");
+        fHitPar = dynamic_cast<R3BPspxHitPar*>(FairRuntimeDb::instance()->getContainer("R3BPspxHitPar"));
 
         if (!fHitPar)
         {
@@ -224,7 +224,7 @@ void R3BPspxCal2Hit::Exec(Option_t* option)
         for (Int_t i = 0; i < nCal; i++)
         {
 
-            R3BPspxCalData* calData = (R3BPspxCalData*)fCalItems[d]->At(i); // get cal level event
+            R3BPspxCalData* calData = dynamic_cast<R3BPspxCalData*>(fCalItems[d]->At(i)); // get cal level event
 
             Float_t energy = calData->GetEnergy() * eGain[d] + eOffset[d]; // convert energy to MeV
             Float_t pos =

--- a/psp/R3BPspxMapped2Precal.cxx
+++ b/psp/R3BPspxMapped2Precal.cxx
@@ -113,7 +113,7 @@ InitStatus R3BPspxMapped2Precal::Init()
     }
 
     // R3BEventHeader for trigger information, if needed!
-    fHeader = (R3BEventHeader*)fMan->GetObject("R3BEventHeader");
+    fHeader = dynamic_cast<R3BEventHeader*>(fMan->GetObject("R3BEventHeader"));
 
     const char xy[2] = { 'x', 'y' }; // orientation of detector face
     // Figure out how many detectors were registered by the reader
@@ -174,7 +174,7 @@ void R3BPspxMapped2Precal::SetParContainers()
         LOG(INFO) << "R3BPspxMapped2Precal::SetParContainers()";
     }
 
-    fPrecalPar = (R3BPspxPrecalPar*)rtdb->getContainer("R3BPspxPrecalPar");
+    fPrecalPar = dynamic_cast<R3BPspxPrecalPar*>(rtdb->getContainer("R3BPspxPrecalPar"));
     if (!fPrecalPar)
     {
         LOG(ERROR) << "R3BPspxMapped2Precal::Could not get access to R3BPspxPrecalPar-Container.";
@@ -192,7 +192,7 @@ InitStatus R3BPspxMapped2Precal::ReInit()
 
     LOG(INFO) << "R3BPspxMapped2Precal::ReInit()";
     /*
-        fPrecalPar = (R3BPspxPrecalPar*)FairRuntimeDb::instance()->getContainer("R3BPspxPrecalPar");
+        fPrecalPar = dynamic_cast<R3BPspxPrecalPar*>(FairRuntimeDb::instance()->getContainer("R3BPspxPrecalPar"));
 
         if (!fPrecalPar)
         {
@@ -228,7 +228,7 @@ void R3BPspxMapped2Precal::Exec(Option_t* option)
         for (Int_t i = 0; i < nMapped; i++)
         {
 
-            R3BPspxMappedData* mappedData = (R3BPspxMappedData*)fMappedItems[d]->At(i);
+            R3BPspxMappedData* mappedData = dynamic_cast<R3BPspxMappedData*>(fMappedItems[d]->At(i));
 
             // get rid of error message from Febex (GSI firmware)
             if (mappedData->GetEnergy1() == 3075811 || mappedData->GetEnergy1() == 3075810)

--- a/psp/R3BPspxOnlineSpectra.cxx
+++ b/psp/R3BPspxOnlineSpectra.cxx
@@ -89,7 +89,7 @@ InitStatus R3BPspxOnlineSpectra::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     FairRunOnline* run = FairRunOnline::Instance();
     run->GetHttpServer()->Register("", this);
@@ -313,7 +313,7 @@ void R3BPspxOnlineSpectra::Exec(Option_t* option)
         fh_pspx_multiplicity[d]->Fill(nHits);
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BPspxMappedData* mappedData = (R3BPspxMappedData*)fMappedItemsPspx[d]->At(ihit);
+            R3BPspxMappedData* mappedData = dynamic_cast<R3BPspxMappedData*>(fMappedItemsPspx[d]->At(ihit));
 
             fh_pspx_strip_1[d]->Fill(mappedData->GetStrip1());
             fh_pspx_strip_2[d]->Fill(mappedData->GetStrip2());
@@ -329,8 +329,8 @@ void R3BPspxOnlineSpectra::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BPspxCalData* calData1 = (R3BPspxCalData*)fCalItemsPspx[2 * d]->At(ihit);
-            R3BPspxCalData* calData2 = (R3BPspxCalData*)fCalItemsPspx[2 * d + 1]->At(ihit);
+            R3BPspxCalData* calData1 = dynamic_cast<R3BPspxCalData*>(fCalItemsPspx[2 * d]->At(ihit));
+            R3BPspxCalData* calData2 = dynamic_cast<R3BPspxCalData*>(fCalItemsPspx[2 * d + 1]->At(ihit));
             fh_pspx_cal_strip_frontback[d]->Fill(calData1->GetStrip(), calData2->GetStrip());
             fh_pspx_cal_pos_frontback[d]->Fill(calData1->GetPos(), calData2->GetPos());
             fh_pspx_cal_energy_frontback[d]->Fill(calData1->GetEnergy(), calData2->GetEnergy());
@@ -343,7 +343,7 @@ void R3BPspxOnlineSpectra::Exec(Option_t* option)
         Int_t nHits_cal = fPrecalItemsPspx[d]->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits_cal; ihit++)
         {
-            R3BPspxPrecalData* precalData = (R3BPspxPrecalData*)fPrecalItemsPspx[d]->At(ihit);
+            R3BPspxPrecalData* precalData = dynamic_cast<R3BPspxPrecalData*>(fPrecalItemsPspx[d]->At(ihit));
             fh_pspx_cal_strip[d]->Fill(precalData->GetStrip());
         }
     }

--- a/psp/R3BPspxPrecal2Cal.cxx
+++ b/psp/R3BPspxPrecal2Cal.cxx
@@ -104,7 +104,7 @@ InitStatus R3BPspxPrecal2Cal::Init()
     }
 
     // R3BEventHeader for trigger information, if needed!
-    fHeader = (R3BEventHeader*)fMan->GetObject("R3BEventHeader");
+    fHeader = dynamic_cast<R3BEventHeader*>(fMan->GetObject("R3BEventHeader"));
 
     // Figure out how many detectors were registered by the reader
     const char xy[2] = { 'x', 'y' }; // orientation of detector face
@@ -163,7 +163,7 @@ void R3BPspxPrecal2Cal::SetParContainers()
         LOG(INFO) << "R3BPspxPrecal2Cal::SetParContainers()";
     }
 
-    fCalPar = (R3BPspxCalPar*)rtdb->getContainer("R3BPspxCalPar");
+    fCalPar = dynamic_cast<R3BPspxCalPar*>(rtdb->getContainer("R3BPspxCalPar"));
     if (!fCalPar)
     {
         LOG(ERROR) << "R3BPspxPrecal2Cal::Could not get access to R3BPspxCalPar-Container.";
@@ -181,7 +181,7 @@ InitStatus R3BPspxPrecal2Cal::ReInit()
 
     LOG(INFO) << "R3BPspxPrecal2Cal::ReInit()";
     /*
-        fCalPar = (R3BPspxCalPar*)FairRuntimeDb::instance()->getContainer("R3BPspxCalPar");
+        fCalPar = dynamic_cast<R3BPspxCalPar*>(FairRuntimeDb::instance()->getContainer("R3BPspxCalPar"));
 
         if (!fCalPar)
         {
@@ -221,7 +221,7 @@ void R3BPspxPrecal2Cal::Exec(Option_t* option)
         for (Int_t i = 0; i < nPrecal; i++)
         {
 
-            R3BPspxPrecalData* precalData = (R3BPspxPrecalData*)fPrecalItems[d]->At(i);
+            R3BPspxPrecalData* precalData = dynamic_cast<R3BPspxPrecalData*>(fPrecalItems[d]->At(i));
 
             Int_t strip = precalData->GetStrip();
             Float_t energy = (precalData->GetEnergy1() + precalData->GetEnergy2()) * gain[d][strip - 1];

--- a/r3bbase/R3BEventHeaderPropagator.cxx
+++ b/r3bbase/R3BEventHeaderPropagator.cxx
@@ -39,10 +39,10 @@ InitStatus R3BEventHeaderPropagator::Init()
 {
     LOG(INFO) << "R3BEventHeaderPropagator::Init()";
     FairRootManager* frm = FairRootManager::Instance();
-    fHeader = (R3BEventHeader*)frm->GetObject("EventHeader.");
+    fHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("EventHeader."));
     if (!fHeader)
     {
-        fHeader = (R3BEventHeader*)frm->GetObject("R3BEventHeader");
+        fHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("R3BEventHeader"));
         LOG(WARNING) << "R3BEventHeaderPropagator::Init() FairEventHeader not found";
     }
     else

--- a/r3bbase/R3BFileSource.cxx
+++ b/r3bbase/R3BFileSource.cxx
@@ -1009,8 +1009,8 @@ Bool_t R3BFileSource::SpecifyRunId()
 
 void R3BFileSource::FillEventHeader(FairEventHeader* feh)
 {
-    ((R3BEventHeader*)feh)->SetRunId(fRunId);
-    ((R3BEventHeader*)feh)->SetInputFileId(0);
+    (dynamic_cast<R3BEventHeader*>(feh)->SetRunId(fRunId));
+    (dynamic_cast<R3BEventHeader*>(feh)->SetInputFileId(0));
     return;
 }
 

--- a/r3bdata/R3BMCStack.cxx
+++ b/r3bdata/R3BMCStack.cxx
@@ -310,7 +310,7 @@ void R3BStack::UpdateTrackIndex(TRefArray* detList)
     // First update mother ID in MCTracks
     for (Int_t i = 0; i < fNTracks; i++)
     {
-        R3BMCTrack* track = (R3BMCTrack*)fTracks->At(i);
+        R3BMCTrack* track = dynamic_cast<R3BMCTrack*>(fTracks->At(i));
         Int_t iMotherOld = track->GetMotherId();
         fIndexIter = fIndexMap.find(iMotherOld);
         if (fIndexIter == fIndexMap.end())
@@ -392,7 +392,7 @@ void R3BStack::Print(Int_t iVerbose) const
         {
             char str[100];
             sprintf(str, "%d", iTrack);
-            ((R3BMCTrack*)fTracks->At(iTrack))->Print((Option_t*)str);
+            (dynamic_cast<R3BMCTrack*>(fTracks->At(iTrack))->Print((Option_t*)str));
         }
     }
 }

--- a/r3bgen/test/testR3BPhaseSpaceGeneratorIntegration.C
+++ b/r3bgen/test/testR3BPhaseSpaceGeneratorIntegration.C
@@ -43,7 +43,7 @@ void testR3BPhaseSpaceGeneratorIntegration()
 
     // Database
     auto rtdb = run.GetRuntimeDb();
-    auto fieldPar = (R3BFieldPar*)rtdb->getContainer("R3BFieldPar");
+    auto fieldPar = dynamic_cast<R3BFieldPar*>(rtdb->getContainer("R3BFieldPar"));
     fieldPar->SetParameters(magField);
     fieldPar->setChanged();
     auto parOut = new FairParRootFileIo(true);
@@ -68,7 +68,7 @@ void testR3BPhaseSpaceGeneratorIntegration()
         return;
     }
 
-    auto track = (R3BMCTrack*)mctc->At(1);
+    auto track = dynamic_cast<R3BMCTrack*>(mctc->At(1));
     if (track->GetPdgCode() != 2112 || track->GetMotherId() != -1)
     {
         cout << "Not the correct primary particle" << endl;

--- a/r3bsource/ams/R3BWhiterabbitAmsReader.cxx
+++ b/r3bsource/ams/R3BWhiterabbitAmsReader.cxx
@@ -59,11 +59,11 @@ Bool_t R3BWhiterabbitAmsReader::Init(ext_data_struct_info* a_struct_info)
 
     // Look for the R3BEventHeader
     FairRootManager* frm = FairRootManager::Instance();
-    fEventHeader = (R3BEventHeader*)frm->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("EventHeader."));
     if (!fEventHeader)
     {
         LOG(WARNING) << "R3BWhiterabbitAmsReader::Init() EventHeader. not found";
-        fEventHeader = (R3BEventHeader*)frm->GetObject("R3BEventHeader");
+        fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("R3BEventHeader"));
     }
     else
         LOG(INFO) << "R3BWhiterabbitAmsReader::Init() R3BEventHeader found";

--- a/r3bsource/base/R3BUcesbSource.cxx
+++ b/r3bsource/base/R3BUcesbSource.cxx
@@ -143,7 +143,7 @@ Bool_t R3BUcesbSource::InitUnpackers()
     /* Initialize all readers */
     for (int i = 0; i < fReaders->GetEntriesFast(); ++i)
     {
-        if (!((R3BReader*)fReaders->At(i))->Init(&fStructInfo))
+        if (!( dynamic_cast<R3BReader*>(fReaders->At(i))->Init(&fStructInfo)))
         {
             R3BLOG(fatal, "UCESB error: " << fClient.last_error());
             return kFALSE;
@@ -182,7 +182,7 @@ void R3BUcesbSource::SetParUnpackers()
 {
     for (int i = 0; i < fReaders->GetEntriesFast(); ++i)
     {
-        ((R3BReader*)fReaders->At(i))->SetParContainers();
+        (dynamic_cast<R3BReader*>(fReaders->At(i))->SetParContainers());
     }
 }
 
@@ -191,7 +191,7 @@ Bool_t R3BUcesbSource::ReInitUnpackers()
     /* Initialize all readers */
     for (int i = 0; i < fReaders->GetEntriesFast(); ++i)
     {
-        if (!((R3BReader*)fReaders->At(i))->ReInit())
+        if (!( dynamic_cast<R3BReader*>(fReaders->At(i))->ReInit()))
         {
             R3BLOG(fatal, "ReInit of a reader failed.");
             return kFALSE;
@@ -277,7 +277,7 @@ Int_t R3BUcesbSource::ReadEvent(UInt_t i)
     /* Run detector specific readers */
     for (int r = 0; r < fReaders->GetEntriesFast(); ++r)
     {
-        R3BReader* reader = (R3BReader*)fReaders->At(r);
+        R3BReader* reader = dynamic_cast<R3BReader*>(fReaders->At(r));
 
         LOG(debug1) << "  Reading reader " << r << " (" << reader->GetName() << ")";
         reader->Read();
@@ -335,7 +335,7 @@ void R3BUcesbSource::Reset()
 {
     for (int i = 0; i < fReaders->GetEntriesFast(); ++i)
     {
-        ((R3BReader*)fReaders->At(i))->Reset();
+        (dynamic_cast<R3BReader*>(fReaders->At(i))->Reset());
     }
 }
 
@@ -347,6 +347,6 @@ Bool_t R3BUcesbSource::SpecifyRunId()
 }
 
 //_____________________________________________________________________________
-void R3BUcesbSource::FillEventHeader(R3BEventHeader* feh) { ((R3BEventHeader*)feh)->SetRunId(fRunId); }
+void R3BUcesbSource::FillEventHeader(R3BEventHeader* feh) { (dynamic_cast<R3BEventHeader*>(feh)->SetRunId(fRunId)); }
 
 ClassImp(R3BUcesbSource);

--- a/r3bsource/base/R3BUnpackReader.cxx
+++ b/r3bsource/base/R3BUnpackReader.cxx
@@ -55,7 +55,7 @@ Bool_t R3BUnpackReader::Init(ext_data_struct_info* a_struct_info)
 
     // Look for the R3BEventHeader
     auto frm = FairRootManager::Instance();
-    fHeader = (R3BEventHeader*)frm->GetObject("EventHeader.");
+    fHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("EventHeader."));
     if (!fHeader)
     {
         R3BLOG(WARNING, "EventHeader. not found");

--- a/r3bsource/califa/R3BWhiterabbitCalifaReader.cxx
+++ b/r3bsource/califa/R3BWhiterabbitCalifaReader.cxx
@@ -63,11 +63,11 @@ Bool_t R3BWhiterabbitCalifaReader::Init(ext_data_struct_info* a_struct_info)
 
     // Look for the R3BEventHeader
     FairRootManager* frm = FairRootManager::Instance();
-    fEventHeader = (R3BEventHeader*)frm->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("EventHeader."));
     if (!fEventHeader)
     {
         LOG(WARNING) << "R3BWhiterabbitCalifaReader::Init() EventHeader. not found";
-        fEventHeader = (R3BEventHeader*)frm->GetObject("R3BEventHeader");
+        fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("R3BEventHeader"));
     }
     else
         LOG(INFO) << "R3BWhiterabbitCalifaReader::Init() R3BEventHeader found";

--- a/r3bsource/foot/R3BWhiterabbitFootReader.cxx
+++ b/r3bsource/foot/R3BWhiterabbitFootReader.cxx
@@ -65,11 +65,11 @@ Bool_t R3BWhiterabbitFootReader::Init(ext_data_struct_info* a_struct_info)
 
     // Look for the R3BEventHeader
     FairRootManager* frm = FairRootManager::Instance();
-    fEventHeader = (R3BEventHeader*)frm->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("EventHeader."));
     if (!fEventHeader)
     {
         R3BLOG(WARNING, "EventHeader. not found");
-        fEventHeader = (R3BEventHeader*)frm->GetObject("R3BEventHeader");
+        fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("R3BEventHeader"));
     }
     else
     {

--- a/r3bsource/los/R3BLosReader.cxx
+++ b/r3bsource/los/R3BLosReader.cxx
@@ -80,10 +80,10 @@ Bool_t R3BLosReader::Init(ext_data_struct_info* a_struct_info)
     FairRootManager* mgr = FairRootManager::Instance();
     R3BLOG_IF(FATAL, !mgr, "FairRootManager not found");
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
     {
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
         R3BLOG(WARNING, "EventHeader. not found");
     }
 
@@ -324,7 +324,7 @@ Bool_t R3BLosReader::Read()
                 Int_t n = fArray->GetEntriesFast();
                 for (Int_t k = 0; k < n; k++)
                 {
-                    R3BLosMappedData const* hit = (R3BLosMappedData*)fArray->At(k);
+                    R3BLosMappedData const* hit = dynamic_cast<R3BLosMappedData*>(fArray->At(k));
 
                     UInt_t const iTypeL = hit->GetType();
                     UInt_t const iCha = hit->GetChannel();

--- a/r3bsource/los/R3BWhiterabbitLosReader.cxx
+++ b/r3bsource/los/R3BWhiterabbitLosReader.cxx
@@ -57,10 +57,10 @@ Bool_t R3BWhiterabbitLosReader::Init(ext_data_struct_info* a_struct_info)
         return kFALSE;
     }
     FairRootManager* mgr = FairRootManager::Instance();
-    fEventHeader = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!fEventHeader)
     {
-        fEventHeader = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        fEventHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
         LOG(WARNING) << "R3BWhiterabbitLosReader::Init() EventHeader. not found";
     }
 

--- a/r3bsource/music/R3BWhiterabbitMusicReader.cxx
+++ b/r3bsource/music/R3BWhiterabbitMusicReader.cxx
@@ -57,7 +57,7 @@ Bool_t R3BWhiterabbitMusicReader::Init(ext_data_struct_info* a_struct_info)
 
     // Look for the R3BEventHeader
     FairRootManager* frm = FairRootManager::Instance();
-    fEventHeader = (R3BEventHeader*)frm->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("EventHeader."));
     if (!fEventHeader)
     {
         LOG(WARNING) << "R3BWhiterabbitMusicReader::Init() EventHeader. not found";

--- a/r3bsource/neuland/R3BWhiterabbitNeulandReader.cxx
+++ b/r3bsource/neuland/R3BWhiterabbitNeulandReader.cxx
@@ -61,11 +61,11 @@ Bool_t R3BWhiterabbitNeulandReader::Init(ext_data_struct_info* a_struct_info)
 
     // Look for the R3BEventHeader
     FairRootManager* frm = FairRootManager::Instance();
-    fEventHeader = (R3BEventHeader*)frm->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("EventHeader."));
     if (!fEventHeader)
     {
         R3BLOG(WARNING, "EventHeader. not found");
-        fEventHeader = (R3BEventHeader*)frm->GetObject("R3BEventHeader");
+        fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("R3BEventHeader"));
     }
     else
         R3BLOG(INFO, "EventHeader. found");

--- a/r3bsource/rolu/R3BRoluReader.cxx
+++ b/r3bsource/rolu/R3BRoluReader.cxx
@@ -196,7 +196,7 @@ Bool_t R3BRoluReader::Read()
                 Int_t n = fArray->GetEntriesFast();
                 for (Int_t k = 0; k < n; k++)
                 {
-                    R3BRoluMappedData const* hit = (R3BRoluMappedData*)fArray->At(k);
+                    R3BRoluMappedData const* hit = dynamic_cast<R3BRoluMappedData*>(fArray->At(k));
 
                     UInt_t const iTypeL = hit->GetType();
                     UInt_t const iCha = hit->GetChannel();

--- a/r3bsource/tofd/R3BPtofReader.cxx
+++ b/r3bsource/tofd/R3BPtofReader.cxx
@@ -243,7 +243,7 @@ Bool_t R3BPtofReader::ReadLeadingEdgeChannel(EXT_STR_h101_PTOF_onion* data,
 
     for (int k = 0; k < n; k++)
     {
-        R3BPaddleTamexMappedData* hit = (R3BPaddleTamexMappedData*)fArray->At(k);
+        R3BPaddleTamexMappedData* hit = dynamic_cast<R3BPaddleTamexMappedData*>(fArray->At(k));
         //
         // see if other PM has a hit and if leading time is within
         // coincidence window
@@ -345,7 +345,7 @@ Bool_t R3BPtofReader::ReadTrailingEdgeChannel(EXT_STR_h101_PTOF_onion* data,
         // PM1
         for (int k = 0; k < n; k++)
         {
-            R3BPaddleTamexMappedData* hit = (R3BPaddleTamexMappedData*)fArray->At(k);
+            R3BPaddleTamexMappedData* hit = dynamic_cast<R3BPaddleTamexMappedData*>(fArray->At(k));
             if (hit->GetBarId() != bar)
             {
                 continue;
@@ -370,7 +370,7 @@ Bool_t R3BPtofReader::ReadTrailingEdgeChannel(EXT_STR_h101_PTOF_onion* data,
         // PM2
         for (int k = 0; k < n; k++)
         {
-            R3BPaddleTamexMappedData* hit = (R3BPaddleTamexMappedData*)fArray->At(k);
+            R3BPaddleTamexMappedData* hit = dynamic_cast<R3BPaddleTamexMappedData*>(fArray->At(k));
             if (hit->GetBarId() != bar)
             {
                 continue;

--- a/r3bsource/trloii/R3BTrloiiTpatReader.cxx
+++ b/r3bsource/trloii/R3BTrloiiTpatReader.cxx
@@ -60,7 +60,7 @@ Bool_t R3BTrloiiTpatReader::Init(ext_data_struct_info* a_struct_info)
     }
 
     FairRootManager* frm = FairRootManager::Instance();
-    fEventHeader = (R3BEventHeader*)frm->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("EventHeader."));
     if (!fEventHeader)
     {
         R3BLOG(FATAL, "EventHeader. not found");

--- a/r3bsource/wr/R3BWhiterabbitMasterReader.cxx
+++ b/r3bsource/wr/R3BWhiterabbitMasterReader.cxx
@@ -62,11 +62,11 @@ Bool_t R3BWhiterabbitMasterReader::Init(ext_data_struct_info* a_struct_info)
 
     // Looking for the R3BEventHeader
     FairRootManager* frm = FairRootManager::Instance();
-    fEventHeader = (R3BEventHeader*)frm->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("EventHeader."));
     if (!fEventHeader)
     {
         R3BLOG(WARNING, "EventHeader. not found");
-        fEventHeader = (R3BEventHeader*)frm->GetObject("R3BEventHeader");
+        fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("R3BEventHeader"));
     }
     else
         R3BLOG(INFO, "EventHeader. found");

--- a/r3bsource/wr/R3BWhiterabbitPspReader.cxx
+++ b/r3bsource/wr/R3BWhiterabbitPspReader.cxx
@@ -61,11 +61,11 @@ Bool_t R3BWhiterabbitPspReader::Init(ext_data_struct_info* a_struct_info)
 
     // Look for the R3BEventHeader
     FairRootManager* frm = FairRootManager::Instance();
-    fEventHeader = (R3BEventHeader*)frm->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("EventHeader."));
     if (!fEventHeader)
     {
         LOG(WARNING) << "R3BWhiterabbitPspReader::Init() EventHeader. not found";
-        fEventHeader = (R3BEventHeader*)frm->GetObject("R3BEventHeader");
+        fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("R3BEventHeader"));
     }
     else
         LOG(INFO) << "R3BWhiterabbitPspReader::Init() R3BEventHeader found";

--- a/r3bsource/wr/R3BWhiterabbitReader.cxx
+++ b/r3bsource/wr/R3BWhiterabbitReader.cxx
@@ -51,11 +51,11 @@ Bool_t R3BWhiterabbitReader::Init(ext_data_struct_info* a_struct_info)
 
     // Look for the R3BEventHeader
     FairRootManager* frm = FairRootManager::Instance();
-    fEventHeader = (R3BEventHeader*)frm->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("EventHeader."));
     if (!fEventHeader)
     {
         LOG(WARNING) << "R3BWhiterabbitReader::Init() R3BEventHeader not found";
-        fEventHeader = (R3BEventHeader*)frm->GetObject("R3BEventHeader");
+        fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("R3BEventHeader"));
     }
     else
         LOG(INFO) << "R3BWhiterabbitReader::Init() R3BEventHeader found";

--- a/r3bsource/wr/R3BWhiterabbitReaderImpl.h
+++ b/r3bsource/wr/R3BWhiterabbitReaderImpl.h
@@ -39,9 +39,9 @@
         }                                                                                                           \
                                                                                                                     \
         FairRootManager* mgr = FairRootManager::Instance();                                                         \
-        fEventHeader = (R3BEventHeader*)mgr->GetObject("EventHeader.");                                             \
+        fEventHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));                                             \
         if (!fEventHeader)                                                                                          \
-            fEventHeader = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");                                       \
+            fEventHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));                                       \
                                                                                                                     \
         return kTRUE;                                                                                               \
     }                                                                                                               \

--- a/r3bsource/wr/R3BWhiterabbitS2Reader.cxx
+++ b/r3bsource/wr/R3BWhiterabbitS2Reader.cxx
@@ -59,11 +59,11 @@ Bool_t R3BWhiterabbitS2Reader::Init(ext_data_struct_info* a_struct_info)
 
     // Look for the R3BEventHeader
     FairRootManager* frm = FairRootManager::Instance();
-    fEventHeader = (R3BEventHeader*)frm->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("EventHeader."));
     if (!fEventHeader)
     {
         LOG(WARNING) << "R3BWhiterabbitS2Reader::Init() R3BEventHeader not found";
-        fEventHeader = (R3BEventHeader*)frm->GetObject("R3BEventHeader");
+        fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("R3BEventHeader"));
     }
     else
         LOG(INFO) << "R3BWhiterabbitS2Reader::Init() R3BEventHeader found";

--- a/r3bsource/wr/R3BWhiterabbitS8Reader.cxx
+++ b/r3bsource/wr/R3BWhiterabbitS8Reader.cxx
@@ -59,11 +59,11 @@ Bool_t R3BWhiterabbitS8Reader::Init(ext_data_struct_info* a_struct_info)
 
     // Look for the R3BEventHeader
     FairRootManager* frm = FairRootManager::Instance();
-    fEventHeader = (R3BEventHeader*)frm->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("EventHeader."));
     if (!fEventHeader)
     {
         LOG(WARNING) << "R3BWhiterabbitS8Reader::Init() EventHeader. not found";
-        fEventHeader = (R3BEventHeader*)frm->GetObject("R3BEventHeader");
+        fEventHeader = dynamic_cast<R3BEventHeader*>(frm->GetObject("R3BEventHeader"));
     }
     else
         LOG(INFO) << "R3BWhiterabbitS8Reader::Init() R3BEventHeader found";

--- a/rolu/R3BRoluCal2Hit.cxx
+++ b/rolu/R3BRoluCal2Hit.cxx
@@ -167,7 +167,7 @@ void R3BRoluCal2Hit::Exec(Option_t* option)
     Double_t lead_trig_ns = 0. / 0.;
     for (UInt_t j = 0; j < nTrig; ++j)
     {
-        auto cur_cal = (R3BRoluCalData*)fCalTriggerItems->At(j);
+        auto cur_cal = dynamic_cast<R3BRoluCalData*>(fCalTriggerItems->At(j));
         lead_trig_ns = cur_cal->GetTimeL_ns(0);
         // cout<<"Trigger: "<<lead_trig_ns<<endl;
     }
@@ -191,7 +191,7 @@ void R3BRoluCal2Hit::Exec(Option_t* option)
         /*
          * nParts is the number of particle passing through detector in one event
          */
-        R3BRoluCalData* calItem = (R3BRoluCalData*)fCalItems->At(iPart);
+        R3BRoluCalData* calItem = dynamic_cast<R3BRoluCalData*>(fCalItems->At(iPart));
         iDet = calItem->GetDetector();
 
         for (Int_t iCha = 0; iCha < 4; iCha++)

--- a/rolu/R3BRoluMapped2Cal.cxx
+++ b/rolu/R3BRoluMapped2Cal.cxx
@@ -92,11 +92,11 @@ InitStatus R3BRoluMapped2Cal::Init()
 
     // try to get a handle on the EventHeader. EventHeader may not be
     // present though and hence may be null. Take care when using.
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
     {
         LOG(WARNING) << "R3BRoluMapped2Cal::Init() EventHeader. not found";
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     }
     else
         LOG(INFO) << "R3BRoluMapped2Cal::Init() R3BEventHeader found";
@@ -130,7 +130,7 @@ InitStatus R3BRoluMapped2Cal::Init()
 // Note that the container may still be empty at this point.
 void R3BRoluMapped2Cal::SetParContainers()
 {
-    fTcalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("RoluTCalPar");
+    fTcalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("RoluTCalPar"));
 
     LOG(INFO) << "R3BRoluMapped2Cal::SetParContainers() ROLU TCAL PARAMETERS SET";
 
@@ -166,7 +166,7 @@ void R3BRoluMapped2Cal::Exec(Option_t* option)
         Double_t times_ns = 0. / 0.;
         Double_t times_raw_ns = 0. / 0.;
 
-        R3BRoluMappedData* hit = (R3BRoluMappedData*)fMappedItems->At(ihit);
+        R3BRoluMappedData* hit = dynamic_cast<R3BRoluMappedData*>(fMappedItems->At(ihit));
         if (!hit)
             continue;
 
@@ -231,7 +231,7 @@ void R3BRoluMapped2Cal::Exec(Option_t* option)
         int iCal;
         for (iCal = 0; iCal < fNofCalItems; iCal++)
         {
-            R3BRoluCalData* aCalItem = (R3BRoluCalData*)fCalItems->At(iCal);
+            R3BRoluCalData* aCalItem = dynamic_cast<R3BRoluCalData*>(fCalItems->At(iCal));
 
             if (aCalItem->GetDetector() != iDet)
             {

--- a/rolu/R3BRoluMapped2CalPar.cxx
+++ b/rolu/R3BRoluMapped2CalPar.cxx
@@ -85,12 +85,12 @@ InitStatus R3BRoluMapped2CalPar::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rm->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("EventHeader."));
     // may be = NULL!
     if (!header)
     {
         LOG(WARNING) << "R3BRoluMapped2CalPar::Init() EventHeader. not found";
-        header = (R3BEventHeader*)rm->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(rm->GetObject("R3BEventHeader"));
     }
     else
         LOG(INFO) << "R3BRoluMapped2CalPar::Init() R3BEventHeader found";
@@ -108,7 +108,7 @@ InitStatus R3BRoluMapped2CalPar::Init()
         LOG(WARNING) << "R3BRoluMapped2CalPar::Branch RoluMapped not found";
     }
 
-    fCal_Par = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("RoluTCalPar");
+    fCal_Par = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("RoluTCalPar"));
     fCal_Par->setChanged();
 
     if (!fNofModules)
@@ -133,7 +133,7 @@ void R3BRoluMapped2CalPar::Exec(Option_t* option)
     // Loop over mapped hits
     for (UInt_t i = 0; i < nHits; i++)
     {
-        R3BRoluMappedData* hit = (R3BRoluMappedData*)fMapped->At(i);
+        R3BRoluMappedData* hit = dynamic_cast<R3BRoluMappedData*>(fMapped->At(i));
         if (!hit)
         {
             continue; // should not happen

--- a/rpc/calibration/R3BRpcCal2Hit.cxx
+++ b/rpc/calibration/R3BRpcCal2Hit.cxx
@@ -76,14 +76,14 @@ InitStatus R3BRpcCal2Hit::Init()
         return kFATAL;
     }
 
-    fR3BEventHeader = (R3BEventHeader*)rootManager->GetObject("EventHeader.");
+    fR3BEventHeader = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("EventHeader."));
     if (!fR3BEventHeader)
     {
         LOG(ERROR) << "R3BRpcCal2HitPar::Init() EventHeader. not found";
         return kFATAL;
     }
 
-    fHitPar = (R3BRpcHitPar*)rtdb->getContainer("RpcHitPar");
+    fHitPar = dynamic_cast<R3BRpcHitPar*>(rtdb->getContainer("RpcHitPar"));
     if (!fHitPar)
     {
         LOG(ERROR) << "R3BRpcCal2Hit::Init() Couldn't get handle on RPCHitPar container";
@@ -138,7 +138,7 @@ void R3BRpcCal2Hit::Exec(Option_t* opt)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        auto map1 = (R3BRpcCalData*)(fRpcCalDataCA->At(i));
+        auto map1 = dynamic_cast<R3BRpcCalData*>((fRpcCalDataCA->At(i)));
 	iDetector = map1->GetDetId() ;
         inum = iDetector * 41 + map1->GetChannelId() -1;
 

--- a/rpc/calibration/R3BRpcCal2HitPar.cxx
+++ b/rpc/calibration/R3BRpcCal2HitPar.cxx
@@ -97,7 +97,7 @@ InitStatus R3BRpcCal2HitPar::Init()
         return kFATAL;
     }
 
-    fHitPar = (R3BRpcHitPar*)rtdb->getContainer("RpcHitPar");
+    fHitPar = dynamic_cast<R3BRpcHitPar*>(rtdb->getContainer("RpcHitPar"));
     if (!fHitPar)
 
     {
@@ -135,7 +135,7 @@ void R3BRpcCal2HitPar::Exec(Option_t* opt)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-     auto map1 = (R3BRpcCalData*)(fCalDataCA->At(i));
+     auto map1 = dynamic_cast<R3BRpcCalData*>((fCalDataCA->At(i)));
      iDetector=map1->GetDetId();
      inum = iDetector * 41 + map1->GetChannelId() -1;
 

--- a/rpc/calibration/R3BRpcMapped2PreCal.cxx
+++ b/rpc/calibration/R3BRpcMapped2PreCal.cxx
@@ -73,7 +73,7 @@ InitStatus R3BRpcMapped2PreCal::Init()
         LOG(ERROR) << "R3BRpcMapped2PreCal:: FairRuntimeDb not opened";
     }
 
-    fTCalPar = (R3BTCalPar*)rtdb->getContainer("RpcTCalPar");
+    fTCalPar = dynamic_cast<R3BTCalPar*>(rtdb->getContainer("RpcTCalPar"));
     if (!fTCalPar)
     {
         LOG(ERROR) << "R3BRpcMapped2PreCalPar::Init() Couldn't get handle on RpcTCalPar container";
@@ -145,7 +145,7 @@ void R3BRpcMapped2PreCal::Exec(Option_t* option)
     Int_t nHits = fMappedDataCA->GetEntries();
     for (Int_t i = 0; i < nHits; i++)
     {
-        auto map1 = (R3BRpcMappedData*)(fMappedDataCA->At(i));
+        auto map1 = dynamic_cast<R3BRpcMappedData*>((fMappedDataCA->At(i)));
 	
         UInt_t iDetector = map1->GetDetId();
 	if(iDetector != 2){continue;}
@@ -193,7 +193,7 @@ void R3BRpcMapped2PreCal::Exec(Option_t* option)
     for (Int_t i = 0; i < nHits; i++)
     {
 
-        auto map1 = (R3BRpcMappedData*)(fMappedDataCA->At(i));
+        auto map1 = dynamic_cast<R3BRpcMappedData*>((fMappedDataCA->At(i)));
         UInt_t iDetector = map1->GetDetId();
 
 	if(iDetector == 2){

--- a/rpc/calibration/R3BRpcMapped2PreCalPar.cxx
+++ b/rpc/calibration/R3BRpcMapped2PreCalPar.cxx
@@ -77,7 +77,7 @@ InitStatus R3BRpcMapped2PreCalPar::Init()
         return kFATAL;
     }
 
-    fTCalPar = (R3BTCalPar*)rtdb->getContainer("RpcTCalPar");
+    fTCalPar = dynamic_cast<R3BTCalPar*>(rtdb->getContainer("RpcTCalPar"));
     if (!fTCalPar)
     {
         LOG(ERROR) << "R3BRpcMapped2PreCalPar::Init() Couldn't get handle on RpcTCalPar container";
@@ -105,7 +105,7 @@ void R3BRpcMapped2PreCalPar::Exec(Option_t* opt)
     Int_t nHits = fMappedDataCA->GetEntries();
     for (Int_t i = 0; i < nHits; i++)
     {
-        auto map1 = (R3BRpcMappedData*)(fMappedDataCA->At(i));
+        auto map1 = dynamic_cast<R3BRpcMappedData*>((fMappedDataCA->At(i)));
 
         UInt_t iDetector = map1->GetDetId();
         UInt_t iStrip = map1->GetChannelId();   // now 1..41

--- a/rpc/calibration/R3BRpcPreCal2Cal.cxx
+++ b/rpc/calibration/R3BRpcPreCal2Cal.cxx
@@ -78,7 +78,7 @@ InitStatus R3BRpcPreCal2Cal::Init()
         return kFATAL;
     }
 
-    fTotCalPar = (R3BRpcTotCalPar*)rtdb->getContainer("RpcTotCalPar");
+    fTotCalPar = dynamic_cast<R3BRpcTotCalPar*>(rtdb->getContainer("RpcTotCalPar"));
     if (!fTotCalPar)
     {
         LOG(ERROR) << "R3BRpcPreCal2CalPar::Init() Couldn't get handle on RpcTotCalPar container";
@@ -115,14 +115,14 @@ void R3BRpcPreCal2Cal::Exec(Option_t* option)
     Int_t nHits = fPreCalDataCA->GetEntries();
     for (Int_t i = 0; i < nHits; i++)
     {
-     auto map1 = (R3BRpcPreCalData*)(fPreCalDataCA->At(i));
+     auto map1 = dynamic_cast<R3BRpcPreCalData*>((fPreCalDataCA->At(i)));
 
      UInt_t iDetector = map1->GetDetId();
      if(iDetector == 2){continue;}
      UInt_t inum = (iDetector * 41 + map1->GetChannelId())*2 + map1->GetSide() -2 ;
      for (Int_t ii = i+1; ii < nHits; ii++)
      {
-       auto nxt_chn = (R3BRpcPreCalData*)fPreCalDataCA->At(ii);
+       auto nxt_chn = dynamic_cast<R3BRpcPreCalData*>(fPreCalDataCA->At(ii));
        if(map1->GetChannelId() == nxt_chn->GetChannelId()
         && map1->GetSide() != nxt_chn->GetSide() ){
            UInt_t nxt_inum = (iDetector * 41 + nxt_chn->GetChannelId())*2 + nxt_chn->GetSide() -2 ;

--- a/rpc/calibration/R3BRpcPreCal2CalPar.cxx
+++ b/rpc/calibration/R3BRpcPreCal2CalPar.cxx
@@ -79,7 +79,7 @@ std::cout << "hre" << std::endl;
         return kFATAL;
     }
 
-    fTotCalPar = (R3BRpcTotCalPar*)rtdbPar->getContainer("RpcTotCalPar");
+    fTotCalPar = dynamic_cast<R3BRpcTotCalPar*>(rtdbPar->getContainer("RpcTotCalPar"));
     if (!fTotCalPar)
     {
         LOG(ERROR) << "R3BRpcPreCal2CalPar::Init() Couldn't get handle on RpcTotCalPar container";
@@ -103,7 +103,7 @@ void R3BRpcPreCal2CalPar::Exec(Option_t* opt)
  UInt_t iDetector = 0;
  for (Int_t i = 0; i < nHits; i++)
  {
-  auto map1 = (R3BRpcPreCalData*)(fPreCalDataCA->At(i));
+  auto map1 = dynamic_cast<R3BRpcPreCalData*>((fPreCalDataCA->At(i)));
   
   UInt_t inum = (iDetector * 41 + map1->GetChannelId())*2 + map1->GetSide() -2 ;
   if(map1->GetDetId() == 0){

--- a/rpc/online/R3BRpcOnlineSpectra.cxx
+++ b/rpc/online/R3BRpcOnlineSpectra.cxx
@@ -102,11 +102,11 @@ InitStatus R3BRpcOnlineSpectra::Init()
     R3BLOG_IF(FATAL, NULL == mgr, "FairRootManager not found");
 
     // Look for the R3BEventHeader
-    fEventHeader = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!fEventHeader)
     {
         R3BLOG(WARNING, "EventHeader. not found");
-        fEventHeader = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        fEventHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     }
     else
         R3BLOG(INFO,"EventHeader. found");
@@ -888,7 +888,7 @@ void R3BRpcOnlineSpectra::Exec(Option_t* option)
      /* ------------------- Map EventLoop ------------------*/
      for (Int_t ihit = 0; ihit < nMappedHits; ihit++) {
 
-            R3BRpcMappedData* hit = (R3BRpcMappedData*)fMappedDataItems->At(ihit);
+            R3BRpcMappedData* hit = dynamic_cast<R3BRpcMappedData*>(fMappedDataItems->At(ihit));
 
             if (!hit)
                 continue;
@@ -951,7 +951,7 @@ void R3BRpcOnlineSpectra::Exec(Option_t* option)
 
     for( Int_t ihit = 0; ihit < nPreCalHits; ihit++) {
 
-      R3BRpcPreCalData* hit = (R3BRpcPreCalData*)fPreCalDataItems->At(ihit);
+      R3BRpcPreCalData* hit = dynamic_cast<R3BRpcPreCalData*>(fPreCalDataItems->At(ihit));
 
       Int_t side = hit->GetSide();
 
@@ -995,7 +995,7 @@ void R3BRpcOnlineSpectra::Exec(Option_t* option)
 
     for( Int_t ihit = 0; ihit < nStripCalHits; ihit++) {
 
-     R3BRpcCalData* hit = (R3BRpcCalData*)fCalDataItems->At(ihit);
+     R3BRpcCalData* hit = dynamic_cast<R3BRpcCalData*>(fCalDataItems->At(ihit));
 
      if(hit->GetDetId()==0){
 
@@ -1022,7 +1022,7 @@ void R3BRpcOnlineSpectra::Exec(Option_t* option)
 
     for( Int_t ihit = 0; ihit < nStripHits; ihit++) {
 
-     R3BRpcHitData* hit = (R3BRpcHitData*)fHitDataItems->At(ihit);
+     R3BRpcHitData* hit = dynamic_cast<R3BRpcHitData*>(fHitDataItems->At(ihit));
 
       detId =  hit->GetDetId();
       channelId =  hit->GetChannelId();
@@ -1054,7 +1054,7 @@ void R3BRpcOnlineSpectra::Exec(Option_t* option)
 
     for( Int_t ihit = 0; ihit < nStripHits; ihit++) {
 
-     R3BRpcHitData* hit = (R3BRpcHitData*)fHitDataItems->At(ihit);
+     R3BRpcHitData* hit = dynamic_cast<R3BRpcHitData*>(fHitDataItems->At(ihit));
       detId =  hit->GetDetId();
       channelId =  hit->GetChannelId();
       pos       =  hit->GetPos();
@@ -1106,7 +1106,7 @@ void R3BRpcOnlineSpectra::Exec(Option_t* option)
 
    for( Int_t ihit = 0; ihit < nStripHits; ihit++) {
 
-    R3BRpcHitData* hit = (R3BRpcHitData*)fHitDataItems->At(ihit);
+    R3BRpcHitData* hit = dynamic_cast<R3BRpcHitData*>(fHitDataItems->At(ihit));
      detId =  hit->GetDetId();
      channelId =  hit->GetChannelId();
      pos       =  hit->GetPos();

--- a/rpc/sim/R3BRpc.cxx
+++ b/rpc/sim/R3BRpc.cxx
@@ -121,7 +121,7 @@ Bool_t R3BRpc::ProcessHits(FairVolume* vol)
                  gMC->CurrentEvent());
 
         // Increment number of RpcPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kRPC);
         ResetParameters();
     }
@@ -168,7 +168,7 @@ void R3BRpc::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BRpcPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BRpcPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BRpcPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BRpcPoint(*oldpoint);

--- a/rpc/sim/R3BRpcDigitizer.cxx
+++ b/rpc/sim/R3BRpcDigitizer.cxx
@@ -109,7 +109,7 @@ void R3BRpcDigitizer::Exec(Option_t* option)
     R3BRpcPoint** pointData = NULL;
     pointData = new R3BRpcPoint*[nHits];
     for (Int_t i = 0; i < nHits; i++)
-        pointData[i] = (R3BRpcPoint*)(fRpcPointDataCA->At(i));
+        pointData[i] = dynamic_cast<R3BRpcPoint*>(fRpcPointDataCA->At(i));
 
     Int_t channelId;
     Double_t time;
@@ -129,12 +129,12 @@ void R3BRpcDigitizer::Exec(Option_t* option)
         {
             for (Int_t j = 0; j < nCals; j++)
             {
-                if (((R3BRpcCalData*)(fRpcCalDataCA->At(j)))->GetChannelId() == channelId)
+              if ( (dynamic_cast<R3BRpcCalData*>((fRpcCalDataCA->At(j))))->GetChannelId() == channelId)
                 {
-                    ((R3BRpcCalData*)(fRpcCalDataCA->At(j)))->AddMoreEnergy(energy);
-                    if (((R3BRpcCalData*)(fRpcCalDataCA->At(j)))->GetTime() > time)
+                    dynamic_cast<R3BRpcCalData*>((fRpcCalDataCA->At(j)))->AddMoreEnergy(energy);
+                    if ( (dynamic_cast<R3BRpcCalData*>((fRpcCalDataCA->At(j))))->GetTime() > time)
                     {
-                        ((R3BRpcCalData*)(fRpcCalDataCA->At(j)))->SetTime(time);
+                        dynamic_cast<R3BRpcCalData*>((fRpcCalDataCA->At(j)))->SetTime(time);
                     }
                     existHit = 1; // to avoid the creation of a new Hit
                     break;

--- a/sci2/calib/R3BSci2Mapped2Cal.cxx
+++ b/sci2/calib/R3BSci2Mapped2Cal.cxx
@@ -86,9 +86,9 @@ InitStatus R3BSci2Mapped2Cal::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     // get access to Mapped data
     fMappedItems = (TClonesArray*)mgr->GetObject("Sci2Mapped");
@@ -109,7 +109,7 @@ InitStatus R3BSci2Mapped2Cal::Init()
 // Note that the container may still be empty at this point.
 void R3BSci2Mapped2Cal::SetParContainers()
 {
-    fTcalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("Sci2TCalPar");
+    fTcalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("Sci2TCalPar"));
     if (!fTcalPar)
     {
         LOG(FATAL) << "Could not get access to Sci2TCalPar-Container.";

--- a/sci2/calib/R3BSci2Mapped2Tcal.cxx
+++ b/sci2/calib/R3BSci2Mapped2Tcal.cxx
@@ -87,9 +87,9 @@ InitStatus R3BSci2Mapped2Tcal::Init()
     }
 
     // try to get a handle on the EventHeader.
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     // --- get access to Mapped data --- //
     fMapped = (TClonesArray*)mgr->GetObject("Sci2Mapped");
@@ -112,7 +112,7 @@ InitStatus R3BSci2Mapped2Tcal::Init()
 // Note that the container may still be empty at this point.
 void R3BSci2Mapped2Tcal::SetParContainers()
 {
-    fTcalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("Sci2TCalPar");
+    fTcalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("Sci2TCalPar"));
     if (!fTcalPar)
     {
         LOG(ERROR) << "Could not get access to Sci2TCalPar container.";

--- a/sci2/online/R3BOnlineSpectraSci2.cxx
+++ b/sci2/online/R3BOnlineSpectraSci2.cxx
@@ -65,9 +65,9 @@ InitStatus R3BOnlineSpectraSci2::Init()
     if (NULL == mgr)
         LOG(FATAL) << "R3BOnlineSpectraSci2::Init FairRootManager not found";
 
-    fEventHeader = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!fEventHeader)
-        fEventHeader = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        fEventHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     FairRunOnline* run = FairRunOnline::Instance();
     run->GetHttpServer()->Register("", this);

--- a/sci2/params/R3BSci2Mapped2CalPar.cxx
+++ b/sci2/params/R3BSci2Mapped2CalPar.cxx
@@ -99,7 +99,7 @@ InitStatus R3BSci2Mapped2CalPar::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rm->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("R3BEventHeader"));
     // may be = NULL!
 
     fMapped = (TClonesArray*)rm->GetObject("Sci2Mapped");
@@ -108,7 +108,7 @@ InitStatus R3BSci2Mapped2CalPar::Init()
         return kFATAL;
     }
 
-    fCal_Par = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("Sci2TCalPar");
+    fCal_Par = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("Sci2TCalPar"));
     fCal_Par->setChanged();
 
     if (!fNofModules)

--- a/sci8/R3BSci8Mapped2Cal.cxx
+++ b/sci8/R3BSci8Mapped2Cal.cxx
@@ -96,7 +96,7 @@ InitStatus R3BSci8Mapped2Cal::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     // get access to Mapped data
     fMappedItems = (TClonesArray*)mgr->GetObject("Sci8Mapped");
@@ -114,7 +114,7 @@ InitStatus R3BSci8Mapped2Cal::Init()
 // Note that the container may still be empty at this point.
 void R3BSci8Mapped2Cal::SetParContainers()
 {
-    fTcalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("Sci8TCalPar");
+    fTcalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("Sci8TCalPar"));
     if (!fTcalPar)
     {
         LOG(ERROR) << "Could not get access to Sci8TCalPar-Container.";

--- a/sci8/R3BSci8Mapped2CalPar.cxx
+++ b/sci8/R3BSci8Mapped2CalPar.cxx
@@ -99,7 +99,7 @@ InitStatus R3BSci8Mapped2CalPar::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rm->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("R3BEventHeader"));
     // may be = NULL!
 
     fMapped = (TClonesArray*)rm->GetObject("Sci8Mapped");
@@ -108,7 +108,7 @@ InitStatus R3BSci8Mapped2CalPar::Init()
         return kFATAL;
     }
 
-    fCal_Par = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("Sci8TCalPar");
+    fCal_Par = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("Sci8TCalPar"));
     fCal_Par->setChanged();
 
     if (!fNofModules)

--- a/sfib/R3BSfibCal2HitPar.cxx
+++ b/sfib/R3BSfibCal2HitPar.cxx
@@ -60,7 +60,7 @@ void R3BSfibHitPar::printParams()
     LOG(INFO) << " Number of HIT Parameters " << fHitParams->GetEntries();
     for (Int_t i = 0; i < fHitParams->GetEntries(); i++)
     {
-        R3BSfibHitModulePar* t_par = (R3BSfibHitModulePar*)fHitParams->At(i);
+        R3BSfibHitModulePar* t_par = dynamic_cast<R3BSfibHitModulePar*>(fHitParams->At(i));
         LOG(INFO) << "----------------------------------------------------------------------";
         if (t_par)
         {

--- a/sfib/R3BSfibHitPar.cxx
+++ b/sfib/R3BSfibHitPar.cxx
@@ -67,7 +67,7 @@ void R3BSfibHitPar::printParams()
     LOG(INFO) << " Number of HIT Parameters " << fHitParams->GetEntries();
     for (Int_t i = 0; i < fHitParams->GetEntries(); i++)
     {
-        R3BSfibHitModulePar* t_par = (R3BSfibHitModulePar*)fHitParams->At(i);
+        R3BSfibHitModulePar* t_par = dynamic_cast<R3BSfibHitModulePar*>(fHitParams->At(i));
         LOG(INFO) << "----------------------------------------------------------------------";
         if (t_par)
         {
@@ -86,7 +86,7 @@ R3BSfibHitModulePar* R3BSfibHitPar::GetModuleParAt(Int_t fiber)
         Int_t index;
         for (Int_t i = 0; i < fHitParams->GetEntries(); i++)
         {
-            par = (R3BSfibHitModulePar*)fHitParams->At(i);
+            par = dynamic_cast<R3BSfibHitModulePar*>(fHitParams->At(i));
             if (NULL == par)
             {
                 continue;
@@ -121,7 +121,7 @@ R3BSfibHitModulePar* R3BSfibHitPar::GetModuleParAt(Int_t fiber)
         return NULL;
     }
     Int_t arind = fIndexMap[index];
-    R3BSfibHitModulePar* par = (R3BSfibHitModulePar*)fHitParams->At(arind);
+    R3BSfibHitModulePar* par = dynamic_cast<R3BSfibHitModulePar*>(fHitParams->At(arind));
     return par;
 }
 

--- a/sfib/R3BSfibMapped2Cal.cxx
+++ b/sfib/R3BSfibMapped2Cal.cxx
@@ -64,7 +64,7 @@ InitStatus R3BSfibMapped2Cal::Init()
 void R3BSfibMapped2Cal::SetParContainers()
 {
     auto name = "SfibTCalPar";
-    fTCalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer(name);
+    fTCalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer(name));
     if (!fTCalPar)
     {
         LOG(ERROR) << "Could not get access to " << name << " container.";
@@ -83,7 +83,7 @@ void R3BSfibMapped2Cal::Exec(Option_t* option)
     LOG(DEBUG) << "R3BSfibMapped2Cal::Exec:fMappedItems=" << fMappedItems->GetName() << '.';
     for (auto i = 0; i < mapped_num; i++)
     {
-        auto mapped = (R3BSfibMappedData*)fMappedItems->At(i);
+        auto mapped = dynamic_cast<R3BSfibMappedData*>(fMappedItems->At(i));
         assert(mapped);
 
         auto channel = mapped->GetChannel();

--- a/sfib/R3BSfibMapped2CalPar.cxx
+++ b/sfib/R3BSfibMapped2CalPar.cxx
@@ -54,7 +54,7 @@ InitStatus R3BSfibMapped2CalPar::Init()
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakeLists.txt in the detector directory.
     auto name = "SfibTCalPar";
-    fTCalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer(name);
+    fTCalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer(name));
     if (!fTCalPar)
     {
         LOG(ERROR) << "Could not get SfibTCalPar.";
@@ -71,7 +71,7 @@ void R3BSfibMapped2CalPar::Exec(Option_t* option)
     auto mapped_num = fMapped->GetEntriesFast();
     for (auto i = 0; i < mapped_num; i++)
     {
-        auto mapped = (R3BSfibMappedData*)fMapped->At(i);
+        auto mapped = dynamic_cast<R3BSfibMappedData*>(fMapped->At(i));
         assert(mapped);
         fEngine->Fill(
             1 + mapped->IsTop(), mapped->GetChannel() * 2 - (mapped->IsLeading() ? 1 : 0), 1, mapped->GetFine());

--- a/sfib/sim/R3Bsfi.cxx
+++ b/sfib/sim/R3Bsfi.cxx
@@ -213,7 +213,7 @@ Bool_t R3Bsfi::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of sfiPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kSFI);
 
         ResetParameters();

--- a/ssd/calibration/R3BAmsMapped2StripCal.cxx
+++ b/ssd/calibration/R3BAmsMapped2StripCal.cxx
@@ -92,7 +92,7 @@ void R3BAmsMapped2StripCal::SetParContainers()
         LOG(ERROR) << "FairRuntimeDb not opened!";
     }
 
-    fCal_Par = (R3BAmsStripCalPar*)rtdb->getContainer("amsStripCalPar");
+    fCal_Par = dynamic_cast<R3BAmsStripCalPar*>(rtdb->getContainer("amsStripCalPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BAmsMapped2StripCalPar::Init() Couldn't get handle on amsStripCalPar container";
@@ -219,7 +219,7 @@ void R3BAmsMapped2StripCal::Exec(Option_t* option)
     Double_t h = 0;
     /*
     for(Int_t i = 0; i < nHits; i++) {
-      mappedData[i] = (R3BAmsMappedData*)(fAmsMappedDataCA->At(i));
+      mappedData[i] = dynamic_cast<R3BAmsMappedData*>((fAmsMappedDataCA->At(i)));
 
       detId   = mappedData[i]->GetDetectorId();
       stripId = mappedData[i]->GetStripId();
@@ -252,7 +252,7 @@ void R3BAmsMapped2StripCal::Exec(Option_t* option)
     nbadc = 0;
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BAmsMappedData*)(fAmsMappedDataCA->At(i));
+        mappedData[i] = dynamic_cast<R3BAmsMappedData*>((fAmsMappedDataCA->At(i)));
         detId = mappedData[i]->GetDetectorId();
         stripId = mappedData[i]->GetStripId();
 

--- a/ssd/calibration/R3BAmsMapped2StripCalPar.cxx
+++ b/ssd/calibration/R3BAmsMapped2StripCalPar.cxx
@@ -106,7 +106,7 @@ void R3BAmsMapped2StripCalPar::SetParContainers()
         LOG(ERROR) << "FairRuntimeDb not opened!";
     }
 
-    fMap_Par = (R3BAmsMappingPar*)rtdb->getContainer("amsMappingPar");
+    fMap_Par = dynamic_cast<R3BAmsMappingPar*>(rtdb->getContainer("amsMappingPar"));
     if (!fMap_Par)
     {
         LOG(ERROR) << "R3BAmsMapped2StripCalPar::Init() Couldn't get handle on amsMappingPar container";
@@ -153,7 +153,7 @@ InitStatus R3BAmsMapped2StripCalPar::Init()
         return kFATAL;
     }
 
-    fStrip_Par = (R3BAmsStripCalPar*)rtdb->getContainer("amsStripCalPar");
+    fStrip_Par = dynamic_cast<R3BAmsStripCalPar*>(rtdb->getContainer("amsStripCalPar"));
     if (!fStrip_Par)
     {
         LOG(ERROR) << "R3BAmsMapped2StripCalPar::Init() Couldn't get handle on amsStripCalPar container";
@@ -195,7 +195,7 @@ void R3BAmsMapped2StripCalPar::Exec(Option_t* opt)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        MapHit = (R3BAmsMappedData*)(fAmsMappedDataCA->At(i));
+        MapHit = dynamic_cast<R3BAmsMappedData*>((fAmsMappedDataCA->At(i)));
         detId = MapHit->GetDetectorId();
         stripId = MapHit->GetStripId();
 

--- a/ssd/calibration/R3BAmsStripCal2Hit.cxx
+++ b/ssd/calibration/R3BAmsStripCal2Hit.cxx
@@ -90,7 +90,7 @@ void R3BAmsStripCal2Hit::SetParContainers()
         LOG(ERROR) << "FairRuntimeDb not opened!";
     }
 
-    fMap_Par = (R3BAmsMappingPar*)rtdb->getContainer("amsMappingPar");
+    fMap_Par = dynamic_cast<R3BAmsMappingPar*>(rtdb->getContainer("amsMappingPar"));
     if (!fMap_Par)
     {
         LOG(ERROR) << "R3BAmsStripCal2Hit::Init() Couldn't get handle on amsMappingPar container";
@@ -178,7 +178,7 @@ void R3BAmsStripCal2Hit::Exec(Option_t* option)
     Double_t energy;
     for (Int_t i = 0; i < nHits; i++)
     {
-        calData[i] = (R3BAmsStripCalData*)(fAmsStripCalDataCA->At(i));
+        calData[i] = dynamic_cast<R3BAmsStripCalData*>((fAmsStripCalDataCA->At(i)));
         detId = calData[i]->GetDetId();
         sideId = calData[i]->GetSideId();
         stripId = calData[i]->GetStripId();

--- a/ssd/calibration/R3BFootMapped2StripCal.cxx
+++ b/ssd/calibration/R3BFootMapped2StripCal.cxx
@@ -70,7 +70,7 @@ void R3BFootMapped2StripCal::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(ERROR, !rtdb, "FairRuntimeDb not found");
 
-    fCal_Par = (R3BFootCalPar*)rtdb->getContainer("footCalPar");
+    fCal_Par = dynamic_cast<R3BFootCalPar*>(rtdb->getContainer("footCalPar"));
     if (!fCal_Par)
     {
         R3BLOG(ERROR, "footCalPar container not found");
@@ -184,7 +184,7 @@ void R3BFootMapped2StripCal::Exec(Option_t* option)
     // Pedestal substraction
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BFootMappedData*)(fFootMappedData->At(i));
+        mappedData[i] = dynamic_cast<R3BFootMappedData*>((fFootMappedData->At(i)));
         detId = mappedData[i]->GetDetId() - 1;
         stripId = mappedData[i]->GetStripId() - 1;
 

--- a/ssd/calibration/R3BFootStripCal2Hit.cxx
+++ b/ssd/calibration/R3BFootStripCal2Hit.cxx
@@ -91,7 +91,7 @@ void R3BFootStripCal2Hit::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(ERROR, !rtdb, "FairRuntimeDb not found");
 
-    fMap_Par = (R3BFootMappingPar*)rtdb->getContainer("footMappingPar");
+    fMap_Par = dynamic_cast<R3BFootMappingPar*>(rtdb->getContainer("footMappingPar"));
     if (!fMap_Par)
     {
         R3BLOG(ERROR, "Couldn't get handle on footMappingPar container");
@@ -219,7 +219,7 @@ void R3BFootStripCal2Hit::Exec(Option_t* option)
     // Filling vectors
     for (Int_t i = 0; i < nHits; i++)
     {
-        calData[i] = (R3BFootCalData*)(fFootCalData->At(i));
+        calData[i] = dynamic_cast<R3BFootCalData*>((fFootCalData->At(i)));
         detId = calData[i]->GetDetId() - 1;
         stripId = calData[i]->GetStripId() - 1;
         energy = calData[i]->GetEnergy();

--- a/ssd/digi/R3BAmsDigitizer.cxx
+++ b/ssd/digi/R3BAmsDigitizer.cxx
@@ -76,7 +76,7 @@ void R3BAmsDigitizer::Exec(Option_t* option)
     auto pointData = new R3BTraPoint*[nHits];
     for (Int_t i = 0; i < nHits; i++)
     {
-        pointData[i] = (R3BTraPoint*)(fPointData->At(i));
+        pointData[i] = dynamic_cast<R3BTraPoint*>((fPointData->At(i)));
 
         Int_t detid = pointData[i]->GetDetectorID();
         Int_t stripid = pointData[i]->GetDetCopyID() - 1;
@@ -94,11 +94,11 @@ void R3BAmsDigitizer::Exec(Option_t* option)
         {
             for (Int_t j = 0; j < nStripCals; j++)
             {
-                if (((R3BAmsStripCalData*)(fCalData->At(j)))->GetStripId() == stripid &&
-                    ((R3BAmsStripCalData*)(fCalData->At(j)))->GetSideId() == sideid &&
-                    ((R3BAmsStripCalData*)(fCalData->At(j)))->GetDetId() == detid)
+                if (( dynamic_cast<R3BAmsStripCalData*>((fCalData->At(j)))->GetStripId()) == stripid &&
+                    ( dynamic_cast<R3BAmsStripCalData*>((fCalData->At(j)))->GetSideId()) == sideid &&
+                    ( dynamic_cast<R3BAmsStripCalData*>((fCalData->At(j)))->GetDetId() == detid))
                 {
-                    ((R3BAmsStripCalData*)(fCalData->At(j)))->AddMoreEnergy(energy);
+                    (dynamic_cast<R3BAmsStripCalData*>((fCalData->At(j)))->AddMoreEnergy(energy));
                     existHit = 1; // to avoid the creation of a new StripCal Hit
                     break;
                 }

--- a/ssd/digi/R3BTarget2pDigitizer.cxx
+++ b/ssd/digi/R3BTarget2pDigitizer.cxx
@@ -170,7 +170,7 @@ void R3BTarget2pDigitizer::Exec(Option_t* opt)
         // if (l<4){
         //   LOG(INFO)<<"entries "<<l;
         //}
-        R3BMCTrack* aTrack = (R3BMCTrack*)fMCTrack->At(l);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fMCTrack->At(l));
 
         Int_t PID = aTrack->GetPdgCode();
         Int_t mother = aTrack->GetMotherId();
@@ -286,12 +286,12 @@ void R3BTarget2pDigitizer::Exec(Option_t* opt)
     {
         //   LOG(INFO)<<"entries "<<l;
 
-        R3BTraPoint* Tra_obj = (R3BTraPoint*)fTarget2pPoints->At(l);
+        R3BTraPoint* Tra_obj = dynamic_cast<R3BTraPoint*>(fTarget2pPoints->At(l));
 
         //     Int_t DetID = Tra_obj->GetDetectorID();
 
         TrackIdTra = Tra_obj->GetTrackID();
-        R3BMCTrack* aTrack = (R3BMCTrack*)fTarget2pMCTrack->At(TrackIdTra);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fTarget2pMCTrack->At(TrackIdTra));
         Int_t PID = aTrack->GetPdgCode();
         Int_t mother = aTrack->GetMotherId();
 

--- a/ssd/digi/R3BTargetDigitizer.cxx
+++ b/ssd/digi/R3BTargetDigitizer.cxx
@@ -71,7 +71,7 @@ void R3BTargetDigitizer::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "SetParContainers: No runtime database";
 
-    fTargetDigiPar = (R3BTargetDigiPar*)(rtdb->getContainer("R3BTargetDigiPar"));
+    fTargetDigiPar = dynamic_cast<R3BTargetDigiPar*>((rtdb->getContainer("R3BTargetDigiPar")));
 
     if (fTargetDigiPar)
     {
@@ -151,7 +151,7 @@ void R3BTargetDigitizer::Exec(Option_t* opt)
     {
         //   LOG(INFO)<<"entries "<<l;
 
-        R3BMCTrack* aTrack = (R3BMCTrack*)fMCTrack->At(l);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fMCTrack->At(l));
 
         Int_t PID = aTrack->GetPdgCode();
         Int_t mother = aTrack->GetMotherId();
@@ -235,12 +235,12 @@ void R3BTargetDigitizer::Exec(Option_t* opt)
     {
         //   LOG(INFO)<<"entries "<<l;
 
-        R3BTraPoint* Tra_obj = (R3BTraPoint*)fTargetPoints->At(l);
+        R3BTraPoint* Tra_obj = dynamic_cast<R3BTraPoint*>(fTargetPoints->At(l));
 
         //     Int_t DetID = Tra_obj->GetDetectorID();
 
         TrackIdTra = Tra_obj->GetTrackID();
-        R3BMCTrack* aTrack = (R3BMCTrack*)fTargetMCTrack->At(TrackIdTra);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fTargetMCTrack->At(TrackIdTra));
         Int_t PID = aTrack->GetPdgCode();
         Int_t mother = aTrack->GetMotherId();
 

--- a/ssd/digi/R3BTra2pDigitizer.cxx
+++ b/ssd/digi/R3BTra2pDigitizer.cxx
@@ -160,7 +160,7 @@ void R3BTra2pDigitizer::Exec(Option_t* opt)
     {
         //   LOG(INFO)<<"entries "<<l;
 
-        R3BTraPoint* Tra2p_obj = (R3BTraPoint*)fTra2pPoints->At(l);
+        R3BTraPoint* Tra2p_obj = dynamic_cast<R3BTraPoint*>(fTra2pPoints->At(l));
 
         //     Int_t DetID = Tra2p_obj->GetDetectorID();
         Double_t fX_In = Tra2p_obj->GetXIn();
@@ -170,7 +170,7 @@ void R3BTra2pDigitizer::Exec(Option_t* opt)
         Double_t fY_Out = Tra2p_obj->GetYOut();
         Double_t fZ_Out = Tra2p_obj->GetZOut();
         TrackIdTra = Tra2p_obj->GetTrackID();
-        R3BMCTrack* aTrack = (R3BMCTrack*)fTra2pMCTrack->At(TrackIdTra);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fTra2pMCTrack->At(TrackIdTra));
         Int_t PID = aTrack->GetPdgCode();
         Int_t mother = aTrack->GetMotherId();
 

--- a/ssd/digi/R3BTraDigitizer.cxx
+++ b/ssd/digi/R3BTraDigitizer.cxx
@@ -61,7 +61,7 @@ void R3BTraDigitizer::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "SetParContainers: No runtime database";
 
-    fTraDigiPar = (R3BTraDigiPar*)(rtdb->getContainer("R3BTraDigiPar"));
+    fTraDigiPar = dynamic_cast<R3BTraDigiPar*>((rtdb->getContainer("R3BTraDigiPar")));
 
     if (fTraDigiPar)
     {
@@ -159,7 +159,7 @@ void R3BTraDigitizer::Exec(Option_t* opt)
     {
         //   LOG(INFO)<<"entries "<<l;
 
-        R3BTraPoint* Tra_obj = (R3BTraPoint*)fTraPoints->At(l);
+        R3BTraPoint* Tra_obj = dynamic_cast<R3BTraPoint*>(fTraPoints->At(l));
 
         //     Int_t DetID = Tra_obj->GetDetectorID();
         Double_t fX_In = Tra_obj->GetXIn();
@@ -169,7 +169,7 @@ void R3BTraDigitizer::Exec(Option_t* opt)
         Double_t fY_Out = Tra_obj->GetYOut();
         Double_t fZ_Out = Tra_obj->GetZOut();
         TrackIdTra = Tra_obj->GetTrackID();
-        R3BMCTrack* aTrack = (R3BMCTrack*)fTraMCTrack->At(TrackIdTra);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fTraMCTrack->At(TrackIdTra));
         Int_t PID = aTrack->GetPdgCode();
         Int_t mother = aTrack->GetMotherId();
 

--- a/ssd/digi/R3BTraFraDigitizer.cxx
+++ b/ssd/digi/R3BTraFraDigitizer.cxx
@@ -61,7 +61,7 @@ void R3BTraFraDigitizer::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "SetParContainers: No runtime database";
 
-    fTraFraDigiPar = (R3BTraFraDigiPar*)(rtdb->getContainer("R3BTraFraDigiPar"));
+    fTraFraDigiPar = dynamic_cast<R3BTraFraDigiPar*>((rtdb->getContainer("R3BTraFraDigiPar")));
 
     if (fTraFraDigiPar)
     {
@@ -136,7 +136,7 @@ void R3BTraFraDigitizer::Exec(Option_t* opt)
     {
         //   LOG(INFO)<<"entries "<<l;
 
-        R3BTraPoint* TraFra_obj = (R3BTraPoint*)fTraFraPoints->At(l);
+        R3BTraPoint* TraFra_obj = dynamic_cast<R3BTraPoint*>(fTraFraPoints->At(l));
 
         // Int_t DetID = TraFra_obj->GetDetectorID();
         Double_t fX_In = TraFra_obj->GetXIn();
@@ -146,7 +146,7 @@ void R3BTraFraDigitizer::Exec(Option_t* opt)
         Double_t fY_Out = TraFra_obj->GetYOut();
         Double_t fZ_Out = TraFra_obj->GetZOut();
         TrackIdTra = TraFra_obj->GetTrackID();
-        R3BMCTrack* aTrack = (R3BMCTrack*)fTraFraMCTrack->At(TrackIdTra);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fTraFraMCTrack->At(TrackIdTra));
         Int_t PID = aTrack->GetPdgCode();
         Int_t mother = aTrack->GetMotherId();
 

--- a/ssd/online/R3BAmsCalifaCorrelatedOnlineSpectra.cxx
+++ b/ssd/online/R3BAmsCalifaCorrelatedOnlineSpectra.cxx
@@ -93,7 +93,7 @@ InitStatus R3BAmsCalifaCorrelatedOnlineSpectra::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     if (NULL == mgr)
         LOG(fatal) << "R3BAmsCalifaCorrelatedOnlineSpectra::Init FairRootManager not found";
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     FairRunOnline* run = FairRunOnline::Instance();
     run->GetHttpServer()->Register("", this);
@@ -376,7 +376,7 @@ void R3BAmsCalifaCorrelatedOnlineSpectra::Exec(Option_t* option)
             /*
              * nPart is the number of particle passing through LOS detector in one event
              */
-            R3BLosCalData* calData = (R3BLosCalData*)fCalItemsLos->At(iPart);
+            R3BLosCalData* calData = dynamic_cast<R3BLosCalData*>(fCalItemsLos->At(iPart));
             iDet = calData->GetDetector();
 
             // lt=0, l=1,lb=2,b=3,rb=4,r=5,rt=6,t=7
@@ -579,7 +579,7 @@ void R3BAmsCalifaCorrelatedOnlineSpectra::Exec(Option_t* option)
         Double_t theta = 0., phi = 0.;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BAmsHitData* hit = (R3BAmsHitData*)fHitItemsAms->At(ihit);
+            R3BAmsHitData* hit = dynamic_cast<R3BAmsHitData*>(fHitItemsAms->At(ihit));
             if (!hit)
                 continue;
             if (hit->GetEnergyS() < 80 || hit->GetEnergyK() < 80 || hit->GetEnergyS() > 8500 ||
@@ -640,7 +640,7 @@ void R3BAmsCalifaCorrelatedOnlineSpectra::Exec(Option_t* option)
         Double_t theta = 0., phi = 0.;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BCalifaHitData* hit = (R3BCalifaHitData*)fHitItemsCalifa->At(ihit);
+            R3BCalifaHitData* hit = dynamic_cast<R3BCalifaHitData*>(fHitItemsCalifa->At(ihit));
             if (!hit)
                 continue;
             theta = hit->GetTheta() / TMath::Pi() * 180.;

--- a/ssd/online/R3BAmsOnlineSpectra.cxx
+++ b/ssd/online/R3BAmsOnlineSpectra.cxx
@@ -95,7 +95,7 @@ void R3BAmsOnlineSpectra::SetParContainers()
         LOG(ERROR) << "FairRuntimeDb not opened!";
     }
 
-    fMap_Par = (R3BAmsMappingPar*)rtdb->getContainer("amsMappingPar");
+    fMap_Par = dynamic_cast<R3BAmsMappingPar*>(rtdb->getContainer("amsMappingPar"));
     if (!fMap_Par)
     {
         LOG(ERROR) << "R3BAmsOnlineSpectra::Couldn't get handle on amsMappingPar container";
@@ -551,7 +551,7 @@ void R3BAmsOnlineSpectra::Exec(Option_t* option)
         // std::cout << "hit:"<<nHits << std::endl;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BAmsMappedData* hit = (R3BAmsMappedData*)fMappedItemsAms->At(ihit);
+            R3BAmsMappedData* hit = dynamic_cast<R3BAmsMappedData*>(fMappedItemsAms->At(ihit));
             if (!hit)
                 continue;
             fh_Ams_energy_allStrips[hit->GetDetectorId()]->Fill(hit->GetStripId(), hit->GetEnergy());
@@ -565,7 +565,7 @@ void R3BAmsOnlineSpectra::Exec(Option_t* option)
         // std::cout << "hit:"<<nHits << std::endl;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BAmsStripCalData* hit = (R3BAmsStripCalData*)fCalItemsAms->At(ihit);
+            R3BAmsStripCalData* hit = dynamic_cast<R3BAmsStripCalData*>(fCalItemsAms->At(ihit));
             if (!hit)
                 continue;
             fh_Ams_energy_allCalStrips[hit->GetDetId() * 2 + hit->GetSideId()]->Fill(hit->GetStripId(),
@@ -596,7 +596,7 @@ void R3BAmsOnlineSpectra::Exec(Option_t* option)
         // std::cout << nHits << std::endl;
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BAmsHitData* hit = (R3BAmsHitData*)fHitItemsAms->At(ihit);
+            R3BAmsHitData* hit = dynamic_cast<R3BAmsHitData*>(fHitItemsAms->At(ihit));
             if (!hit)
                 continue;
             DetId = hit->GetDetId();

--- a/ssd/online/R3BFootOnlineSpectra.cxx
+++ b/ssd/online/R3BFootOnlineSpectra.cxx
@@ -77,11 +77,11 @@ InitStatus R3BFootOnlineSpectra::Init()
     if (NULL == mgr)
         LOG(FATAL) << "R3BFootOnlineSpectra::FairRootManager not found";
     // Look for the R3BEventHeader
-    fEventHeader = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    fEventHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!fEventHeader)
     {
         LOG(WARNING) << "R3BFootOnlineSpectra::Init() EventHeader. not found";
-        fEventHeader = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        fEventHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     }
     else
         LOG(INFO) << "R3BFootOnlineSpectra::Init() EventHeader. found";
@@ -338,7 +338,7 @@ void R3BFootOnlineSpectra::Exec(Option_t* option)
         auto nHits = fMappedItems->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BFootMappedData* hit = (R3BFootMappedData*)fMappedItems->At(ihit);
+            R3BFootMappedData* hit = dynamic_cast<R3BFootMappedData*>(fMappedItems->At(ihit));
             if (!hit)
                 continue;
             fh2_EnergyVsStrip[hit->GetDetId() - 1]->Fill(hit->GetStripId(), hit->GetEnergy());
@@ -351,7 +351,7 @@ void R3BFootOnlineSpectra::Exec(Option_t* option)
         auto nHits = fCalItems->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BFootCalData* hit = (R3BFootCalData*)fCalItems->At(ihit);
+            R3BFootCalData* hit = dynamic_cast<R3BFootCalData*>(fCalItems->At(ihit));
             if (!hit)
                 continue;
             fh2_EnergyVsStrip_cal[hit->GetDetId() - 1]->Fill(hit->GetStripId(), hit->GetEnergy());
@@ -364,7 +364,7 @@ void R3BFootOnlineSpectra::Exec(Option_t* option)
         auto nHits = fHitItems->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BFootHitData* hit = (R3BFootHitData*)fHitItems->At(ihit);
+            R3BFootHitData* hit = dynamic_cast<R3BFootHitData*>(fHitItems->At(ihit));
             if (!hit)
                 continue;
             fh1_pos[hit->GetDetId() - 1]->Fill(hit->GetPos());
@@ -375,8 +375,8 @@ void R3BFootOnlineSpectra::Exec(Option_t* option)
         {
             for (Int_t jhit = ihit + 1; jhit < nHits; jhit++)
             {
-                R3BFootHitData* hitI = (R3BFootHitData*)fHitItems->At(ihit);
-                R3BFootHitData* hitJ = (R3BFootHitData*)fHitItems->At(jhit);
+                R3BFootHitData* hitI = dynamic_cast<R3BFootHitData*>(fHitItems->At(ihit));
+                R3BFootHitData* hitJ = dynamic_cast<R3BFootHitData*>(fHitItems->At(jhit));
                 if (!hitI)
                     continue;
                 if (!hitJ)

--- a/ssd/sim/R3BTra.cxx
+++ b/ssd/sim/R3BTra.cxx
@@ -469,7 +469,7 @@ Bool_t R3BTra::ProcessHits(FairVolume* vol)
                gMC->TrackPid());
 
         // Increment number of TraPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kTRA);
 
         ResetParameters();
@@ -531,7 +531,7 @@ void R3BTra::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BTraPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BTraPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BTraPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BTraPoint(*oldpoint);

--- a/ssd/sim/R3BTraHitFinder.cxx
+++ b/ssd/sim/R3BTraHitFinder.cxx
@@ -587,7 +587,7 @@ void R3BTraHitFinder::Exec(Option_t* opt)
         for (Int_t i = 0; i < traHitsPerEvent; i++)
         {
             traHit[i] = new R3BTraPoint;
-            traHit[i] = (R3BTraPoint*)fTrackerHitCA->At(i);
+            traHit[i] = dynamic_cast<R3BTraPoint*>(fTrackerHitCA->At(i));
             Energy = ExpResSmearing(traHit[i]->GetEnergyLoss());
             // Energy = traHit[i]->GetEnergyLoss();
             Detector = traHit[i]->GetDetCopyID();

--- a/ssd/sim/R3BTra_Si_Lampshade.cxx
+++ b/ssd/sim/R3BTra_Si_Lampshade.cxx
@@ -206,7 +206,7 @@ Bool_t R3BTra::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of TraPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kTRA);
 
         ResetParameters();
@@ -302,7 +302,7 @@ void R3BTra::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BTraPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BTraPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BTraPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BTraPoint(*oldpoint);
@@ -1622,7 +1622,7 @@ void R3BTra::ConstructGeometry() {
   // store geo parameter
   FairRun *fRun = FairRun::Instance();
   FairRuntimeDb *rtdb= FairRun::Instance()->GetRuntimeDb();
-  R3BGeoTraPar* par=(R3BGeoTraPar*)(rtdb->getContainer("R3BGeoTraPar"));
+  R3BGeoTraPar* par=dynamic_cast<R3BGeoTraPar*>((rtdb->getContainer("R3BGeoTraPar")));
   TObjArray *fSensNodes = par->GetGeoSensitiveNodes();
   TObjArray *fPassNodes = par->GetGeoPassiveNodes();
 

--- a/startrack/Finder/R3BSTaRTraHitFinder.cxx
+++ b/startrack/Finder/R3BSTaRTraHitFinder.cxx
@@ -1070,7 +1070,7 @@ void R3BSTaRTraHitFinder::Exec(Option_t* opt)
         for (Int_t i = 0; i < traHitsPerEvent; i++)
         {
             traHit[i] = new R3BSTaRTraPoint;
-            traHit[i] = (R3BSTaRTraPoint*)fSTaRTrackerHitCA->At(i);
+            traHit[i] = dynamic_cast<R3BSTaRTraPoint*>(fSTaRTrackerHitCA->At(i));
             Energy = ExpResSmearing(traHit[i]->GetEnergyLoss());
             // Energy = traHit[i]->GetEnergyLoss();
             Detector = traHit[i]->GetDetCopyID();

--- a/startrack/Finder/R3BSTaRTraHitFinderMarc.cxx
+++ b/startrack/Finder/R3BSTaRTraHitFinderMarc.cxx
@@ -80,7 +80,7 @@ void R3BSTaRTraHitFinder::Exec(Option_t* opt)
         for (Int_t i = 0; i < traHitsPerEvent; i++)
         {
             traHit[i] = new R3BSTaRTraPoint;
-            traHit[i] = (R3BSTaRTraPoint*)fTrackerHitCA->At(i);
+            traHit[i] = dynamic_cast<R3BSTaRTraPoint*>(fTrackerHitCA->At(i));
             energy = ExpResSmearing(traHit[i]->GetEnergyLoss());
         }
     }

--- a/startrack/Finder/R3BSTaRTraHitFinderNick.cxx
+++ b/startrack/Finder/R3BSTaRTraHitFinderNick.cxx
@@ -590,7 +590,7 @@ void R3BSTaRTraHitFinder::Exec(Option_t* opt)
         for (Int_t i = 0; i < traHitsPerEvent; i++)
         {
             traHit[i] = new R3BSTaRTraPoint;
-            traHit[i] = (R3BSTaRTraPoint*)fTrackerHitCA->At(i);
+            traHit[i] = dynamic_cast<R3BSTaRTraPoint*>(fTrackerHitCA->At(i));
             Energy = ExpResSmearing(traHit[i]->GetEnergyLoss());
             // Energy = traHit[i]->GetEnergyLoss();
             Detector = traHit[i]->GetDetCopyID();

--- a/startrack/GeoConfig/R3BSTaRTraBox.cxx
+++ b/startrack/GeoConfig/R3BSTaRTraBox.cxx
@@ -209,7 +209,7 @@ Bool_t R3BSTaRTra::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of TraPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kTRA);
 
         ResetParameters();
@@ -305,7 +305,7 @@ void R3BSTaRTra::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BSTaRTraPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BSTaRTraPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BSTaRTraPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BSTaRTraPoint(*oldpoint);
@@ -848,7 +848,7 @@ void R3BSTaRTra::ConstructGeometry() {
   // store geo parameter
   FairRun *fRun = FairRun::Instance();
   FairRuntimeDb *rtdb= FairRun::Instance()->GetRuntimeDb();
-  R3BGeoSTaRTraPar* par=(R3BGeoSTaRTraPar*)(rtdb->getContainer("R3BGeoSTaRTraPar"));
+  R3BGeoSTaRTraPar* par=dynamic_cast<R3BGeoSTaRTraPar*>((rtdb->getContainer("R3BGeoSTaRTraPar")));
   TObjArray *fSensNodes = par->GetGeoSensitiveNodes();
   TObjArray *fPassNodes = par->GetGeoPassiveNodes();
 

--- a/startrack/GeoConfig/R3BSTaRTraLampshade_01_01.cxx
+++ b/startrack/GeoConfig/R3BSTaRTraLampshade_01_01.cxx
@@ -210,7 +210,7 @@ Bool_t R3BSTaRTra::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of TraPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kSTaRTrack);
 
         ResetParameters();
@@ -306,7 +306,7 @@ void R3BSTaRTra::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BSTaRTraPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BSTaRTraPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BSTaRTraPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BSTaRTraPoint(*oldpoint);
@@ -1752,7 +1752,7 @@ void R3BSTaRTra::ConstructGeometry() {
   // store geo parameter
   FairRun *fRun = FairRun::Instance();
   FairRuntimeDb *rtdb= FairRun::Instance()->GetRuntimeDb();
-  R3BGeoTraPar* par=(R3BGeoTraPar*)(rtdb->getContainer("R3BGeoTraPar"));
+  R3BGeoTraPar* par=dynamic_cast<R3BGeoTraPar*>((rtdb->getContainer("R3BGeoTraPar")));
   TObjArray *fSensNodes = par->GetGeoSensitiveNodes();
   TObjArray *fPassNodes = par->GetGeoPassiveNodes();
 

--- a/startrack/GeoConfig/R3BSTaRTraLampshade_01_02.cxx
+++ b/startrack/GeoConfig/R3BSTaRTraLampshade_01_02.cxx
@@ -210,7 +210,7 @@ Bool_t R3BSTaRTra::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of TraPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kSTaRTrack);
 
         ResetParameters();
@@ -306,7 +306,7 @@ void R3BSTaRTra::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BSTaRTraPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BSTaRTraPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BSTaRTraPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BSTaRTraPoint(*oldpoint);
@@ -1627,7 +1627,7 @@ void R3BSTaRTra::ConstructGeometry() {
   // store geo parameter
   FairRun *fRun = FairRun::Instance();
   FairRuntimeDb *rtdb= FairRun::Instance()->GetRuntimeDb();
-  R3BGeoTraPar* par=(R3BGeoTraPar*)(rtdb->getContainer("R3BGeoTraPar"));
+  R3BGeoTraPar* par=dynamic_cast<R3BGeoTraPar*>((rtdb->getContainer("R3BGeoTraPar")));
   TObjArray *fSensNodes = par->GetGeoSensitiveNodes();
   TObjArray *fPassNodes = par->GetGeoPassiveNodes();
 

--- a/startrack/GeoConfig/R3BSTaRTraLampshade_01_03.cxx
+++ b/startrack/GeoConfig/R3BSTaRTraLampshade_01_03.cxx
@@ -210,7 +210,7 @@ Bool_t R3BSTaRTra::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of STaRTraPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kSTaRTrack);
 
         ResetParameters();
@@ -306,7 +306,7 @@ void R3BSTaRTra::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BSTaRTraPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BSTaRTraPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BSTaRTraPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BSTaRTraPoint(*oldpoint);
@@ -1978,7 +1978,7 @@ void R3BSTaRTra::ConstructGeometry() {
   // store geo parameter
   FairRun *fRun = FairRun::Instance();
   FairRuntimeDb *rtdb= FairRun::Instance()->GetRuntimeDb();
-  R3BGeoSTaRTraPar* par=(R3BGeoSTaRTraPar*)(rtdb->getContainer("R3BGeoSTaRTraPar"));
+  R3BGeoSTaRTraPar* par=dynamic_cast<R3BGeoSTaRTraPar*>((rtdb->getContainer("R3BGeoSTaRTraPar")));
   TObjArray *fSensNodes = par->GetGeoSensitiveNodes();
   TObjArray *fPassNodes = par->GetGeoPassiveNodes();
 

--- a/startrack/GeoConfig/R3BSTaRTraLampshade_01_04.cxx
+++ b/startrack/GeoConfig/R3BSTaRTraLampshade_01_04.cxx
@@ -210,7 +210,7 @@ Bool_t R3BSTaRTra::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of STaRTraPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kSTaRTrack);
 
         ResetParameters();
@@ -306,7 +306,7 @@ void R3BSTaRTra::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BSTaRTraPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BSTaRTraPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BSTaRTraPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BSTaRTraPoint(*oldpoint);

--- a/startrack/GeoConfig/R3BSTaRTra_2Barrels.cxx
+++ b/startrack/GeoConfig/R3BSTaRTra_2Barrels.cxx
@@ -209,7 +209,7 @@ Bool_t R3BSTaRTra::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of TraPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kTRA);
 
         ResetParameters();
@@ -305,7 +305,7 @@ void R3BSTaRTra::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BSTaRTraPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BSTaRTraPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BSTaRTraPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BSTaRTraPoint(*oldpoint);
@@ -1512,7 +1512,7 @@ void R3BSTaRTra::ConstructGeometry() {
   // store geo parameter
   FairRun *fRun = FairRun::Instance();
   FairRuntimeDb *rtdb= FairRun::Instance()->GetRuntimeDb();
-  R3BGeoSTaRTraPar* par=(R3BGeoSTaRTraPar*)(rtdb->getContainer("R3BGeoSTaRTraPar"));
+  R3BGeoSTaRTraPar* par=dynamic_cast<R3BGeoSTaRTraPar*>((rtdb->getContainer("R3BGeoSTaRTraPar")));
   TObjArray *fSensNodes = par->GetGeoSensitiveNodes();
   TObjArray *fPassNodes = par->GetGeoPassiveNodes();
 

--- a/startrack/GeoConfig/R3BSTaRTra_2Barrels_initial.cxx
+++ b/startrack/GeoConfig/R3BSTaRTra_2Barrels_initial.cxx
@@ -209,7 +209,7 @@ Bool_t R3BSTaRTra::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of STaRTraPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kTRA);
 
         ResetParameters();
@@ -305,7 +305,7 @@ void R3BSTaRTra::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BSTaRTraPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BSTaRTraPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BSTaRTraPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BSTaRTraPoint(*oldpoint);
@@ -1012,7 +1012,7 @@ void R3BSTaRTra::ConstructGeometry() {
   // store geo parameter
   FairRun *fRun = FairRun::Instance();
   FairRuntimeDb *rtdb= FairRun::Instance()->GetRuntimeDb();
-  R3BGeoSTaRTraPar* par=(R3BGeoSTaRTraPar*)(rtdb->getContainer("R3BGeoSTaRTraPar"));
+  R3BGeoSTaRTraPar* par=dynamic_cast<R3BGeoSTaRTraPar*>((rtdb->getContainer("R3BGeoSTaRTraPar")));
   TObjArray *fSensNodes = par->GetGeoSensitiveNodes();
   TObjArray *fPassNodes = par->GetGeoPassiveNodes();
 

--- a/startrack/GeoConfig/R3BSTaRTra_3BarrelEndcap.cxx
+++ b/startrack/GeoConfig/R3BSTaRTra_3BarrelEndcap.cxx
@@ -209,7 +209,7 @@ Bool_t R3BSTaRTra::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of TraPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kTRA);
 
         ResetParameters();
@@ -305,7 +305,7 @@ void R3BSTaRTra::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BSTaRTraPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BSTaRTraPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BSTaRTraPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BSTaRTraPoint(*oldpoint);
@@ -1520,7 +1520,7 @@ void R3BSTaRTra::ConstructGeometry() {
   // store geo parameter
   FairRun *fRun = FairRun::Instance();
   FairRuntimeDb *rtdb= FairRun::Instance()->GetRuntimeDb();
-  R3BGeoSTaRTraPar* par=(R3BGeoSTaRTraPar*)(rtdb->getContainer("R3BGeoSTaRTraPar"));
+  R3BGeoSTaRTraPar* par=dynamic_cast<R3BGeoSTaRTraPar*>((rtdb->getContainer("R3BGeoSTaRTraPar")));
   TObjArray *fSensNodes = par->GetGeoSensitiveNodes();
   TObjArray *fPassNodes = par->GetGeoPassiveNodes();
 

--- a/startrack/R3BStartrack.cxx
+++ b/startrack/R3BStartrack.cxx
@@ -168,7 +168,7 @@ Bool_t R3BStartrack::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of StartrackPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kSTARTRACK);
 
         ResetParameters();
@@ -265,7 +265,7 @@ void R3BStartrack::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset
     R3BStartrackPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BStartrackPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BStartrackPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BStartrackPoint(*oldpoint);

--- a/startrack/R3BStartrackContFact.cxx
+++ b/startrack/R3BStartrackContFact.cxx
@@ -101,11 +101,11 @@ void R3BStartrackContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BStartrackParRootFileIo* p=new R3BStartrackParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BStartrackParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BStartrackParAsciiFileIo* p=new R3BStartrackParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BStartrackParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/startrack/R3BStartrackDigit.cxx
+++ b/startrack/R3BStartrackDigit.cxx
@@ -67,7 +67,7 @@ void R3BStartrackDigit::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "SetParContainers: No runtime database";
 
-    fStartrackHitPar = (R3BStartrackHitPar*)(rtdb->getContainer("R3BStartrackHitPar"));
+    fStartrackHitPar = dynamic_cast<R3BStartrackHitPar*>((rtdb->getContainer("R3BStartrackHitPar")));
 
     if (fStartrackHitPar)
     {
@@ -471,7 +471,7 @@ void R3BStartrackDigit::Exec(Option_t* opt)
         for (Int_t i = 0; i < traHitsPerEvent; i++)
         {
             traHit[i] = new R3BStartrackPoint;
-            traHit[i] = (R3BStartrackPoint*)fStartrackerHitCA->At(i);
+            traHit[i] = dynamic_cast<R3BStartrackPoint*>(fStartrackerHitCA->At(i));
             Energy = ExpResSmearing(traHit[i]->GetEnergyLoss());
             // Energy = traHit[i]->GetEnergyLoss();
             Detector = traHit[i]->GetDetCopyID(); // from 1 to 30

--- a/startrack/R3BStartrackHitFinder.cxx
+++ b/startrack/R3BStartrackHitFinder.cxx
@@ -1107,7 +1107,7 @@ void R3BStartrackHitFinder::Exec(Option_t* opt)
         for (Int_t i = 0; i < traHitsPerEvent; i++)
         {
             traHit[i] = new R3BStartrackPoint;
-            traHit[i] = (R3BStartrackPoint*)fStartrackerHitCA->At(i);
+            traHit[i] = dynamic_cast<R3BStartrackPoint*>(fStartrackerHitCA->At(i));
             Energy = ExpResSmearing(traHit[i]->GetEnergyLoss());
             // Energy = traHit[i]->GetEnergyLoss();
             Detector = traHit[i]->GetDetCopyID();

--- a/startrack/unpack/B4Ucesb/R3BStartrackCalib.cxx
+++ b/startrack/unpack/B4Ucesb/R3BStartrackCalib.cxx
@@ -68,7 +68,7 @@ void R3BStartrackCalib::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "R3BStarTraCalib::SetParContainers: No runtime database";
 
-    fStartrackCalibPar = (R3BStartrackCalibPar*)(rtdb->getContainer("R3BStartrackCalibPar"));
+    fStartrackCalibPar = dynamic_cast<R3BStartrackCalibPar*>((rtdb->getContainer("R3BStartrackCalibPar")));
 
     if (fVerbose && fStartrackCalibPar)
     {
@@ -121,7 +121,7 @@ void R3BStartrackCalib::Exec(Option_t* opt)
         for (Int_t i = 0; i < rawHits; i++)
         {
             rawHit[i] = new R3BStartrackRawHit;
-            rawHit[i] = (R3BStartrackRawHit*)fSiDetHitCA->At(i);
+            rawHit[i] = dynamic_cast<R3BStartrackRawHit*>(fSiDetHitCA->At(i));
 
             module_id = MapModuleID(rawHit[i]);
             side = MapSide(rawHit[i]);

--- a/startrack/unpack/B4Ucesb/R3BStartrackCalibParFinder.cxx
+++ b/startrack/unpack/B4Ucesb/R3BStartrackCalibParFinder.cxx
@@ -62,7 +62,7 @@ void R3BStartrackCalibParFinder::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "R3BStartrackCalibParFinder::SetParContainers: No runtime database";
 
-    fStartrackCalibPar = (R3BStartrackCalibPar*)(rtdb->getContainer("R3BStartrackCalibPar"));
+    fStartrackCalibPar = dynamic_cast<R3BStartrackCalibPar*>((rtdb->getContainer("R3BStartrackCalibPar")));
 
     if (fVerbose && fStartrackCalibPar)
     {

--- a/startrack/unpack/B4Ucesb/R3BStartrackCaliblmd.cxx
+++ b/startrack/unpack/B4Ucesb/R3BStartrackCaliblmd.cxx
@@ -68,7 +68,7 @@ void R3BStartrackCalib::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "R3BStarTraCalib::SetParContainers: No runtime database";
 
-    fStartrackCalibPar = (R3BStartrackCalibPar*)(rtdb->getContainer("R3BStartrackCalibPar"));
+    fStartrackCalibPar = dynamic_cast<R3BStartrackCalibPar*>((rtdb->getContainer("R3BStartrackCalibPar")));
 
     if (fVerbose && fStartrackCalibPar)
     {
@@ -121,7 +121,7 @@ void R3BStartrackCalib::Exec(Option_t* opt)
         for (Int_t i = 0; i < rawHits; i++)
         {
             rawHit[i] = new R3BStartrackRawHit;
-            rawHit[i] = (R3BStartrackRawHit*)fSiDetHitCA->At(i);
+            rawHit[i] = dynamic_cast<R3BStartrackRawHit*>(fSiDetHitCA->At(i));
 
             module_id = MapModuleID(rawHit[i]);
             side = MapSide(rawHit[i]);

--- a/startrack/unpack/B4Ucesb/R3BStartrackOrderTS.cxx
+++ b/startrack/unpack/B4Ucesb/R3BStartrackOrderTS.cxx
@@ -89,7 +89,7 @@ InitStatus R3BStartrackOrderTS::Init()
     fRawData = (TClonesArray*)mgr->GetObject(
         "StartrackRawHit"); // StartrackRawHit is the name of the branch object in the tree to get the information from
 
-    // fCal_Par = (R3BTofCalPar*)FairRuntimeDb::instance()->getContainer("StartrackCalPar");
+    // fCal_Par = dynamic_cast<R3BTofCalPar*>(FairRuntimeDb::instance()->getContainer("StartrackCalPar"));
     // fCal_Par->setChanged();
 
     if (!fRawData)
@@ -273,7 +273,7 @@ void R3BStartrackOrderTS::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nItems; i++)
     {
-        item = (R3BStartrackRawHit*)fRawData->At(i);
+        item = dynamic_cast<R3BStartrackRawHit*>(fRawData->At(i));
 
         if (NULL == item)
         {
@@ -680,7 +680,7 @@ void R3BStartrackOrderTS::Exec(Option_t* option)
 
                 // cout << "j= " << j << endl;
 
-                item = (R3BStartrackRawHit*)fRawData->At(index_hit_temp.at(j));
+                item = dynamic_cast<R3BStartrackRawHit*>(fRawData->At(index_hit_temp.at(j)));
 
                 cout << "index_hit_temp.at(j=" << j << ")= " << index_hit_temp.at(j) << endl;
 

--- a/startrack/unpack/B4Ucesb/R3BStartrackRawAna.cxx
+++ b/startrack/unpack/B4Ucesb/R3BStartrackRawAna.cxx
@@ -54,7 +54,7 @@ void R3BStartrackRawAna::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        hit = (R3BStartrackRawHit*)fRawData->At(i);
+        hit = dynamic_cast<R3BStartrackRawHit*>(fRawData->At(i));
         thw->Fill(hit->GetWordType());
         thh->Fill(hit->GetHitBit());
         thm->Fill(hit->GetModuleId());

--- a/startrack/unpack/B4Ucesb/R3BStartrackRawAnalmd.cxx
+++ b/startrack/unpack/B4Ucesb/R3BStartrackRawAnalmd.cxx
@@ -54,7 +54,7 @@ void R3BStartrackRawAna::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        hit = (R3BStartrackRawHit*)fRawData->At(i);
+        hit = dynamic_cast<R3BStartrackRawHit*>(fRawData->At(i));
         thw->Fill(hit->GetWordType());
         thh->Fill(hit->GetHitBit());
         thm->Fill(hit->GetModuleId());

--- a/startrack/unpack/B4Ucesb/R3BStartrackRecTS.cxx
+++ b/startrack/unpack/B4Ucesb/R3BStartrackRecTS.cxx
@@ -78,7 +78,7 @@ InitStatus R3BStartrackRecTS::Init()
     fRawData = (TClonesArray*)mgr->GetObject(
         "StartrackRawHit"); // StartrackRawHit is the name of the branch object in the tree to get the information from
 
-    // fCal_Par = (R3BTofCalPar*)FairRuntimeDb::instance()->getContainer("StartrackCalPar");
+    // fCal_Par = dynamic_cast<R3BTofCalPar*>(FairRuntimeDb::instance()->getContainer("StartrackCalPar"));
     // fCal_Par->setChanged();
 
     if (!fRawData)
@@ -259,7 +259,7 @@ void R3BStartrackRecTS::Exec(Option_t* option) // called for each data block
     for (Int_t i = 0; i < nItems; i++) // nItem is the number of hits in the block
     {
 
-        item = (R3BStartrackRawHit*)fRawData->At(i);
+        item = dynamic_cast<R3BStartrackRawHit*>(fRawData->At(i));
 
         if (NULL == item)
         {

--- a/startrack/unpack/B4Ucesb/R3BStartrackSortRawAna.cxx
+++ b/startrack/unpack/B4Ucesb/R3BStartrackSortRawAna.cxx
@@ -72,7 +72,7 @@ void R3BStartrackSortRawAna::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        hit = (R3BStartrackRawHit*)fRawData->At(i);
+        hit = dynamic_cast<R3BStartrackRawHit*>(fRawData->At(i));
 
         my_type = hit->GetWordType();
         my_hit = hit->GetHitBit();

--- a/startrack/unpack/B4Ucesb/R3BStartrackStripAna.cxx
+++ b/startrack/unpack/B4Ucesb/R3BStartrackStripAna.cxx
@@ -48,7 +48,7 @@ void R3BStartrackStripAna::Exec(Option_t* option)
     R3BStartrackerDigitHit* hit;
     for (Int_t i = 0; i < nHits; i++)
     {
-        hit = (R3BStartrackerDigitHit*)fSiDetData->At(i);
+        hit = dynamic_cast<R3BStartrackerDigitHit*>(fSiDetData->At(i));
 
         // thWordType->Fill(hit->GetWordType());  // 10->type A  ; 11->
         // thHitBit->Fill(hit->GetHitBit());  // 0->timestamp from energy branch (ie over energy threshold) ;

--- a/startrack/unpack/R3BStartrackCal2Hit.cxx
+++ b/startrack/unpack/R3BStartrackCal2Hit.cxx
@@ -76,7 +76,7 @@ void R3BStartrackCal2Hit::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "SetParContainers: No runtime database";
 
-    fStartrackHitPar = (R3BStartrackHitPar*)(rtdb->getContainer("R3BStartrackHitPar"));
+    fStartrackHitPar = dynamic_cast<R3BStartrackHitPar*>((rtdb->getContainer("R3BStartrackHitPar")));
 
     if (fStartrackHitPar)
     {
@@ -481,7 +481,7 @@ void R3BStartrackCal2Hit::Exec(Option_t* opt)
         for (Int_t i = 0; i < traHitsPerEvent; i++)
         {
             traHit[i] = new R3BStartrackPoint;
-            traHit[i] = (R3BStartrackPoint*)fStartrackerHitCA->At(i);
+            traHit[i] = dynamic_cast<R3BStartrackPoint*>(fStartrackerHitCA->At(i));
             Energy = ExpResSmearing(traHit[i]->GetEnergyLoss());
             // Energy = traHit[i]->GetEnergyLoss();
             Detector = traHit[i]->GetDetCopyID(); // from 1 to 30

--- a/startrack/unpack/R3BStartrackMapped2Cal.cxx
+++ b/startrack/unpack/R3BStartrackMapped2Cal.cxx
@@ -84,7 +84,7 @@ InitStatus R3BStartrackMapped2Cal::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
-    // header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    // header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
 
     // get access to Mapped data
     fMappedItemsCA = (TClonesArray*)mgr->GetObject("StartrackMapped"); // = branch name in TTree
@@ -202,7 +202,7 @@ void R3BStartrackMapped2Cal::Exec(Option_t* option)
         //    for (Int_t ihit = 0; ihit < 2; ihit++)
         for (Int_t ihit = 0; ihit < nRawHits; ihit++)
         {
-            R3BStartrackMappedData* hit = (R3BStartrackMappedData*)fMappedItemsCA->At(ihit);
+            R3BStartrackMappedData* hit = dynamic_cast<R3BStartrackMappedData*>(fMappedItemsCA->At(ihit));
             if (!hit)
                 continue;
 
@@ -252,7 +252,7 @@ void R3BStartrackMapped2Cal::Exec(Option_t* option)
                 for (Int_t j = 0; j < n_loop; j++)
                 { // transport sorted data to output_tree
 
-                    R3BStartrackMappedData* newhit = (R3BStartrackMappedData*)fMappedItemsCA->At(index_hit_temp.at(j));
+                    R3BStartrackMappedData* newhit = dynamic_cast<R3BStartrackMappedData*>(fMappedItemsCA->At(index_hit_temp.at(j)));
 
                     my_new_ts = (ts_temp.at(j));        // in nanosec
                     my_new_ts_ext = newhit->GetTSExt(); // in nanosec

--- a/startrack/unpack/par/R3BCalifaCrystalCalPar.cxx
+++ b/startrack/unpack/par/R3BCalifaCrystalCalPar.cxx
@@ -66,7 +66,7 @@ void R3BCalifaCrystalCalPar::putParams(FairParamList* list)
         ss << i;
         TString du_id(ss.str());
         TArrayD values(8);
-        R3BCalifaDUCalPar* dupar = (R3BCalifaDUCalPar*)fDUCalParams->At(i);
+        R3BCalifaDUCalPar* dupar = dynamic_cast<R3BCalifaDUCalPar*>(fDUCalParams->At(i));
         values[0] = dupar->GetGammaCal_offset();
         values[1] = dupar->GetGammaCal_gain();
         values[2] = dupar->GetToTCal_par0();
@@ -188,7 +188,7 @@ void R3BCalifaCrystalCalPar::fill(UInt_t rid)
     cout << "-I- R3BCalifaCrystalCalPar numOfRow " << numTCh << endl;
     for (int i = 0; i <= numTCh; ++i)
     {
-        R3BCalifaDUCalPar* tcal_par = (R3BCalifaDUCalPar*)r_tpar->GetRow(i);
+        R3BCalifaDUCalPar* tcal_par = dynamic_cast<R3BCalifaDUCalPar*>(r_tpar->GetRow(i));
         if (!tcal_par)
         {
             continue;
@@ -215,7 +215,7 @@ void R3BCalifaCrystalCalPar::store(UInt_t rid)
         // TCal Objects
         for (Int_t i = 0; i < nParams; i++)
         {
-            R3BCalifaDUCalPar* t_par = (R3BCalifaDUCalPar*)fDUCalParams->At(i);
+            R3BCalifaDUCalPar* t_par = dynamic_cast<R3BCalifaDUCalPar*>(fDUCalParams->At(i));
             if (t_par)
                 *cW << *t_par;
         }
@@ -239,7 +239,7 @@ void R3BCalifaCrystalCalPar::Print()
     std::cout << " Number of DUCal Parameters " << fDUCalParams->GetEntries() << std::endl;
     for (Int_t i = 0; i < fDUCalParams->GetEntries(); i++)
     {
-        R3BCalifaDUCalPar* du_par = (R3BCalifaDUCalPar*)fDUCalParams->At(i);
+        R3BCalifaDUCalPar* du_par = dynamic_cast<R3BCalifaDUCalPar*>(fDUCalParams->At(i));
         cout << "----------------------------------------------------------------------" << endl;
         if (du_par)
             du_par->Print();

--- a/startrack/unpack/par/R3BCalifaCrystalCalPar.h
+++ b/startrack/unpack/par/R3BCalifaCrystalCalPar.h
@@ -52,7 +52,7 @@ class R3BCalifaCrystalCalPar : public FairDbObjTableMap
     void AddDUCalPar(R3BCalifaDUCalPar* tch) { fDUCalParams->Add(tch); }
     TObjArray* GetListOfDUCalPar(Int_t side) { return fDUCalParams; }
     Int_t GetNumDUCalPar() { return fDUCalParams->GetEntries(); }
-    R3BCalifaDUCalPar* GetDUCalParAt(Int_t idx) { return (R3BCalifaDUCalPar*)fDUCalParams->At(idx); }
+    R3BCalifaDUCalPar* GetDUCalParAt(Int_t idx) { return dynamic_cast<R3BCalifaDUCalPar*>(fDUCalParams->At(idx)); }
 
     // Add-ons: SQL descriptors for the parameter class
     virtual std::string GetTableDefinition(const char* Name = 0)

--- a/startrack/unpack/par/R3BStartrackMapped2CalPar.cxx
+++ b/startrack/unpack/par/R3BStartrackMapped2CalPar.cxx
@@ -93,7 +93,7 @@ InitStatus R3BStartrackMapped2CalPar::Init()
     /*
       // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
       // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-      fCal_Par = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("TofdTCalPar");
+      fCal_Par = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("TofdTCalPar"));
       if (!fCal_Par)
       {
           LOG(ERROR) << "R3BTofdMapped2TCalPar::Init() Couldn't get handle on TofdTCalPar. ";
@@ -128,7 +128,7 @@ void R3BStartrackMapped2CalPar::Exec(Option_t* option)
     // Loop over mapped hits
     for (Int_t i = 0; i < nHits; i++)
     {
-        R3BStartrackMappedData* hit = (R3BStartrackMappedData*)fStartrackMappedDataCA->At(i);
+        R3BStartrackMappedData* hit = dynamic_cast<R3BStartrackMappedData*>(fStartrackMappedDataCA->At(i));
 
         Int_t iLadder = hit->GetLadderId(); // 1..n
         Int_t iAsic = hit->GetAsicId();     // 1..n

--- a/strawtubes/R3BStrawtubesCal2Hit.cxx
+++ b/strawtubes/R3BStrawtubesCal2Hit.cxx
@@ -38,7 +38,7 @@ void R3BStrawtubesCal2Hit::Exec(Option_t* option)
     Int_t nDets = fCalItems->GetEntriesFast();
     for (Int_t i = 0; i < nDets; i++)
     {
-        auto calItem = (R3BStrawtubesCalData*)fCalItems->At(i);
+        auto calItem = dynamic_cast<R3BStrawtubesCalData*>(fCalItems->At(i));
         if (!calItem)
         {
             continue;

--- a/strawtubes/R3BStrawtubesMapped2Cal.cxx
+++ b/strawtubes/R3BStrawtubesMapped2Cal.cxx
@@ -55,7 +55,7 @@ void R3BStrawtubesMapped2Cal::Exec(Option_t* option)
     Int_t mapped_num = fMappedItems->GetEntriesFast();
     for (Int_t mapped_i = 0; mapped_i < mapped_num; mapped_i++)
     {
-        R3BStrawtubesMappedData* mapped = (R3BStrawtubesMappedData*)fMappedItems->At(mapped_i);
+        R3BStrawtubesMappedData* mapped = dynamic_cast<R3BStrawtubesMappedData*>(fMappedItems->At(mapped_i));
         if (!mapped)
         {
             LOG(ERROR) << "R3BStrawtubesMapped2Cal::Exec: NULL mapped item?";
@@ -87,7 +87,7 @@ void R3BStrawtubesMapped2Cal::Exec(Option_t* option)
         R3BStrawtubesCalData* cal = NULL;
         for (int cal_i = 0; cal_i < fCalItems->GetEntriesFast(); ++cal_i)
         {
-            R3BStrawtubesCalData* cal_test = (R3BStrawtubesCalData*)fCalItems->At(cal_i);
+            R3BStrawtubesCalData* cal_test = dynamic_cast<R3BStrawtubesCalData*>(fCalItems->At(cal_i));
             // We want the same straw.
             if (cal_test->GetPlane() != mapped->GetPlane() || cal_test->GetStraw() != mapped->GetStraw())
             {
@@ -160,7 +160,7 @@ InitStatus R3BStrawtubesMapped2Cal::ReInit()
 
 void R3BStrawtubesMapped2Cal::SetParContainers()
 {
-    fTcalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("StrawtubesTCalPar");
+    fTcalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("StrawtubesTCalPar"));
     if (!fTcalPar)
     {
         LOG(ERROR) << "No StrawtubesTCalPar container.";

--- a/strawtubes/R3BStrawtubesMapped2CalPar.cxx
+++ b/strawtubes/R3BStrawtubesMapped2CalPar.cxx
@@ -54,7 +54,7 @@ InitStatus R3BStrawtubesMapped2CalPar::Init()
         return kFATAL;
     }
 
-    fCalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("StrawtubesTCalPar");
+    fCalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("StrawtubesTCalPar"));
     fCalPar->setChanged();
 
     fEngine = new R3BTCalEngine(fCalPar, fMinStats);
@@ -67,7 +67,7 @@ void R3BStrawtubesMapped2CalPar::Exec(Option_t* option)
     Int_t mapped_num = fMapped->GetEntries();
     for (Int_t i = 0; i < mapped_num; i++)
     {
-        auto mapped = (R3BStrawtubesMappedData*)fMapped->At(i);
+        auto mapped = dynamic_cast<R3BStrawtubesMappedData*>(fMapped->At(i));
         if (!mapped)
         {
             LOG(ERROR) << "R3BStrawtubesMapped2CalPar::Exec(): What is this crap?";

--- a/tcal/R3BTCalPar.cxx
+++ b/tcal/R3BTCalPar.cxx
@@ -74,7 +74,7 @@ void R3BTCalPar::printParams()
     R3BLOG(INFO, "Number of TCal Parameters " << fTCalParams->GetEntries());
     for (Int_t i = 0; i < fTCalParams->GetEntries(); i++)
     {
-        R3BTCalModulePar* t_par = (R3BTCalModulePar*)fTCalParams->At(i);
+        R3BTCalModulePar* t_par = dynamic_cast<R3BTCalModulePar*>(fTCalParams->At(i));
         LOG(INFO) << "----------------------------------------------------------------------";
         if (t_par)
         {
@@ -95,7 +95,7 @@ R3BTCalModulePar* R3BTCalPar::GetModuleParAt(Int_t plane, Int_t paddle, Int_t si
         Int_t index;
         for (Int_t i = 0; i < fTCalParams->GetEntries(); i++)
         {
-            par = (R3BTCalModulePar*)fTCalParams->At(i);
+            par = dynamic_cast<R3BTCalModulePar*>(fTCalParams->At(i));
             if (NULL == par)
             {
                 continue;
@@ -133,7 +133,7 @@ R3BTCalModulePar* R3BTCalPar::GetModuleParAt(Int_t plane, Int_t paddle, Int_t si
         return NULL;
     }
     Int_t arind = fIndexMap[index];
-    return (R3BTCalModulePar*)fTCalParams->At(arind);
+    return dynamic_cast<R3BTCalModulePar*>(fTCalParams->At(arind));
 }
 
 void R3BTCalPar::AddModulePar(R3BTCalModulePar* tch)

--- a/tof/R3BPtofMapped2Cal.cxx
+++ b/tof/R3BPtofMapped2Cal.cxx
@@ -112,7 +112,7 @@ InitStatus R3BPtofMapped2Cal::Init()
 // Note that the container may still be empty at this point.
 void R3BPtofMapped2Cal::SetParContainers()
 {
-    fTcalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("PtofTCalPar");
+    fTcalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("PtofTCalPar"));
     if (!fTcalPar)
         LOG(ERROR) << "Could not get access to PtofTCalPar-Container.";
 }
@@ -129,7 +129,7 @@ void R3BPtofMapped2Cal::Exec(Option_t* option)
 
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        R3BPaddleTamexMappedData* mapped = (R3BPaddleTamexMappedData*)fMappedItems->At(ihit);
+        R3BPaddleTamexMappedData* mapped = dynamic_cast<R3BPaddleTamexMappedData*>(fMappedItems->At(ihit));
 
         Int_t iPlane = mapped->GetPlaneId(); // 1..n; no need to check range
         Int_t iBar = mapped->GetBarId();     // 1..n

--- a/tof/R3BPtofMapped2CalPar.cxx
+++ b/tof/R3BPtofMapped2CalPar.cxx
@@ -78,7 +78,7 @@ InitStatus R3BPtofMapped2CalPar::Init()
 
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-    fCal_Par = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("PtofTCalPar");
+    fCal_Par = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("PtofTCalPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BPtofMapped2CalPar::Init() Couldn't get handle on PtofTCalPar. ";
@@ -101,7 +101,7 @@ void R3BPtofMapped2CalPar::Exec(Option_t* option)
     for (Int_t i = 0; i < nHits; i++)
     {
 
-        R3BPaddleTamexMappedData* hit = (R3BPaddleTamexMappedData*)fMapped->At(i);
+        R3BPaddleTamexMappedData* hit = dynamic_cast<R3BPaddleTamexMappedData*>(fMapped->At(i));
         if (!hit)
             continue; // should not happen
 

--- a/tof/R3BTof.cxx
+++ b/tof/R3BTof.cxx
@@ -203,7 +203,7 @@ Bool_t R3BTof::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of TofPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kTOF);
 
         ResetParameters();
@@ -287,7 +287,7 @@ void R3BTof::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BTofPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BTofPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BTofPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BTofPoint(*oldpoint);

--- a/tof/R3BTof2pDigitizer.cxx
+++ b/tof/R3BTof2pDigitizer.cxx
@@ -130,12 +130,12 @@ void R3BTof2pDigitizer::Exec(Option_t* opt)
     /*
        for (Int_t l=0;l<nentriesTof;l++){
 
-         R3BTofPoint *tof_obj = (R3BTofPoint*) fTofPoints->At(l);
+         R3BTofPoint *tof_obj = dynamic_cast<R3BTofPoint*>( fTofPoints->At(l));
 
          TOFeloss = tof_obj->GetEnergyLoss()*1000;
 
          TrackIdTof = tof_obj->GetTrackID();
-         R3BMCTrack *aTrack = (R3BMCTrack*) fTofMCTrack->At(TrackIdTof);
+         R3BMCTrack *aTrack = dynamic_cast<R3BMCTrack*>( fTofMCTrack->At(TrackIdTof));
          Int_t PID = aTrack->GetPdgCode();
 
 
@@ -170,10 +170,10 @@ void R3BTof2pDigitizer::Exec(Option_t* opt)
     for (Int_t l = 0; l < nentriesTof; l++)
     {
 
-        R3BTofPoint* tof_obj = (R3BTofPoint*)fTofPoints->At(l);
+        R3BTofPoint* tof_obj = dynamic_cast<R3BTofPoint*>(fTofPoints->At(l));
 
         TrackIdTof = tof_obj->GetTrackID();
-        R3BMCTrack* aTrack = (R3BMCTrack*)fTofMCTrack->At(TrackIdTof);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fTofMCTrack->At(TrackIdTof));
         Int_t PID = aTrack->GetPdgCode();
         Int_t mother = aTrack->GetMotherId();
 

--- a/tof/R3BTofContFact.cxx
+++ b/tof/R3BTofContFact.cxx
@@ -108,11 +108,11 @@ void R3BTofContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BTofParRootFileIo* p=new R3BTofParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BTofParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BTofParAsciiFileIo* p=new R3BTofParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BTofParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/tof/R3BTofDigitizer.cxx
+++ b/tof/R3BTofDigitizer.cxx
@@ -62,7 +62,7 @@ void R3BTofDigitizer::SetParContainers()
     if (!rtdb)
         LOG(fatal) << "SetParContainers: No runtime database";
 
-    fTofDigiPar = (R3BTofDigiPar*)(rtdb->getContainer("R3BTofDigiPar"));
+    fTofDigiPar = dynamic_cast<R3BTofDigiPar*>((rtdb->getContainer("R3BTofDigiPar")));
 
     if (fTofDigiPar)
     {
@@ -138,10 +138,10 @@ void R3BTofDigitizer::Exec(Option_t* opt)
 
     for (Int_t l = 0; l < nentriesTof; l++)
     {
-        R3BTofPoint* tof_obj = (R3BTofPoint*)fTofPoints->At(l);
+        R3BTofPoint* tof_obj = dynamic_cast<R3BTofPoint*>(fTofPoints->At(l));
         //        if (tof_obj==NULL) continue;
         TrackIdTof = tof_obj->GetTrackID();
-        R3BMCTrack* aTrack = (R3BMCTrack*)fTofMCTrack->At(TrackIdTof);
+        R3BMCTrack* aTrack = dynamic_cast<R3BMCTrack*>(fTofMCTrack->At(TrackIdTof));
         Int_t PID = aTrack->GetPdgCode();
         Int_t mother = aTrack->GetMotherId();
 

--- a/tof/R3BTofd.cxx
+++ b/tof/R3BTofd.cxx
@@ -210,7 +210,7 @@ Bool_t R3BTofd::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of TofdPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kTOFD);
 
         ResetParameters();
@@ -294,7 +294,7 @@ void R3BTofd::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BTofdPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BTofdPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BTofdPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BTofdPoint(*oldpoint);

--- a/tof/R3BTofdCal2Histo.cxx
+++ b/tof/R3BTofdCal2Histo.cxx
@@ -169,7 +169,7 @@ InitStatus R3BTofdCal2Histo::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rm->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("R3BEventHeader"));
     // may be = NULL!
 
     fCalData = (TClonesArray*)rm->GetObject("TofdCal");
@@ -198,7 +198,7 @@ void R3BTofdCal2Histo::SetParContainers()
 {
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-    fCal_Par = (R3BTofdHitPar*)FairRuntimeDb::instance()->getContainer("TofdHitPar");
+    fCal_Par = dynamic_cast<R3BTofdHitPar*>(FairRuntimeDb::instance()->getContainer("TofdHitPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BTofdCal2Histo::Init() Couldn't get handle on TofdHitPar. ";
@@ -243,7 +243,7 @@ void R3BTofdCal2Histo::Exec(Option_t* option)
     std::map<size_t, Entry> bar_map;
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        auto* hit = (R3BTofdCalData*)fCalData->At(ihit);
+        auto* hit = dynamic_cast<R3BTofdCalData*>(fCalData->At(ihit));
         size_t idx = hit->GetDetectorId() * fPaddlesPerPlane * hit->GetBarId();
         // std::cout << "Hits: " << hit->GetDetectorId() << ' ' << hit->GetBarId() << ' ' << hit->GetSideId() << ' '
         //          << hit->GetTimeLeading_ns() << ' ' << hit->GetTimeTrailing_ns() << '\n';

--- a/tof/R3BTofdCal2HistoPar.cxx
+++ b/tof/R3BTofdCal2HistoPar.cxx
@@ -123,7 +123,7 @@ InitStatus R3BTofdCal2HistoPar::Init()
     {
         return kFATAL;
     }
-    header = (R3BEventHeader*)rm->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("R3BEventHeader"));
     // may be = NULL!
     fCalData = (TClonesArray*)rm->GetObject("TofdCal");
     if (!fCalData)
@@ -152,7 +152,7 @@ void R3BTofdCal2HistoPar::SetParContainers()
 {
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-    fCal_Par = (R3BTofdHitPar*)FairRuntimeDb::instance()->getContainer("TofdHitPar");
+    fCal_Par = dynamic_cast<R3BTofdHitPar*>(FairRuntimeDb::instance()->getContainer("TofdHitPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BTofdCal2HistoPar::Init() Couldn't get handle on TofdHitPar. ";

--- a/tof/R3BTofdCal2Hit.cxx
+++ b/tof/R3BTofdCal2Hit.cxx
@@ -192,7 +192,7 @@ R3BTofdCal2Hit::~R3BTofdCal2Hit()
 
 InitStatus R3BTofdCal2Hit::Init()
 {
-    fHitPar = (R3BTofdHitPar*)FairRuntimeDb::instance()->getContainer("TofdHitPar");
+    fHitPar = dynamic_cast<R3BTofdHitPar*>(FairRuntimeDb::instance()->getContainer("TofdHitPar"));
     if (!fHitPar)
     {
         LOG(ERROR) << "Could not get access to TofdHitPar-Container.";
@@ -209,10 +209,10 @@ InitStatus R3BTofdCal2Hit::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     R3BLOG_IF(fatal, NULL == mgr, "FairRootManager not found");
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (header == nullptr)
     {
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
         R3BLOG(WARNING, "R3BEventHeader was found instead of EventHeader.");
     }
 
@@ -236,7 +236,7 @@ InitStatus R3BTofdCal2Hit::Init()
 // Note that the container may still be empty at this point.
 void R3BTofdCal2Hit::SetParContainers()
 {
-    fHitPar = (R3BTofdHitPar*)FairRuntimeDb::instance()->getContainer("TofdHitPar");
+    fHitPar = dynamic_cast<R3BTofdHitPar*>(FairRuntimeDb::instance()->getContainer("TofdHitPar"));
     if (!fHitPar)
     {
         LOG(ERROR) << "Could not get access to TofdHitPar-Container.";
@@ -314,7 +314,7 @@ void R3BTofdCal2Hit::Exec(Option_t* option)
         {
             countloshit++;
             LOG(WARNING) << "LOS Ihit  " << ihit << " " << nHits;
-            R3BLosHitData* hitData = (R3BLosHitData*)fHitItemsLos->At(ihit);
+            R3BLosHitData* hitData = dynamic_cast<R3BLosHitData*>(fHitItemsLos->At(ihit));
             if (ihit == 0)
                 timeLos = hitData->fTime_ns;
             LOG(WARNING) << "LOS Time " << timeLos;
@@ -348,7 +348,7 @@ void R3BTofdCal2Hit::Exec(Option_t* option)
             for (Int_t ihit = 0; ihit < nHits; ihit++)
             {
                 LOG(WARNING) << "LOS Ihit  "<< ihit<<" "<<nHits<<FairLogger::endl;
-                R3BLosCalData *calData = (R3BLosCalData*)fCalItemsLos->At(ihit);
+                R3BLosCalData *calData = dynamic_cast<R3BLosCalData*>(fCalItemsLos->At(ihit));
                 timeLos=(calData->fTimeV_r_ns+calData->fTimeV_l_ns+calData->fTimeV_t_ns+calData->fTimeV_b_ns)/4.;
                 LosTresM=(calData->fTimeV_r_ns+calData->fTimeV_l_ns)/2.-(calData->fTimeV_t_ns+calData->fTimeV_b_ns)/2.;
                 LOG(WARNING) << "LOS MCFD  "<< LosTresM<<" "<<timeLos<<FairLogger::endl;
@@ -386,7 +386,7 @@ void R3BTofdCal2Hit::Exec(Option_t* option)
     std::map<size_t, Entry> bar_map;
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        auto* hit = (R3BTofdCalData*)fCalItems->At(ihit);
+        auto* hit = dynamic_cast<R3BTofdCalData*>(fCalItems->At(ihit));
         size_t idx = hit->GetDetectorId() * fPaddlesPerPlane * hit->GetBarId();
         // std::cout << "Hits: " << hit->GetDetectorId() << ' ' << hit->GetBarId() << ' ' << hit->GetSideId() << ' '
         //          << hit->GetTimeLeading_ns() << ' ' << hit->GetTimeTrailing_ns() << '\n';

--- a/tof/R3BTofdCal2HitPar.cxx
+++ b/tof/R3BTofdCal2HitPar.cxx
@@ -153,7 +153,7 @@ InitStatus R3BTofdCal2HitPar::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rm->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("R3BEventHeader"));
     // may be = NULL!
 
     fCalData = (TClonesArray*)rm->GetObject("TofdCal");
@@ -178,7 +178,7 @@ void R3BTofdCal2HitPar::SetParContainers()
 {
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-    fCal_Par = (R3BTofdHitPar*)FairRuntimeDb::instance()->getContainer("TofdHitPar");
+    fCal_Par = dynamic_cast<R3BTofdHitPar*>(FairRuntimeDb::instance()->getContainer("TofdHitPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BTofdCal2HitPar::Init() Couldn't get handle on TofdHitPar. ";
@@ -205,7 +205,7 @@ void R3BTofdCal2HitPar::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BLosCalData* calData = (R3BLosCalData*)fCalItemsLos->At(ihit);
+            R3BLosCalData* calData = dynamic_cast<R3BLosCalData*>(fCalItemsLos->At(ihit));
 
             Int_t iDet = calData->GetDetector();
             // Int_t iCha=calData->GetChannel();
@@ -244,7 +244,7 @@ void R3BTofdCal2HitPar::Exec(Option_t* option)
 
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        auto* hit = (R3BTofdCalData*)fCalData->At(ihit);
+        auto* hit = dynamic_cast<R3BTofdCalData*>(fCalData->At(ihit));
         size_t idx = hit->GetDetectorId() * fPaddlesPerPlane * hit->GetBarId();
 
         // std::cout << "Hits: " << hit->GetDetectorId() << ' ' << hit->GetBarId() << ' ' << hit->GetSideId() << ' '

--- a/tof/R3BTofdCal2HitS454.cxx
+++ b/tof/R3BTofdCal2HitS454.cxx
@@ -143,7 +143,7 @@ R3BTofdCal2HitS454::~R3BTofdCal2HitS454()
 
 InitStatus R3BTofdCal2HitS454::Init()
 {
-    fHitPar = (R3BTofdHitPar*)FairRuntimeDb::instance()->getContainer("TofdHitPar");
+    fHitPar = dynamic_cast<R3BTofdHitPar*>(FairRuntimeDb::instance()->getContainer("TofdHitPar"));
     if (!fHitPar)
     {
         LOG(ERROR) << "Could not get access to TofdHitPar-Container.";
@@ -161,7 +161,7 @@ InitStatus R3BTofdCal2HitS454::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     
     fCalItems = (TClonesArray*)mgr->GetObject("TofdCal");
     if (NULL == fCalItems)
@@ -182,7 +182,7 @@ InitStatus R3BTofdCal2HitS454::Init()
 // Note that the container may still be empty at this point.
 void R3BTofdCal2HitS454::SetParContainers()
 {
-    fHitPar = (R3BTofdHitPar*)FairRuntimeDb::instance()->getContainer("TofdHitPar");
+    fHitPar = dynamic_cast<R3BTofdHitPar*>(FairRuntimeDb::instance()->getContainer("TofdHitPar"));
     if (!fHitPar)
     {
         LOG(ERROR) << "Could not get access to TofdHitPar-Container.";
@@ -272,7 +272,7 @@ void R3BTofdCal2HitS454::Exec(Option_t* option)
     // puts("Event");
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        auto* hit = (R3BTofdCalData*)fCalItems->At(ihit);
+        auto* hit = dynamic_cast<R3BTofdCalData*>(fCalItems->At(ihit));
         size_t idx = hit->GetDetectorId() * fPaddlesPerPlane * hit->GetBarId();
 
         /*std::cout << "Hits: " << hit->GetDetectorId() << ' ' << hit->GetBarId() << ' ' << hit->GetSideId() << '  '

--- a/tof/R3BTofdCal2HitS494.cxx
+++ b/tof/R3BTofdCal2HitS494.cxx
@@ -161,7 +161,7 @@ R3BTofdCal2HitS494::~R3BTofdCal2HitS494()
 InitStatus R3BTofdCal2HitS494::Init()
 {
     R3BLOG(INFO, "");
-    fHitPar = (R3BTofdHitPar*)FairRuntimeDb::instance()->getContainer("TofdHitPar");
+    fHitPar = dynamic_cast<R3BTofdHitPar*>(FairRuntimeDb::instance()->getContainer("TofdHitPar"));
     if (!fHitPar)
     {
         LOG(ERROR) << "Could not get access to TofdHitPar-Container.";
@@ -179,10 +179,10 @@ InitStatus R3BTofdCal2HitS494::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     R3BLOG_IF(fatal, NULL == mgr, "FairRootManager not found");
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (header == nullptr)
     {
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
         R3BLOG(WARNING, "R3BEventHeader was found instead of EventHeader.");
     }
 
@@ -206,7 +206,7 @@ InitStatus R3BTofdCal2HitS494::Init()
 // Note that the container may still be empty at this point.
 void R3BTofdCal2HitS494::SetParContainers()
 {
-    fHitPar = (R3BTofdHitPar*)FairRuntimeDb::instance()->getContainer("TofdHitPar");
+    fHitPar = dynamic_cast<R3BTofdHitPar*>(FairRuntimeDb::instance()->getContainer("TofdHitPar"));
     if (!fHitPar)
     {
         LOG(ERROR) << "Could not get access to TofdHitPar-Container.";
@@ -338,7 +338,7 @@ void R3BTofdCal2HitS494::Exec(Option_t* option)
     // puts("Event");
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        auto* hit = (R3BTofdCalData*)fCalItems->At(ihit);
+        auto* hit = dynamic_cast<R3BTofdCalData*>(fCalItems->At(ihit));
         size_t idx = hit->GetDetectorId() * fPaddlesPerPlane * hit->GetBarId();
 
         // std::cout << "Hits: " << hit->GetDetectorId() << ' ' << hit->GetBarId() << ' ' << hit->GetSideId() << '  '

--- a/tof/R3BTofdChangePar.cxx
+++ b/tof/R3BTofdChangePar.cxx
@@ -101,7 +101,7 @@ InitStatus R3BTofdChangePar::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rm->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("R3BEventHeader"));
     // may be = NULL!
 
     fCalData = (TClonesArray*)rm->GetObject("TofdCal");
@@ -123,7 +123,7 @@ void R3BTofdChangePar::SetParContainers()
 {
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-    fCal_Par = (R3BTofdHitPar*)FairRuntimeDb::instance()->getContainer("TofdHitPar");
+    fCal_Par = dynamic_cast<R3BTofdHitPar*>(FairRuntimeDb::instance()->getContainer("TofdHitPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BTofdChangePar::Init() Couldn't get handle on TofdHitPar. ";

--- a/tof/R3BTofdDigitizer.cxx
+++ b/tof/R3BTofdDigitizer.cxx
@@ -112,7 +112,7 @@ void R3BTofdDigitizer::Exec(Option_t* opt)
     for (Int_t entry = 0; entry < n_entries; entry++)
     {
 
-        R3BTofdPoint* data_element = (R3BTofdPoint*)fTofdPoints->At(entry);
+        R3BTofdPoint* data_element = dynamic_cast<R3BTofdPoint*>(fTofdPoints->At(entry));
 
         Int_t DetectorID = data_element->GetDetectorID();
         Double_t energy_loss = data_element->GetEnergyLoss();

--- a/tof/R3BTofdDigitizerCal.cxx
+++ b/tof/R3BTofdDigitizerCal.cxx
@@ -139,7 +139,7 @@ void R3BTofdDigitizerCal::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BTofdPoint* data_element = (R3BTofdPoint*)Points->At(i);
+            R3BTofdPoint* data_element = dynamic_cast<R3BTofdPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(), // channel nummer
                                        data_element->GetEnergyLoss(),

--- a/tof/R3BTofdHitPar.cxx
+++ b/tof/R3BTofdHitPar.cxx
@@ -67,7 +67,7 @@ void R3BTofdHitPar::printParams()
     LOG(INFO) << " Number of HIT Parameters " << fHitParams->GetEntries();
     for (Int_t i = 0; i < fHitParams->GetEntries(); i++)
     {
-        R3BTofdHitModulePar* t_par = (R3BTofdHitModulePar*)fHitParams->At(i);
+        R3BTofdHitModulePar* t_par = dynamic_cast<R3BTofdHitModulePar*>(fHitParams->At(i));
         LOG(INFO) << "----------------------------------------------------------------------";
         if (t_par)
         {
@@ -87,7 +87,7 @@ R3BTofdHitModulePar* R3BTofdHitPar::GetModuleParAt(Int_t plane, Int_t paddle)
         Int_t index;
         for (Int_t i = 0; i < fHitParams->GetEntries(); i++)
         {
-            par = (R3BTofdHitModulePar*)fHitParams->At(i);
+            par = dynamic_cast<R3BTofdHitModulePar*>(fHitParams->At(i));
             if (NULL == par)
             {
                 continue;
@@ -125,7 +125,7 @@ R3BTofdHitModulePar* R3BTofdHitPar::GetModuleParAt(Int_t plane, Int_t paddle)
         return NULL;
     }
     Int_t arind = fIndexMap[index];
-    R3BTofdHitModulePar* par = (R3BTofdHitModulePar*)fHitParams->At(arind);
+    R3BTofdHitModulePar* par = dynamic_cast<R3BTofdHitModulePar*>(fHitParams->At(arind));
     return par;
 }
 

--- a/tof/R3BTofdMapped2Cal.cxx
+++ b/tof/R3BTofdMapped2Cal.cxx
@@ -91,7 +91,7 @@ void R3BTofdMapped2Cal::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(ERROR, !rtdb, "FairRuntimeDb not found");
 
-    fTcalPar = (R3BTCalPar*)rtdb->getContainer("TofdTCalPar");
+    fTcalPar = dynamic_cast<R3BTCalPar*>(rtdb->getContainer("TofdTCalPar"));
     if (!fTcalPar)
     {
         R3BLOG(ERROR, "Could not get access to TofdTCalPar-Container.");

--- a/tof/R3BTofdMapped2CalPar.cxx
+++ b/tof/R3BTofdMapped2CalPar.cxx
@@ -81,7 +81,7 @@ InitStatus R3BTofdMapped2CalPar::Init()
 
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-    fCalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("TofdTCalPar");
+    fCalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("TofdTCalPar"));
     if (!fCalPar)
     {
         LOG(ERROR) << "R3BTofdMapped2CalPar::Init() Couldn't get handle on TofdTCalPar. ";

--- a/tof/R3BTofdMapped2TCal.cxx
+++ b/tof/R3BTofdMapped2TCal.cxx
@@ -83,10 +83,10 @@ InitStatus R3BTofdMapped2TCal::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     R3BLOG_IF(fatal, NULL == mgr, "FairRootManager not found");
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (header == nullptr)
     {
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
         R3BLOG(WARNING, "R3BEventHeader was found instead of EventHeader.");
     }
 
@@ -103,7 +103,7 @@ InitStatus R3BTofdMapped2TCal::Init()
 // Note that the container may still be empty at this point.
 void R3BTofdMapped2TCal::SetParContainers()
 {
-    fTcalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("TofdTCalPar");
+    fTcalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("TofdTCalPar"));
     if (!fTcalPar)
     {
         LOG(ERROR) << "Could not get access to TofdTCalPar-Container.";
@@ -127,7 +127,7 @@ void R3BTofdMapped2TCal::Exec(Option_t* option)
     Int_t nHits = fMappedItems->GetEntriesFast();
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        R3BTofdMappedData* hit = (R3BTofdMappedData*)fMappedItems->At(ihit);
+        R3BTofdMappedData* hit = dynamic_cast<R3BTofdMappedData*>(fMappedItems->At(ihit));
 
         Int_t iDetector = hit->GetDetector(); // 1..n
         Int_t iSide = hit->GetSide();         // 1/2
@@ -151,7 +151,7 @@ void R3BTofdMapped2TCal::Exec(Option_t* option)
         Int_t nCals = fCalItems->GetEntriesFast();
         for (Int_t ical = 0; ical < nCals; ical++)
         {
-            cal = (R3BTofdCalData*)fCalItems->At(ical);
+            cal = dynamic_cast<R3BTofdCalData*>(fCalItems->At(ical));
             if (cal->GetBar() != iBar)
             {
                 continue;

--- a/tof/R3BTofdMapped2TCalPar.cxx
+++ b/tof/R3BTofdMapped2TCalPar.cxx
@@ -101,7 +101,7 @@ InitStatus R3BTofdMapped2TCalPar::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rm->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("R3BEventHeader"));
     // may be = NULL!
 
     fMapped = (TClonesArray*)rm->GetObject("TofdMapped");
@@ -112,7 +112,7 @@ InitStatus R3BTofdMapped2TCalPar::Init()
 
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-    fCal_Par = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("TofdTCalPar");
+    fCal_Par = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("TofdTCalPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BTofdMapped2TCalPar::Init() Couldn't get handle on TofdTCalPar. ";
@@ -143,7 +143,7 @@ void R3BTofdMapped2TCalPar::Exec(Option_t* option)
     // Loop over mapped hits
     for (Int_t i = 0; i < nHits; i++)
     {
-        R3BTofdMappedData* hit = (R3BTofdMappedData*)fMapped->At(i);
+        R3BTofdMappedData* hit = dynamic_cast<R3BTofdMappedData*>(fMapped->At(i));
 
         Int_t iDetector = hit->GetDetector(); // 1..n
         Int_t iSide = hit->GetSide();         // 1/2

--- a/tof/calibration/R3BPtofCal2Hit.cxx
+++ b/tof/calibration/R3BPtofCal2Hit.cxx
@@ -84,7 +84,7 @@ InitStatus R3BPtofCal2Hit::Init()
 
 void R3BPtofCal2Hit::SetParContainers()
 {
-    fHitPar = (R3BPtofHitPar*)FairRuntimeDb::instance()->getContainer("PtofHitPar");
+    fHitPar = dynamic_cast<R3BPtofHitPar*>(FairRuntimeDb::instance()->getContainer("PtofHitPar"));
     ;
 }
 
@@ -141,7 +141,7 @@ void R3BPtofCal2Hit::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nItems; i++)
     {
-        R3BPaddleCalData* caldata = (R3BPaddleCalData*)fCalItems->At(i);
+        R3BPaddleCalData* caldata = dynamic_cast<R3BPaddleCalData*>(fCalItems->At(i));
         Int_t iPlane = caldata->GetPlane() - 1;
         Int_t iBar = caldata->GetBar() - 1;
         assert(iBar >= 0 && iBar < PtofPaddlesPerPlane);

--- a/tof/calibration/R3BPtofCal2HitPar.cxx
+++ b/tof/calibration/R3BPtofCal2HitPar.cxx
@@ -75,7 +75,7 @@ InitStatus R3BPtofCal2HitPar::Init()
         return kFATAL;
     }
 
-    fPar = (R3BPtofHitPar*)FairRuntimeDb::instance()->getContainer("PtofHitPar");
+    fPar = dynamic_cast<R3BPtofHitPar*>(FairRuntimeDb::instance()->getContainer("PtofHitPar"));
     if (NULL == fPar)
     {
         LOG(fatal) << "PtofHitPar not found!";
@@ -101,7 +101,7 @@ void R3BPtofCal2HitPar::Exec(Option_t* option)
     Int_t nData = fCalData->GetEntriesFast();
     for (Int_t i = 0; i < nData; i++)
     {
-        R3BPaddleCalData* cdata = (R3BPaddleCalData*)fCalData->At(i);
+        R3BPaddleCalData* cdata = dynamic_cast<R3BPaddleCalData*>(fCalData->At(i));
 
         Int_t id = (cdata->GetPlane() - 1) * PtofPaddlesPerPlane + cdata->GetBar() - 1;
 

--- a/tofd/calibration/R3BTofDCal2Hit.cxx
+++ b/tofd/calibration/R3BTofDCal2Hit.cxx
@@ -154,10 +154,10 @@ R3BTofDCal2Hit::~R3BTofDCal2Hit()
 
 void R3BTofDCal2Hit::SetParContainers()
 {
-    fMapPar = (R3BTofDMappingPar*)FairRuntimeDb::instance()->getContainer("tofdMappingPar");
+    fMapPar = dynamic_cast<R3BTofDMappingPar*>(FairRuntimeDb::instance()->getContainer("tofdMappingPar"));
     R3BLOG_IF(WARNING, !fMapPar, "Could not get access to tofdMappingPar container");
 
-    fHitPar = (R3BTofDHitPar*)FairRuntimeDb::instance()->getContainer("tofdHitPar");
+    fHitPar = dynamic_cast<R3BTofDHitPar*>(FairRuntimeDb::instance()->getContainer("tofdHitPar"));
     if (!fHitPar)
     {
         R3BLOG(ERROR, "Could not get access to tofdHitPar container");
@@ -190,7 +190,7 @@ InitStatus R3BTofDCal2Hit::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     R3BLOG_IF(fatal, NULL == header, "EventHeader. not found");
 
     fCalItems = (TClonesArray*)mgr->GetObject("TofdCal");
@@ -316,7 +316,7 @@ void R3BTofDCal2Hit::Exec(Option_t* option)
     // puts("Event");
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        auto* hit = (R3BTofdCalData*)fCalItems->At(ihit);
+        auto* hit = dynamic_cast<R3BTofdCalData*>(fCalItems->At(ihit));
         size_t idx = (hit->GetDetectorId() - 1) * fPaddlesPerPlane + (hit->GetBarId() - 1);
 
         // std::cout << "Hits: " << hit->GetDetectorId() << ' ' << hit->GetBarId() << ' ' << hit->GetSideId() << '  '

--- a/tofd/calibration/R3BTofDMapped2Cal.cxx
+++ b/tofd/calibration/R3BTofDMapped2Cal.cxx
@@ -80,10 +80,10 @@ void R3BTofDMapped2Cal::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(ERROR, !rtdb, "FairRuntimeDb not found");
 
-    fMapPar = (R3BTofDMappingPar*)FairRuntimeDb::instance()->getContainer("tofdMappingPar");
+    fMapPar = dynamic_cast<R3BTofDMappingPar*>(FairRuntimeDb::instance()->getContainer("tofdMappingPar"));
     R3BLOG_IF(WARNING, !fMapPar, "Could not get access to tofdMappingPar container");
 
-    fTcalPar = (R3BTCalPar*)rtdb->getContainer("TofdTCalPar");
+    fTcalPar = dynamic_cast<R3BTCalPar*>(rtdb->getContainer("TofdTCalPar"));
     if (!fTcalPar)
     {
         R3BLOG(ERROR, "Could not get access to TofdTCalPar-Container.");

--- a/tofd/digi/R3BTofDDigitizer.cxx
+++ b/tofd/digi/R3BTofDDigitizer.cxx
@@ -104,7 +104,7 @@ void R3BTofDDigitizer::Exec(Option_t* opt)
 
     for (Int_t entry = 0; entry < n_entries; entry++)
     {
-        auto data_element = (R3BTofdPoint*)fTofdPoints->At(entry);
+        auto data_element = dynamic_cast<R3BTofdPoint*>(fTofdPoints->At(entry));
         Int_t planeID = data_element->GetPlane() - 1;
         Int_t paddleID = data_element->GetPaddle() - 1;
         Double_t energy_loss = data_element->GetEnergyLoss();

--- a/tofd/digi/R3BTofDDigitizerCal.cxx
+++ b/tofd/digi/R3BTofDDigitizerCal.cxx
@@ -113,7 +113,7 @@ void R3BTofDDigitizerCal::Exec(Option_t* opt)
         std::vector<TempHit> TempHits;
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BTofdPoint* data_element = (R3BTofdPoint*)Points->At(i);
+            R3BTofdPoint* data_element = dynamic_cast<R3BTofdPoint*>(Points->At(i));
             // Plane and paddle data members in 1-base
             auto channel = (data_element->GetPlane() - 1) * number_paddles + data_element->GetPaddle() - 1;
             TempHits.push_back(TempHit(channel, // channel nummer

--- a/tofd/online/R3BTofDOnlineSpectra.cxx
+++ b/tofd/online/R3BTofDOnlineSpectra.cxx
@@ -96,7 +96,7 @@ R3BTofDOnlineSpectra::~R3BTofDOnlineSpectra()
 
 void R3BTofDOnlineSpectra::SetParContainers()
 {
-    fMapPar = (R3BTofDMappingPar*)FairRuntimeDb::instance()->getContainer("tofdMappingPar");
+    fMapPar = dynamic_cast<R3BTofDMappingPar*>(FairRuntimeDb::instance()->getContainer("tofdMappingPar"));
     R3BLOG_IF(WARNING, !fMapPar, "Could not get access to tofdMappingPar container");
     return;
 }
@@ -119,11 +119,11 @@ InitStatus R3BTofDOnlineSpectra::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     R3BLOG_IF(FATAL, NULL == mgr, "FairRootManager not found");
 
-    header = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!header)
     {
         R3BLOG(WARNING, "EventHeader. not found");
-        header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     }
     else
         R3BLOG(INFO, "EventHeader. found");
@@ -680,7 +680,7 @@ void R3BTofDOnlineSpectra::Exec(Option_t* option)
 
         for (Int_t imapped = 0; imapped < nMapped; imapped++)
         {
-            auto mapped = (R3BTofdMappedData*)fMappedItems->At(imapped);
+            auto mapped = dynamic_cast<R3BTofdMappedData*>(fMappedItems->At(imapped));
             if (!mapped)
                 continue; // should not happen
 
@@ -728,12 +728,12 @@ void R3BTofDOnlineSpectra::Exec(Option_t* option)
         Float_t losTriggerTime=0.0;
 
         if(fLosCalDataItems && fLosCalDataItems->GetEntriesFast()>0){R3BLosCalData* losHit =
-       (R3BLosCalData*)fLosCalDataItems->At(0); Int_t losChannel = losHit->GetDetector();
+       dynamic_cast<R3BLosCalData*>(fLosCalDataItems->At(0); Int_t losChannel = losHit->GetDetector());
        // std::cout<<"LOS Time : "<<losHit->GetTimeT_ns(losChannel)<<std::endl;
         losTime = losHit->GetTimeV_ns(losChannel);}
 
         if(fLosTriggerCalDataItems && fLosTriggerCalDataItems->GetEntriesFast()>0){R3BLosCalData* losTriggerHit =
-       (R3BLosCalData*)fLosTriggerCalDataItems->At(0); Int_t losChannelTrigger = losTriggerHit->GetDetector();
+       dynamic_cast<R3BLosCalData*>(fLosTriggerCalDataItems->At(0); Int_t losChannelTrigger = losTriggerHit->GetDetector());
         //std::cout<<"LOS Time (Trigger) :
        "<<losTriggerHit->Ge(losHit->GetTime()-losCalTriggerHits->GetTimeL_ns(channelLos)tTimeL_ns(0)<<"
        "<<losChannelTrigger<<std::endl; losTriggerTime = losTriggerHit->GetTimeL_ns(0);}
@@ -775,7 +775,7 @@ void R3BTofDOnlineSpectra::Exec(Option_t* option)
         //   puts("Event");
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto* hit = (R3BTofdCalData*)fCalItems->At(ihit);
+            auto* hit = dynamic_cast<R3BTofdCalData*>(fCalItems->At(ihit));
             size_t idx = (hit->GetDetectorId() - 1) * fPaddlesPerPlane + hit->GetBarId() - 1;
 
             auto ret = bar_map.insert(std::pair<size_t, Entry>(idx, Entry()));
@@ -789,7 +789,7 @@ void R3BTofDOnlineSpectra::Exec(Option_t* option)
         std::vector<R3BTofdCalData*> trig_map;
         for (int i = 0; i < fCalTriggerItems->GetEntries(); ++i)
         {
-            auto trig = (R3BTofdCalData*)fCalTriggerItems->At(i);
+            auto trig = dynamic_cast<R3BTofdCalData*>(fCalTriggerItems->At(i));
             if (trig_map.size() < trig->GetBarId())
             {
                 trig_map.resize(trig->GetBarId());
@@ -1066,7 +1066,7 @@ void R3BTofDOnlineSpectra::Exec(Option_t* option)
 
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            auto hitTofd = (R3BTofdHitData*)fHitItems->At(ihit);
+            auto hitTofd = dynamic_cast<R3BTofdHitData*>(fHitItems->At(ihit));
             if (IS_NAN(hitTofd->GetTime()))
                 continue;
             Int_t iPlane = hitTofd->GetDetId();

--- a/tofd/pars/R3BTofDCal2HitPar.cxx
+++ b/tofd/pars/R3BTofDCal2HitPar.cxx
@@ -146,7 +146,7 @@ InitStatus R3BTofDCal2HitPar::Init()
         return kFATAL;
     }
 
-    fHeader = (R3BEventHeader*)rm->GetObject("EventHeader.");
+    fHeader = dynamic_cast<R3BEventHeader*>(rm->GetObject("EventHeader."));
     R3BLOG_IF(fatal, NULL == fHeader, "EventHeader. not found");
 
     fCalData = (TClonesArray*)rm->GetObject("TofdCal");
@@ -155,7 +155,7 @@ InitStatus R3BTofDCal2HitPar::Init()
     fCalTriggerItems = (TClonesArray*)rm->GetObject("TofdTriggerCal");
     R3BLOG_IF(fatal, NULL == fCalTriggerItems, "TofdTriggerCal not found");
 
-    fHitPar = (R3BTofDHitPar*)FairRuntimeDb::instance()->getContainer("tofdHitPar");
+    fHitPar = dynamic_cast<R3BTofDHitPar*>(FairRuntimeDb::instance()->getContainer("tofdHitPar"));
     if (!fHitPar)
     {
         R3BLOG(ERROR, "Could not get access to tofdHitPar container");
@@ -174,7 +174,7 @@ InitStatus R3BTofDCal2HitPar::Init()
 
 void R3BTofDCal2HitPar::SetParContainers()
 {
-    fMapPar = (R3BTofDMappingPar*)FairRuntimeDb::instance()->getContainer("tofdMappingPar");
+    fMapPar = dynamic_cast<R3BTofDMappingPar*>(FairRuntimeDb::instance()->getContainer("tofdMappingPar"));
     R3BLOG_IF(WARNING, !fMapPar, "Could not get access to tofdMappingPar container");
 }
 
@@ -215,7 +215,7 @@ void R3BTofDCal2HitPar::Exec(Option_t* option)
     std::map<size_t, Entry> bar_map;
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        auto* hit = (R3BTofdCalData*)fCalData->At(ihit);
+        auto* hit = dynamic_cast<R3BTofdCalData*>(fCalData->At(ihit));
         size_t idx = (hit->GetDetectorId() - 1) * fPaddlesPerPlane + (hit->GetBarId() - 1);
         auto ret = bar_map.insert(std::pair<size_t, Entry>(idx, Entry()));
         auto& vec = 1 == hit->GetSideId() ? ret.first->second.top : ret.first->second.bot;

--- a/tofd/pars/R3BTofDHitPar.cxx
+++ b/tofd/pars/R3BTofDHitPar.cxx
@@ -76,7 +76,7 @@ void R3BTofDHitPar::printParams()
     R3BLOG(INFO, "Number of HIT Parameters " << fHitParams->GetEntries());
     for (Int_t i = 0; i < fHitParams->GetEntries(); i++)
     {
-        R3BTofDHitModulePar* t_par = (R3BTofDHitModulePar*)fHitParams->At(i);
+        R3BTofDHitModulePar* t_par = dynamic_cast<R3BTofDHitModulePar*>(fHitParams->At(i));
         LOG(INFO) << "-------------------------------------------------------";
         if (t_par)
         {
@@ -96,7 +96,7 @@ R3BTofDHitModulePar* R3BTofDHitPar::GetModuleParAt(Int_t plane, Int_t paddle)
         Int_t index;
         for (Int_t i = 0; i < fHitParams->GetEntries(); i++)
         {
-            par = (R3BTofDHitModulePar*)fHitParams->At(i);
+            par = dynamic_cast<R3BTofDHitModulePar*>(fHitParams->At(i));
             if (NULL == par)
             {
                 continue;
@@ -132,7 +132,7 @@ R3BTofDHitModulePar* R3BTofDHitPar::GetModuleParAt(Int_t plane, Int_t paddle)
         return NULL;
     }
     Int_t arind = fIndexMap[index];
-    R3BTofDHitModulePar* par = (R3BTofDHitModulePar*)fHitParams->At(arind);
+    R3BTofDHitModulePar* par = dynamic_cast<R3BTofDHitModulePar*>(fHitParams->At(arind));
     return par;
 }
 

--- a/tofd/pars/R3BTofDMapped2CalPar.cxx
+++ b/tofd/pars/R3BTofDMapped2CalPar.cxx
@@ -78,7 +78,7 @@ InitStatus R3BTofDMapped2CalPar::Init()
         fMappedTrigger = NULL;
     }
 
-    fCalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("TofdTCalPar");
+    fCalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("TofdTCalPar"));
     if (!fCalPar)
     {
         R3BLOG(ERROR, "Couldn't get handle on TofdTCalPar. ");

--- a/tofd/sim/R3BTofD.cxx
+++ b/tofd/sim/R3BTofD.cxx
@@ -201,7 +201,7 @@ Bool_t R3BTofD::ProcessHits(FairVolume* vol)
                fA_in);
 
         // Increment number of TofdPoints for this track
-        auto stack = (R3BStack*)gMC->GetStack();
+        auto stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kTOFD);
 
         ResetParameters();
@@ -264,7 +264,7 @@ void R3BTofD::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BTofdPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BTofdPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BTofdPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BTofdPoint(*oldpoint);

--- a/tofi/calibration/R3BTofiCal2Histo.cxx
+++ b/tofi/calibration/R3BTofiCal2Histo.cxx
@@ -165,7 +165,7 @@ InitStatus R3BTofiCal2Histo::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rm->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("R3BEventHeader"));
     // may be = NULL!
 
     fCalData = (TClonesArray*)rm->GetObject("TofiCal");
@@ -194,7 +194,7 @@ void R3BTofiCal2Histo::SetParContainers()
 {
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-    fCal_Par = (R3BTofiHitPar*)FairRuntimeDb::instance()->getContainer("TofiHitPar");
+    fCal_Par = dynamic_cast<R3BTofiHitPar*>(FairRuntimeDb::instance()->getContainer("TofiHitPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BTofiCal2Histo::Init() Couldn't get handle on TofiHitPar. ";
@@ -240,7 +240,7 @@ void R3BTofiCal2Histo::Exec(Option_t* option)
     std::map<size_t, Entry> bar_map;
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        auto* hit = (R3BTofiCalData*)fCalData->At(ihit);
+        auto* hit = dynamic_cast<R3BTofiCalData*>(fCalData->At(ihit));
         size_t idx = hit->GetDetectorId() * fPaddlesPerPlane * hit->GetBarId();
         // std::cout << "Hits: " << hit->GetDetectorId() << ' ' << hit->GetBarId() << ' ' << hit->GetSideId() << ' '
         //          << hit->GetTimeLeading_ns() << ' ' << hit->GetTimeTrailing_ns() << '\n';

--- a/tofi/calibration/R3BTofiCal2HitS494.cxx
+++ b/tofi/calibration/R3BTofiCal2HitS494.cxx
@@ -204,7 +204,7 @@ R3BTofiCal2HitS494::~R3BTofiCal2HitS494()
 
 InitStatus R3BTofiCal2HitS494::Init()
 {
-    fHitPar = (R3BTofiHitPar*)FairRuntimeDb::instance()->getContainer("TofiHitPar");
+    fHitPar = dynamic_cast<R3BTofiHitPar*>(FairRuntimeDb::instance()->getContainer("TofiHitPar"));
     if (!fHitPar)
     {
         LOG(ERROR) << "Could not get access to TofiHitPar-Container.";
@@ -222,7 +222,7 @@ InitStatus R3BTofiCal2HitS494::Init()
     FairRootManager* mgr = FairRootManager::Instance();
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
-    header = (R3BEventHeader*)mgr->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("R3BEventHeader"));
     fCalItems = (TClonesArray*)mgr->GetObject("TofiCal");
     if (NULL == fCalItems)
         LOG(fatal) << "Branch TofiCal not found";
@@ -245,7 +245,7 @@ InitStatus R3BTofiCal2HitS494::Init()
 // Note that the container may still be empty at this point.
 void R3BTofiCal2HitS494::SetParContainers()
 {
-    fHitPar = (R3BTofiHitPar*)FairRuntimeDb::instance()->getContainer("TofiHitPar");
+    fHitPar = dynamic_cast<R3BTofiHitPar*>(FairRuntimeDb::instance()->getContainer("TofiHitPar"));
     if (!fHitPar)
     {
         LOG(ERROR) << "Could not get access to TofiHitPar-Container.";
@@ -341,7 +341,7 @@ void R3BTofiCal2HitS494::Exec(Option_t* option)
     // puts("Event");
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
-        auto* hit = (R3BTofiCalData*)fCalItems->At(ihit);
+        auto* hit = dynamic_cast<R3BTofiCalData*>(fCalItems->At(ihit));
         size_t idx = hit->GetDetectorId() * fPaddlesPerPlane * hit->GetBarId();
         /*
                 std::cout << "Hits: " << hit->GetDetectorId() << ' ' << hit->GetBarId() << ' ' << hit->GetSideId() << '

--- a/tofi/calibration/R3BTofiMapped2Cal.cxx
+++ b/tofi/calibration/R3BTofiMapped2Cal.cxx
@@ -132,7 +132,7 @@ InitStatus R3BTofiMapped2Cal::Init()
 // Note that the container may still be empty at this point.
 void R3BTofiMapped2Cal::SetParContainers()
 {
-    fTcalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("TofiTCalPar");
+    fTcalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("TofiTCalPar"));
     if (!fTcalPar)
     {
         LOG(ERROR) << "Could not get access to TofiTCalPar-Container.";

--- a/tofi/calibration/R3BTofiMapped2CalPar.cxx
+++ b/tofi/calibration/R3BTofiMapped2CalPar.cxx
@@ -81,7 +81,7 @@ InitStatus R3BTofiMapped2CalPar::Init()
 
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-    fCalPar = (R3BTCalPar*)FairRuntimeDb::instance()->getContainer("TofiTCalPar");
+    fCalPar = dynamic_cast<R3BTCalPar*>(FairRuntimeDb::instance()->getContainer("TofiTCalPar"));
     if (!fCalPar)
     {
         LOG(ERROR) << "R3BTofiMapped2CalPar::Init() Couldn't get handle on TofiTCalPar. ";

--- a/tofi/digi/R3BTofiDigitizerCal.cxx
+++ b/tofi/digi/R3BTofiDigitizerCal.cxx
@@ -142,7 +142,7 @@ void R3BTofiDigitizerCal::Exec(Option_t* opt)
 
         for (Int_t i = 0; i < entryNum; ++i)
         {
-            R3BTofiPoint* data_element = (R3BTofiPoint*)Points->At(i);
+            R3BTofiPoint* data_element = dynamic_cast<R3BTofiPoint*>(Points->At(i));
 
             TempHits.push_back(TempHit(data_element->GetDetectorID(), // channel nummer
                                        data_element->GetEnergyLoss(),

--- a/tofi/pars/R3BTofiChangePar.cxx
+++ b/tofi/pars/R3BTofiChangePar.cxx
@@ -114,7 +114,7 @@ void R3BTofiChangePar::SetParContainers()
 {
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-    fCal_Par = (R3BTofiHitPar*)FairRuntimeDb::instance()->getContainer("TofiHitPar");
+    fCal_Par = dynamic_cast<R3BTofiHitPar*>(FairRuntimeDb::instance()->getContainer("TofiHitPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BTofiChangePar::Init() Couldn't get handle on TofiHitPar. ";
@@ -188,7 +188,7 @@ void R3BTofiChangePar::FinishTask()
 void R3BTofiChangePar::changeAll0(Int_t plane, Int_t bar, Int_t pm, Double_t* pars)
 {
     auto container = "TofiHitPar";
-    fCal_Par = (R3BTofiHitPar*)FairRuntimeDb::instance()->getContainer(container);
+    fCal_Par = dynamic_cast<R3BTofiHitPar*>(FairRuntimeDb::instance()->getContainer(container));
     if (!fCal_Par)
     {
         R3BTofiHitModulePar* mpar;

--- a/tofi/pars/R3BTofiContFact.cxx
+++ b/tofi/pars/R3BTofiContFact.cxx
@@ -106,11 +106,11 @@ void R3BTofiContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BTofiParRootFileIo* p=new R3BTofiParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BTofiParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BTofiParAsciiFileIo* p=new R3BTofiParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BTofiParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/tofi/pars/R3BTofiHisto2HitPar.cxx
+++ b/tofi/pars/R3BTofiHisto2HitPar.cxx
@@ -121,7 +121,7 @@ InitStatus R3BTofiHisto2HitPar::Init()
     {
         return kFATAL;
     }
-    header = (R3BEventHeader*)rm->GetObject("R3BEventHeader");
+    header = dynamic_cast<R3BEventHeader*>(rm->GetObject("R3BEventHeader"));
     // may be = NULL!
     fCalData = (TClonesArray*)rm->GetObject("TofiCal");
     if (!fCalData)
@@ -150,7 +150,7 @@ void R3BTofiHisto2HitPar::SetParContainers()
 {
     // container needs to be created in tcal/R3BTCalContFact.cxx AND R3BTCal needs
     // to be set as dependency in CMakelists.txt (in this case in the tof directory)
-    fCal_Par = (R3BTofiHitPar*)FairRuntimeDb::instance()->getContainer("TofiHitPar");
+    fCal_Par = dynamic_cast<R3BTofiHitPar*>(FairRuntimeDb::instance()->getContainer("TofiHitPar"));
     if (!fCal_Par)
     {
         LOG(ERROR) << "R3BTofiHisto2HitPar::Init() Couldn't get handle on TofiHitPar. ";

--- a/tofi/pars/R3BTofiHitPar.cxx
+++ b/tofi/pars/R3BTofiHitPar.cxx
@@ -67,7 +67,7 @@ void R3BTofiHitPar::printParams()
     LOG(INFO) << " Number of HIT Parameters " << fHitParams->GetEntries();
     for (Int_t i = 0; i < fHitParams->GetEntries(); i++)
     {
-        R3BTofiHitModulePar* t_par = (R3BTofiHitModulePar*)fHitParams->At(i);
+        R3BTofiHitModulePar* t_par = dynamic_cast<R3BTofiHitModulePar*>(fHitParams->At(i));
         LOG(INFO) << "----------------------------------------------------------------------";
         if (t_par)
         {
@@ -87,7 +87,7 @@ R3BTofiHitModulePar* R3BTofiHitPar::GetModuleParAt(Int_t plane, Int_t paddle)
         Int_t index;
         for (Int_t i = 0; i < fHitParams->GetEntries(); i++)
         {
-            par = (R3BTofiHitModulePar*)fHitParams->At(i);
+            par = dynamic_cast<R3BTofiHitModulePar*>(fHitParams->At(i));
             if (NULL == par)
             {
                 continue;
@@ -125,7 +125,7 @@ R3BTofiHitModulePar* R3BTofiHitPar::GetModuleParAt(Int_t plane, Int_t paddle)
         return NULL;
     }
     Int_t arind = fIndexMap[index];
-    R3BTofiHitModulePar* par = (R3BTofiHitModulePar*)fHitParams->At(arind);
+    R3BTofiHitModulePar* par = dynamic_cast<R3BTofiHitModulePar*>(fHitParams->At(arind));
     return par;
 }
 

--- a/tofi/sim/R3BTofi.cxx
+++ b/tofi/sim/R3BTofi.cxx
@@ -210,7 +210,7 @@ Bool_t R3BTofi::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of TofiPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kTOFI);
 
         ResetParameters();
@@ -294,7 +294,7 @@ void R3BTofi::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BTofiPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BTofiPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BTofiPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BTofiPoint(*oldpoint);

--- a/tracking/CMakeLists.txt
+++ b/tracking/CMakeLists.txt
@@ -66,7 +66,7 @@ CHANGE_FILE_EXTENSION(*.cxx *.h HEADERS "${SRCS}")
 Set(LINKDEF TrackingLinkDef.h)
 Set(LIBRARY_NAME R3BTracking)
 Set(DEPENDENCIES
-  Base ParBase TrkBase R3BBase Minuit)
+  Base ParBase TrkBase R3BBase Minuit Field)
 
 GENERATE_LIBRARY()
 

--- a/tracking/R3BFragmentTracker.cxx
+++ b/tracking/R3BFragmentTracker.cxx
@@ -174,7 +174,7 @@ InitStatus R3BFragmentTracker::ReInit()
 
 void R3BFragmentTracker::SetParContainers()
 {
-    fFieldPar = (R3BFieldPar*)FairRuntimeDb::instance()->getContainer("R3BFieldPar");
+    fFieldPar = dynamic_cast<R3BFieldPar*>(FairRuntimeDb::instance()->getContainer("R3BFieldPar"));
 
     fDetectors->SetParContainers();
 }
@@ -216,7 +216,7 @@ void R3BFragmentTracker::Exec(const Option_t*)
 
     // fetch start pos, default momentum and charge from the simulation
     // (just for this test!)
-    R3BMCTrack* ion = (R3BMCTrack*)fArrayMCTracks->At(0);
+    R3BMCTrack* ion = dynamic_cast<R3BMCTrack*>(fArrayMCTracks->At(0));
     // Check if primary
     if (ion->GetMotherId() != -1)
     {
@@ -621,7 +621,7 @@ Bool_t R3BFragmentTracker::InitPropagator()
     fFieldPar->printParams();
     if (2 == fFieldPar->GetType())
     {
-        gladField = (R3BGladFieldMap*)fairField;
+        gladField = dynamic_cast<R3BGladFieldMap*>(fairField);
 
         if (fPropagator)
         {

--- a/tracking/R3BTrackingDetector.cxx
+++ b/tracking/R3BTrackingDetector.cxx
@@ -103,7 +103,7 @@ void R3BTrackingDetector::CopyHits()
     hits.clear();
     for (Int_t i = 0; i < fArrayHits->GetEntriesFast(); i++)
     {
-        R3BHit* hit = (R3BHit*)fArrayHits->At(i);
+        R3BHit* hit = dynamic_cast<R3BHit*>(fArrayHits->At(i));
         hit->SetHitId(i);
         hits.push_back(hit);
     }
@@ -178,7 +178,7 @@ Double_t R3BTrackingDetector::GetEnergyLoss(const R3BTrackingParticle* particle)
 void R3BTrackingDetector::SetParContainers()
 {
     // fetch geometry and position of detector
-    fGeo = (R3BTGeoPar*)FairRuntimeDb::instance()->getContainer(fGeoParName);
+    fGeo = dynamic_cast<R3BTGeoPar*>(FairRuntimeDb::instance()->getContainer(fGeoParName));
 }
 
 void R3BTrackingDetector::Draw(Option_t*)

--- a/tracking/R3BTrackingS515.cxx
+++ b/tracking/R3BTrackingS515.cxx
@@ -99,7 +99,7 @@ InitStatus R3BTrackingS515::Init()
     if (NULL == mgr)
         LOG(fatal) << "FairRootManager not found";
 
-    fHeader = (R3BEventHeader*)mgr->GetObject("EventHeader.");
+    fHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
     if (!fHeader)
     {
         LOG(WARNING) << "R3BTrackingS515::Init() EventHeader. not found";
@@ -179,17 +179,17 @@ void R3BTrackingS515::Exec(Option_t* option)
 
     // Get hit data from every upstream detector
     // (for now using only one/first hit)
-    auto los_data = (R3BLosHitData*)los_DataItems->At(0);
+    auto los_data = dynamic_cast<R3BLosHitData*>(los_DataItems->At(0));
 
-    auto frs_data = (R3BFrsData*)frs_DataItems->At(0);
+    auto frs_data = dynamic_cast<R3BFrsData*>(frs_DataItems->At(0));
     if( !IsInsideFrsEllipticPIDCut(frs_data->GetZ(), frs_data->GetAq()))
         return;
 
-    auto music_hit = (R3BMusicHitData*)music_DataItems->At(0);
+    auto music_hit = dynamic_cast<R3BMusicHitData*>(music_DataItems->At(0));
     if(music_hit->GetZcharge() < MusicZMin || music_hit->GetZcharge() > MusicZMax)
         return;
 
-    auto mwpc_hit = (R3BMwpcHitData*)mwpc_DataItems->At(0);
+    auto mwpc_hit = dynamic_cast<R3BMwpcHitData*>(mwpc_DataItems->At(0));
 
     // Reading fiber detectors (using only highest energy hit)
     R3BBunchedFiberHitData *f10_hit, *f11_hit, *f12_hit, *this_hit;
@@ -200,13 +200,13 @@ void R3BTrackingS515::Exec(Option_t* option)
         energy=0;
         for(auto i=0; i<fDataItems.at(f)->GetEntriesFast(); ++i)
         {
-            this_hit = (R3BBunchedFiberHitData*)fDataItems.at(f)->At(i);
+            this_hit = dynamic_cast<R3BBunchedFiberHitData*>(fDataItems.at(f)->At(i));
             if(this_hit->GetEloss()>FiberEnergyMin && this_hit->GetEloss()<FiberEnergyMax
                     && this_hit->GetEloss()>energy)
             {
-                if(f==DET_FI10){ f10_hit = (R3BBunchedFiberHitData*)fDataItems.at(f)->At(i); }
-                else if(f==DET_FI11){ f11_hit = (R3BBunchedFiberHitData*)fDataItems.at(f)->At(i); } 
-                else if(f==DET_FI12){ f12_hit = (R3BBunchedFiberHitData*)fDataItems.at(f)->At(i); }
+                if(f==DET_FI10){ f10_hit = dynamic_cast<R3BBunchedFiberHitData*>(fDataItems.at(f)->At(i)); }
+                else if(f==DET_FI11){ f11_hit = dynamic_cast<R3BBunchedFiberHitData*>(fDataItems.at(f)->At(i)); } 
+                else if(f==DET_FI12){ f12_hit = dynamic_cast<R3BBunchedFiberHitData*>(fDataItems.at(f)->At(i)); }
                 energy = this_hit->GetEloss();
             }
         }
@@ -219,7 +219,7 @@ void R3BTrackingS515::Exec(Option_t* option)
     bool is_good_tofd = false;
     for(auto i=0; i<tofd_DataItems->GetEntriesFast(); ++i)
     {
-        tofd_hit = (R3BTofdHitData*) tofd_DataItems->At(i);
+        tofd_hit = dynamic_cast<R3BTofdHitData*>( tofd_DataItems->At(i));
         if(tofd_hit->GetDetId()==1)//only hits from first plane
             is_good_tofd=true;
     }

--- a/twim/ana/R3BTwimVertexReconstruction.cxx
+++ b/twim/ana/R3BTwimVertexReconstruction.cxx
@@ -70,9 +70,9 @@ InitStatus R3BTwimVertexReconstruction::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rootManager->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)rootManager->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("R3BEventHeader"));
 
     // INPUT DATA
     // get access to cal data of the Twim
@@ -104,7 +104,7 @@ void R3BTwimVertexReconstruction::Exec(Option_t* option)
 
         for (Int_t i = 0; i < nHitTwim; i++)
         {
-            HitDat[i] = (R3BTwimHitData*)(fTwimHitDataCA->At(i));
+            HitDat[i] = dynamic_cast<R3BTwimHitData*>((fTwimHitDataCA->At(i)));
             trajparams[i].SetXYZ(HitDat[i]->GetSecID(), HitDat[i]->GetOffset(), HitDat[i]->GetTheta());
         }
 

--- a/twim/calibration/R3BTwimCal2Hit.cxx
+++ b/twim/calibration/R3BTwimCal2Hit.cxx
@@ -90,7 +90,7 @@ void R3BTwimCal2Hit::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(ERROR, !rtdb, "FairRuntimeDb not found");
 
-    fCal_Par = (R3BTwimHitPar*)rtdb->getContainer("twimHitPar");
+    fCal_Par = dynamic_cast<R3BTwimHitPar*>(rtdb->getContainer("twimHitPar"));
     if (!fCal_Par)
     {
         R3BLOG(ERROR, "Couldn't get handle on twimHitPar container");
@@ -216,9 +216,9 @@ InitStatus R3BTwimCal2Hit::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rootManager->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)rootManager->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("R3BEventHeader"));
     if (fExpId == 0) // Obtain global ExpId if it's not set locally.
     {
         fExpId = header->GetExpId();
@@ -371,7 +371,7 @@ void R3BTwimCal2Hit::S4551()
 
         for (Int_t i = 0; i < nHitTofW; i++)
         {
-            HitTofW[i] = (R3BSofTofWHitData*)(fHitItemsTofW->At(i));
+            HitTofW[i] = dynamic_cast<R3BSofTofWHitData*>((fHitItemsTofW->At(i)));
             if (i == 0)
             {
                 postof[0].SetXYZ(HitTofW[i]->GetPaddle(), HitTofW[i]->GetY(), HitTofW[i]->GetTof());
@@ -457,7 +457,7 @@ void R3BTwimCal2Hit::S4551()
 
         for (Int_t i = 0; i < nHitTwim; i++)
         {
-            CalDat[i] = (R3BTwimCalData*)(fTwimCalDataCA->At(i));
+            CalDat[i] = dynamic_cast<R3BTwimCalData*>((fTwimCalDataCA->At(i)));
             secId = CalDat[i]->GetSecID() - 1;
             anodeId = CalDat[i]->GetAnodeID() - 1;
             if (energyperanode[secId][anodeId] == 0)
@@ -584,7 +584,7 @@ void R3BTwimCal2Hit::S455()
     // std::cout<<"Event " <<std::endl;
     for (Int_t i = 0; i < nHits; i++)
     {
-        CalDat[i] = (R3BTwimCalData*)(fTwimCalDataCA->At(i));
+        CalDat[i] = dynamic_cast<R3BTwimCalData*>((fTwimCalDataCA->At(i)));
         secId = CalDat[i]->GetSecID() - 1;
         anodeId = CalDat[i]->GetAnodeID() - 1;
         if (energyperanode[secId][anodeId] == 0)
@@ -604,7 +604,7 @@ void R3BTwimCal2Hit::S455()
         nHits = fHitItemsTofW->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BSofTofWHitData* hit = (R3BSofTofWHitData*)fHitItemsTofW->At(ihit);
+            R3BSofTofWHitData* hit = dynamic_cast<R3BSofTofWHitData*>(fHitItemsTofW->At(ihit));
             if (!hit)
                 continue;
             if (padid[0] == 0)
@@ -750,7 +750,7 @@ void R3BTwimCal2Hit::S467()
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        CalDat[i] = (R3BTwimCalData*)(fTwimCalDataCA->At(i));
+        CalDat[i] = dynamic_cast<R3BTwimCalData*>((fTwimCalDataCA->At(i)));
         secId = CalDat[i]->GetSecID() - 1;
         anodeId = CalDat[i]->GetAnodeID() - 1;
         energyperanode[secId][anodeId] = CalDat[i]->GetEnergy();

--- a/twim/calibration/R3BTwimMapped2Cal.cxx
+++ b/twim/calibration/R3BTwimMapped2Cal.cxx
@@ -83,7 +83,7 @@ void R3BTwimMapped2Cal::SetParContainers()
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
     R3BLOG_IF(FATAL, !rtdb, "FairRuntimeDb not found");
 
-    fCal_Par = (R3BTwimCalPar*)rtdb->getContainer("twimCalPar");
+    fCal_Par = dynamic_cast<R3BTwimCalPar*>(rtdb->getContainer("twimCalPar"));
     if (!fCal_Par)
     {
         R3BLOG(ERROR, "Couldn't get handle on twimCalPar container");
@@ -158,9 +158,9 @@ InitStatus R3BTwimMapped2Cal::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rootManager->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)rootManager->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("R3BEventHeader"));
     if (fExpId == 0) // Obtain global ExpId if it's not set locally.
     {
         fExpId = header->GetExpId();
@@ -225,7 +225,7 @@ void R3BTwimMapped2Cal::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BTwimMappedData*)(fTwimMappedDataCA->At(i));
+        mappedData[i] = dynamic_cast<R3BTwimMappedData*>((fTwimMappedDataCA->At(i)));
         secId = mappedData[i]->GetSecID() - 1;
         anodeId = mappedData[i]->GetAnodeID() - 1;
 

--- a/twim/calibration/R3BTwimMapped2CalPar.cxx
+++ b/twim/calibration/R3BTwimMapped2CalPar.cxx
@@ -90,9 +90,9 @@ InitStatus R3BTwimMapped2CalPar::Init()
         return kFATAL;
     }
 
-    header = (R3BEventHeader*)rootManager->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)rootManager->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("R3BEventHeader"));
     if (fExpId == 0) // Obtain global ExpId if it's not set locally.
     {
         fExpId = header->GetExpId();
@@ -127,7 +127,7 @@ InitStatus R3BTwimMapped2CalPar::Init()
         return kFATAL;
     }
 
-    fCal_Par = (R3BTwimCalPar*)rtdb->getContainer("twimCalPar");
+    fCal_Par = dynamic_cast<R3BTwimCalPar*>(rtdb->getContainer("twimCalPar"));
     if (!fCal_Par)
     {
         R3BLOG(ERROR, "Couldn't get handle on twimCalPar container");
@@ -187,14 +187,14 @@ void R3BTwimMapped2CalPar::Exec(Option_t* option)
     R3BMwpcHitData** hitMwAData = new R3BMwpcHitData*[nHitsA];
     for (Int_t i = 0; i < nHitsA; i++)
     {
-        hitMwAData[i] = (R3BMwpcHitData*)(fHitItemsMwpcA->At(i));
+        hitMwAData[i] = dynamic_cast<R3BMwpcHitData*>((fHitItemsMwpcA->At(i)));
         PosMwpcA.SetX(hitMwAData[i]->GetX());
         // R3BLOG(INFO,hitMwAData[i]->GetX());
     }
     R3BMwpcHitData** hitMwBData = new R3BMwpcHitData*[nHitsB];
     for (Int_t i = 0; i < nHitsB; i++)
     {
-        hitMwBData[i] = (R3BMwpcHitData*)(fHitItemsMwpcB->At(i));
+        hitMwBData[i] = dynamic_cast<R3BMwpcHitData*>((fHitItemsMwpcB->At(i)));
         PosMwpcB.SetX(hitMwBData[i]->GetX());
         // R3BLOG(INFO,hitMwBData[i]->GetX());
     }
@@ -216,7 +216,7 @@ void R3BTwimMapped2CalPar::Exec(Option_t* option)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        mappedData[i] = (R3BTwimMappedData*)(fTwimMappedDataCA->At(i));
+        mappedData[i] = dynamic_cast<R3BTwimMappedData*>((fTwimMappedDataCA->At(i)));
         secId = mappedData[i]->GetSecID() - 1;
         anodeId = mappedData[i]->GetAnodeID() - 1;
 

--- a/twim/digi/R3BTwimDigitizer.cxx
+++ b/twim/digi/R3BTwimDigitizer.cxx
@@ -107,10 +107,10 @@ void R3BTwimDigitizer::Exec(Option_t* opt)
 
     for (Int_t i = 0; i < nHits; i++)
     {
-        pointData[i] = (R3BTwimPoint*)(fTwimPoints->At(i));
+        pointData[i] = dynamic_cast<R3BTwimPoint*>((fTwimPoints->At(i)));
         TrackId = pointData[i]->GetTrackID();
 
-        auto Track = (R3BMCTrack*)fMCTrack->At(TrackId);
+        auto Track = dynamic_cast<R3BMCTrack*>(fMCTrack->At(TrackId));
         PID = Track->GetPdgCode();
 
         if (PID > 1000080160) // Z=8 and A=16

--- a/twim/online/R3BTwimOnlineSpectra.cxx
+++ b/twim/online/R3BTwimOnlineSpectra.cxx
@@ -86,9 +86,9 @@ InitStatus R3BTwimOnlineSpectra::Init()
     FairRunOnline* run = FairRunOnline::Instance();
     run->GetHttpServer()->Register("", this);
 
-    header = (R3BEventHeader*)rootManager->GetObject("EventHeader.");
+    header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("EventHeader."));
     if (!header)
-        header = (R3BEventHeader*)rootManager->GetObject("R3BEventHeader");
+        header = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("R3BEventHeader"));
     if (fExpId == 0) // Obtain global ExpId if it's not set locally.
     {
         fExpId = header->GetExpId();
@@ -985,7 +985,7 @@ void R3BTwimOnlineSpectra::s455()
         // std::cout << "Event:\n";
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BTwimMappedData* hit = (R3BTwimMappedData*)fMappedItemsTwim->At(ihit);
+            R3BTwimMappedData* hit = dynamic_cast<R3BTwimMappedData*>(fMappedItemsTwim->At(ihit));
             if (!hit)
                 continue;
             fh1_Twimmap_mult[hit->GetSecID() - 1]->Fill(hit->GetAnodeID());
@@ -1056,7 +1056,7 @@ void R3BTwimOnlineSpectra::s455()
         Int_t nHits = fCalItemsTwim->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BTwimCalData* hit = (R3BTwimCalData*)fCalItemsTwim->At(ihit);
+            R3BTwimCalData* hit = dynamic_cast<R3BTwimCalData*>(fCalItemsTwim->At(ihit));
             if (!hit)
                 continue;
             fh1_Twimcal_Pos[(hit->GetSecID() - 1) * fNbAnodes + (hit->GetAnodeID() - 1)]->Fill(hit->GetDTime());
@@ -1072,7 +1072,7 @@ void R3BTwimOnlineSpectra::s455()
         Int_t nHits = fHitItemsTofW->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BSofTofWHitData* hit = (R3BSofTofWHitData*)fHitItemsTofW->At(ihit);
+            R3BSofTofWHitData* hit = dynamic_cast<R3BSofTofWHitData*>(fHitItemsTofW->At(ihit));
             if (!hit)
                 continue;
             if (padid[0] == 0)
@@ -1106,7 +1106,7 @@ void R3BTwimOnlineSpectra::s455()
         Float_t zr[2] = { 0., 0. }, zl[2] = { 0., 0. };
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BTwimHitData* hit = (R3BTwimHitData*)fHitItemsTwim->At(ihit);
+            R3BTwimHitData* hit = dynamic_cast<R3BTwimHitData*>(fHitItemsTwim->At(ihit));
             if (!hit)
                 continue;
             // FIXME: this is defined only for the experiment 4-march-2021
@@ -1189,7 +1189,7 @@ void R3BTwimOnlineSpectra::s444_s467()
         // std::cout << "Event:\n";
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BTwimMappedData* hit = (R3BTwimMappedData*)fMappedItemsTwim->At(ihit);
+            R3BTwimMappedData* hit = dynamic_cast<R3BTwimMappedData*>(fMappedItemsTwim->At(ihit));
             if (!hit)
                 continue;
             fh1_Twimmap_mult[hit->GetSecID() - 1]->Fill(hit->GetAnodeID());
@@ -1265,7 +1265,7 @@ void R3BTwimOnlineSpectra::s444_s467()
         Int_t nHits = fCalItemsTwim->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BTwimCalData* hit = (R3BTwimCalData*)fCalItemsTwim->At(ihit);
+            R3BTwimCalData* hit = dynamic_cast<R3BTwimCalData*>(fCalItemsTwim->At(ihit));
             if (!hit)
                 continue;
             fh1_Twimcal_Pos[(hit->GetSecID() - 1) * fNbAnodes + (hit->GetAnodeID() - 1)]->Fill(hit->GetDTime());
@@ -1279,7 +1279,7 @@ void R3BTwimOnlineSpectra::s444_s467()
         Int_t nHits = fHitItemsMwpc3->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BMwpcHitData* hit = (R3BMwpcHitData*)fHitItemsMwpc3->At(ihit);
+            R3BMwpcHitData* hit = dynamic_cast<R3BMwpcHitData*>(fHitItemsMwpc3->At(ihit));
             if (!hit)
                 continue;
             mwpc3x = hit->GetX();
@@ -1292,7 +1292,7 @@ void R3BTwimOnlineSpectra::s444_s467()
         Int_t nHits = fHitItemsTwim->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BTwimHitData* hit = (R3BTwimHitData*)fHitItemsTwim->At(ihit);
+            R3BTwimHitData* hit = dynamic_cast<R3BTwimHitData*>(fHitItemsTwim->At(ihit));
             if (!hit)
                 continue;
             fh1_Twimhit_z->Fill(hit->GetZcharge());

--- a/twim/pars/R3BTwimGainMatching.cxx
+++ b/twim/pars/R3BTwimGainMatching.cxx
@@ -84,7 +84,7 @@ InitStatus R3BTwimGainMatching::Init()
         return kFATAL;
     }
 
-    fCal_Par = (R3BTwimCalPar*)rtdb->getContainer("twimCalPar");
+    fCal_Par = dynamic_cast<R3BTwimCalPar*>(rtdb->getContainer("twimCalPar"));
     if (!fCal_Par)
     {
         R3BLOG(FATAL, "Couldn't get handle on twimCalPar container");
@@ -136,7 +136,7 @@ void R3BTwimGainMatching::Exec(Option_t* option)
         // std::cout << "nHits = " << nHits << "\n";
         for (Int_t i = 0; i < nHits; i++)
         {
-            mappedData[i] = (R3BTwimMappedData*)(fTwimMappedDataCA->At(i));
+            mappedData[i] = dynamic_cast<R3BTwimMappedData*>((fTwimMappedDataCA->At(i)));
             secId = mappedData[i]->GetSecID() - 1;
             anodeId = mappedData[i]->GetAnodeID() - 1;
             if (multanode[secId][anodeId] == 0 && mappedData[i]->GetPileupStatus() == 0 &&

--- a/twim/sim/R3BTwim.cxx
+++ b/twim/sim/R3BTwim.cxx
@@ -135,7 +135,7 @@ Bool_t R3BTwim::ProcessHits(FairVolume* vol)
                      fELoss);
 
             // Increment number of SofTRIMPoints for this track
-            R3BStack* stack = (R3BStack*)gMC->GetStack();
+            R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
             stack->AddPoint(kSOFTWIM);
 
             ResetParameters();
@@ -190,7 +190,7 @@ void R3BTwim::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BTwimPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BTwimPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BTwimPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BTwimPoint(*oldpoint);

--- a/xball/R3BXBall.cxx
+++ b/xball/R3BXBall.cxx
@@ -210,7 +210,7 @@ Bool_t R3BXBall::ProcessHits(FairVolume* vol)
                    fELoss);
 
             // Increment number of XBallPoints for this track
-            R3BStack* stack = (R3BStack*)gMC->GetStack();
+            R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
             stack->AddPoint(kCAL);
         }
 
@@ -236,13 +236,13 @@ Bool_t R3BXBall::ProcessHits(FairVolume* vol)
             {
                 for (Int_t i = 0; i < nCrystalHits; i++)
                 {
-                    if (((R3BXBallCrystalHitSim*)(fXBallCrystalHitCollection->At(i)))->GetCrystalNumber() == copyNo)
+                    if (( dynamic_cast<R3BXBallCrystalHitSim*>((fXBallCrystalHitCollection->At(i)))->GetCrystalNumber() == copyNo))
                     {
-                        ((R3BXBallCrystalHitSim*)(fXBallCrystalHitCollection->At(i)))
+                        ( dynamic_cast<R3BXBallCrystalHitSim*>((fXBallCrystalHitCollection->At(i))))
                             ->AddMoreEnergy(NUSmearing(fELoss));
-                        if (((R3BXBallCrystalHitSim*)(fXBallCrystalHitCollection->At(i)))->GetTime() > fTime)
+                        if (( dynamic_cast<R3BXBallCrystalHitSim*>((fXBallCrystalHitCollection->At(i)))->GetTime() > fTime))
                         {
-                            ((R3BXBallCrystalHitSim*)(fXBallCrystalHitCollection->At(i)))->SetTime(fTime);
+                            (dynamic_cast<R3BXBallCrystalHitSim*>((fXBallCrystalHitCollection->At(i)))->SetTime(fTime));
                         }
                         existHit = 1; // to avoid the creation of a new CrystalHit
                         break;
@@ -449,7 +449,7 @@ void R3BXBall::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BXBallPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BXBallPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BXBallPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BXBallPoint(*oldpoint);

--- a/xball/R3BXBallContFact.cxx
+++ b/xball/R3BXBallContFact.cxx
@@ -92,11 +92,11 @@ void R3BXBallContFact::activateParIo(FairParIo* io)
     // needed by the Sts
     /*
     if (strcmp(io->IsA()->GetName(),"FairParRootFileIo")==0) {
-      R3BXBallParRootFileIo* p=new R3BXBallParRootFileIo(((FairParRootFileIo*)io)->getParRootFile());
+      auto p=new R3BXBallParRootFileIo(dynamic_cast<FairParRootFileIo*>(io)->getParRootFile());
       io->setDetParIo(p);
     }
     if (strcmp(io->IsA()->GetName(),"FairParAsciiFileIo")==0) {
-      R3BXBallParAsciiFileIo* p=new R3BXBallParAsciiFileIo(((FairParAsciiFileIo*)io)->getFile());
+      auto p=new R3BXBallParAsciiFileIo(dynamic_cast<FairParAsciiFileIo*>(io)->getFile());
       io->setDetParIo(p);
       }
     */

--- a/xball/R3BXBallv0.cxx
+++ b/xball/R3BXBallv0.cxx
@@ -207,7 +207,7 @@ Bool_t R3BXBallv0::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of XBallPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kCAL);
 
         ResetParameters();
@@ -273,7 +273,7 @@ void R3BXBallv0::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BXBallPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BXBallPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BXBallPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BXBallPoint(*oldpoint);

--- a/xball/R3BXBallv1.cxx
+++ b/xball/R3BXBallv1.cxx
@@ -210,7 +210,7 @@ Bool_t R3BXBallv1::ProcessHits(FairVolume* vol)
                fELoss);
 
         // Increment number of XBallPoints for this track
-        R3BStack* stack = (R3BStack*)gMC->GetStack();
+        R3BStack* stack = dynamic_cast<R3BStack*>(gMC->GetStack());
         stack->AddPoint(kCAL);
 
         ResetParameters();
@@ -275,7 +275,7 @@ void R3BXBallv1::CopyClones(TClonesArray* cl1, TClonesArray* cl2, Int_t offset)
     R3BXBallPoint* oldpoint = NULL;
     for (Int_t i = 0; i < nEntries; i++)
     {
-        oldpoint = (R3BXBallPoint*)cl1->At(i);
+        oldpoint = dynamic_cast<R3BXBallPoint*>(cl1->At(i));
         Int_t index = oldpoint->GetTrackID() + offset;
         oldpoint->SetTrackID(index);
         new (clref[fPosIndex]) R3BXBallPoint(*oldpoint);


### PR DESCRIPTION
Makes some progress to fixing some parts of #674. 

Also, fixed a casting bug which became visible in R3BFieldPar.

Also, I hereby pre-commit to not working with any version of R3BRoot which contains any C-style casts in C++ which were merged after 2022-12-14. 

This code will fail in CI because of clang-format. I will rebase it when #724 is resolved. 

@YanzhaoW could you look over my changes? My regex was not clever enough to know operator precedence, so in theory there could be some instances where ``(T*)A OP B`` was converted to ``dynamic_cast<T*>(A OP B)`` even though the correct replacement would have been ``dynamic_cast<T*>(A) OP B``.  (Of course, this assumes that both cases would compile.) I looked over the replacements, and did not find such cases, but it might help if you double-checked.