### PR TITLE
enabled _GLIBCXX_ASSERTIONS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,7 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-sign-compare -Wno-reorder -Wno-unused-variable -Wno-unused-but-set-variable")
   endif()
 endif()
+set(CMAKE_CXX_FLAGS "-D_GLIBCXX_ASSERTIONS ${CMAKE_CXX_FLAGS}" )
 
 set(LIBRARY_OUTPUT_PATH "${CMAKE_BINARY_DIR}/lib")
 set(EXECUTABLE_OUTPUT_PATH "${CMAKE_BINARY_DIR}/bin")

--- a/R3BRoot_test.cmake
+++ b/R3BRoot_test.cmake
@@ -85,6 +85,7 @@ Ctest_Test(BUILD "${CTEST_BINARY_DIRECTORY}"
     RETURN_VALUE _ctest_test_ret_val
     )
 
+
 If(GCOV_COMMAND)
   Ctest_Coverage(BUILD "${CTEST_BINARY_DIRECTORY}")
 EndIf()
@@ -92,5 +93,7 @@ EndIf()
 Ctest_Submit()
 
 if (_ctest_test_ret_val)
-  Message(FATAL_ERROR "Some tests failed.")
+  Message(ERROR "Some tests failed, printing output of failed tests:")
+  execute_process(COMMAND ctest  --rerun-failed --output-on-failure )
+  Message(ERROR "End of failed tests output.")
 endif()


### PR DESCRIPTION
I think we should enable libstdc++ asserts (such as for vector boundaries) per default. 