### PR TITLE
[WIP] A new type-safe and casting-free wrapper for TClonesArray: TCAViewer

### DIFF
--- a/neuland/executables/CMakeLists.txt
+++ b/neuland/executables/CMakeLists.txt
@@ -15,3 +15,18 @@ set(SRCS
 
 GENERATE_EXECUTABLE()
 
+set(EXE_NAME neulandAna)
+ set(DEPENDENCIES R3BNeulandShared R3BNeulandDigitizing R3BPassive R3BData R3BBase Gen)
+
+ set(INCLUDE_DIRECTORIES
+ ${INCLUDE_DIRECTORIES}
+ ${R3BROOT_SOURCE_DIR}/passive
+ ${R3BROOT_SOURCE_DIR}/neuland/executables
+ )
+
+ include_directories(${INCLUDE_DIRECTORIES})
+ set(SRCS
+     neulandAna.cxx
+     )
+
+ GENERATE_EXECUTABLE()

--- a/neuland/executables/neulandAna.cxx
+++ b/neuland/executables/neulandAna.cxx
@@ -49,7 +49,7 @@ class MyTask : public FairTask
             // auto output_Viewer = mNeulandOutputPoints.Get(); // this will cause error
             auto neulandPoint = *point;
             neulandPoint.SetEnergyLoss(neulandPoint.GetEnergyLoss() + 0.005);
-            outputPointers_Viewer->Emplace_back(std::move(neulandPoint));
+            outputPointers_Viewer.Emplace_back(std::move(neulandPoint));
         }
     }
 

--- a/neuland/executables/neulandAna.cxx
+++ b/neuland/executables/neulandAna.cxx
@@ -1,0 +1,88 @@
+#include "FairFileSource.h"
+#include "FairParRootFileIo.h"
+#include "FairRootFileSink.h"
+#include "FairRunAna.h"
+#include "FairRuntimeDb.h"
+#include "FairTask.h"
+#include "R3BNeulandPoint.h"
+#include "TCAConnector.h"
+#include "TCAViewer.h"
+#include "TRandom3.h"
+#include "TStopwatch.h"
+#include <iostream>
+
+class MyTask : public FairTask
+{
+  public:
+    MyTask(const TString& input = "NeulandPoints", const TString& output = "NeulandTestPoints")
+        : fPoints(input)
+        , mNeulandInputPoints(input.Data())
+        , mNeulandOutputPoints(output.Data())
+    {
+    }
+    auto Init() -> InitStatus override
+    {
+        mNeulandInputPoints.Init();
+        mNeulandOutputPoints.Init();
+        fPoints.Init();
+
+        return kSUCCESS;
+    }
+
+    void Exec(Option_t*) override
+    {
+        auto inputPointers_Viewer = mNeulandInputPoints.Get();
+        auto outputPointers_Viewer = mNeulandOutputPoints.Get();
+
+        auto inputPoints_Connector = fPoints.Retrieve();
+
+        // check consistancy with TCAConnector
+        for (int i = 1; i < inputPoints_Connector.size(); i++)
+        {
+            if (inputPointers_Viewer[i]->GetLightYield() != inputPoints_Connector[i]->GetLightYield())
+                LOG(error) << "light yield mismatch";
+        }
+
+        // test output
+        for (const auto& point : inputPointers_Viewer)
+        {
+            // auto output_Viewer = mNeulandOutputPoints.Get(); // this will cause error
+            auto neulandPoint = *point;
+            neulandPoint.SetEnergyLoss(neulandPoint.GetEnergyLoss() + 0.005);
+            outputPointers_Viewer->Emplace_back(std::move(neulandPoint));
+        }
+    }
+
+  private:
+    TClonesArray* tracks = nullptr;
+    TCAViewer::Pointers<R3BNeulandPoint, TCAViewer::in> mNeulandInputPoints;
+    TCAViewer::Pointers<R3BNeulandPoint, TCAViewer::out> mNeulandOutputPoints;
+    TCAInputConnector<R3BNeulandPoint> fPoints;
+};
+
+auto main() -> int
+{
+    TStopwatch timer;
+    timer.Start();
+
+    FairLogger::GetLogger()->SetLogScreenLevel("debug3");
+
+    auto run = std::make_unique<FairRunAna>();
+    run->SetSource(new FairFileSource("test.simu.root"));
+    run->SetSink(new FairRootFileSink("test.digi.root"));
+
+    auto io = new FairParRootFileIo();
+    io->open("test.para.root");
+    run->GetRuntimeDb()->setFirstInput(io);
+
+    run->AddTask(new MyTask());
+    run->Init();
+    run->Run(0, 1);
+
+    timer.Stop();
+    auto sink = run->GetSink();
+    sink->Close();
+    std::cout << "Macro finished successfully." << std::endl;
+    std::cout << "Real time: " << timer.RealTime() << "s, CPU time: " << timer.CpuTime() << "s" << std::endl;
+    return 0;
+}

--- a/neuland/executables/neulandAna.cxx
+++ b/neuland/executables/neulandAna.cxx
@@ -9,6 +9,7 @@
 #include "TCAViewer.h"
 #include "TRandom3.h"
 #include "TStopwatch.h"
+#include <R3BNeulandHit.h>
 #include <iostream>
 
 class MyTask : public FairTask
@@ -31,31 +32,37 @@ class MyTask : public FairTask
 
     void Exec(Option_t*) override
     {
-        auto inputPointers_Viewer = mNeulandInputPoints.Get();
-        auto outputPointers_Viewer = mNeulandOutputPoints.Get();
-
+        auto inputData = mNeulandInputPoints.Get();
         auto inputPoints_Connector = fPoints.Retrieve();
+        // if (inputData.size() > 200) // this will cause error
+        if (!inputData.empty())
+        {
+            auto outputPointers_Viewer = mNeulandOutputPoints.Get();
+            for (const auto& point : inputData)
+            {
+                // auto output_Viewer = mNeulandOutputPoints.Get(); // this will cause error
+                auto neulandPoint = *point;
+                neulandPoint.SetEnergyLoss(neulandPoint.GetEnergyLoss() + 0.005);
+                outputPointers_Viewer.Emplace_back(std::move(neulandPoint));
+            }
+        }
+
+        // test output
 
         // check consistancy with TCAConnector
         for (int i = 1; i < inputPoints_Connector.size(); i++)
         {
-            if (inputPointers_Viewer[i]->GetLightYield() != inputPoints_Connector[i]->GetLightYield())
+            if (inputData[i]->GetLightYield() != inputPoints_Connector[i]->GetLightYield())
                 LOG(error) << "light yield mismatch";
-        }
-
-        // test output
-        for (const auto& point : inputPointers_Viewer)
-        {
-            // auto output_Viewer = mNeulandOutputPoints.Get(); // this will cause error
-            auto neulandPoint = *point;
-            neulandPoint.SetEnergyLoss(neulandPoint.GetEnergyLoss() + 0.005);
-            outputPointers_Viewer.Emplace_back(std::move(neulandPoint));
+            // LOG(info) << "Viewer: " << inputPointers_Viewer[i]->GetLightYield()
+            //           << "\t Con: " << inputPoints_Connector[i]->GetLightYield();
         }
     }
 
   private:
     TClonesArray* tracks = nullptr;
     TCAViewer::Data<R3BNeulandPoint, TCAViewer::in> mNeulandInputPoints;
+    // TCAViewer::Data<R3BNeulandHit, TCAViewer::in> mNeulandInputPoints; // this will cause error
     TCAViewer::Data<R3BNeulandPoint, TCAViewer::out> mNeulandOutputPoints;
     TCAInputConnector<R3BNeulandPoint> fPoints;
 };
@@ -65,7 +72,7 @@ auto main() -> int
     TStopwatch timer;
     timer.Start();
 
-    FairLogger::GetLogger()->SetLogScreenLevel("debug3");
+    FairLogger::GetLogger()->SetLogScreenLevel("info");
 
     auto run = std::make_unique<FairRunAna>();
     run->SetSource(new FairFileSource("test.simu.root"));
@@ -77,7 +84,7 @@ auto main() -> int
 
     run->AddTask(new MyTask());
     run->Init();
-    run->Run(0, 1);
+    run->Run(0, 100);
 
     timer.Stop();
     auto sink = run->GetSink();

--- a/neuland/executables/neulandAna.cxx
+++ b/neuland/executables/neulandAna.cxx
@@ -55,8 +55,8 @@ class MyTask : public FairTask
 
   private:
     TClonesArray* tracks = nullptr;
-    TCAViewer::Pointers<R3BNeulandPoint, TCAViewer::in> mNeulandInputPoints;
-    TCAViewer::Pointers<R3BNeulandPoint, TCAViewer::out> mNeulandOutputPoints;
+    TCAViewer::Data<R3BNeulandPoint, TCAViewer::in> mNeulandInputPoints;
+    TCAViewer::Data<R3BNeulandPoint, TCAViewer::out> mNeulandOutputPoints;
     TCAInputConnector<R3BNeulandPoint> fPoints;
 };
 

--- a/neuland/shared/CMakeLists.txt
+++ b/neuland/shared/CMakeLists.txt
@@ -13,25 +13,13 @@
 
 cmake_minimum_required(VERSION 3.14)
 
-
-include(FetchContent)
-
-FetchContent_Declare(GSL
-    GIT_REPOSITORY "https://github.com/microsoft/GSL"
-    GIT_TAG "v4.0.0"
-    GIT_SHALLOW ON
-)
-
-FetchContent_MakeAvailable(GSL)
-
 set(LIBRARY_NAME R3BNeulandShared)
 set(LINKDEF NeulandSharedLinkDef.h)
 
-set(DEPENDENCIES R3BData R3BBase ParBase Microsoft.GSL::GSL)
+set(DEPENDENCIES R3BData R3BBase ParBase)
 
 set(INCLUDE_DIRECTORIES 
 ${INCLUDE_DIRECTORIES} 
-${gsl_SOURCE_DIR}/include
 )
 
 include_directories(${INCLUDE_DIRECTORIES} )

--- a/neuland/shared/CMakeLists.txt
+++ b/neuland/shared/CMakeLists.txt
@@ -11,12 +11,30 @@
 # or submit itself to any jurisdiction.                                      #
 ##############################################################################
 
+cmake_minimum_required(VERSION 3.14)
+
+
+include(FetchContent)
+
+FetchContent_Declare(GSL
+    GIT_REPOSITORY "https://github.com/microsoft/GSL"
+    GIT_TAG "v4.0.0"
+    GIT_SHALLOW ON
+)
+
+FetchContent_MakeAvailable(GSL)
+
 set(LIBRARY_NAME R3BNeulandShared)
 set(LINKDEF NeulandSharedLinkDef.h)
 
-set(DEPENDENCIES R3BData R3BBase ParBase)
+set(DEPENDENCIES R3BData R3BBase ParBase Microsoft.GSL::GSL)
 
-include_directories(${INCLUDE_DIRECTORIES})
+set(INCLUDE_DIRECTORIES 
+${INCLUDE_DIRECTORIES} 
+${gsl_SOURCE_DIR}/include
+)
+
+include_directories(${INCLUDE_DIRECTORIES} )
 
 set(SRCS
     ElasticScattering.cxx
@@ -30,6 +48,7 @@ set(HEADERS
     ElasticScattering.h
     Filterable.h
     TCAConnector.h
+    TCAViewer.h
     Validated.h
     IsElastic.h
     R3BNeulandGeoPar.h

--- a/neuland/shared/TCAViewer.h
+++ b/neuland/shared/TCAViewer.h
@@ -117,7 +117,7 @@ namespace TCAViewer
             return is_sucess ? gsl::span<DataType*>(mFirstAddr, mTCA->GetEntriesFast()) : gsl::span<DataType*>();
         }
 
-        [[nodiscard]] auto OutputGet() -> std::unique_ptr<TCAOutput_SafeGuard<DataType>>
+        [[nodiscard]] auto OutputGet() -> TCAOutput_SafeGuard<DataType>
         {
             if (mSafeGuard)
             {
@@ -126,9 +126,8 @@ namespace TCAViewer
             else
             {
                 Clear();
-                EnableGuard();
             }
-            return std::make_unique<TCAOutput_SafeGuard<DataType>>(this);
+            return TCAOutput_SafeGuard<DataType>(this);
         }
 
         auto SetFirstAddr() -> bool
@@ -176,6 +175,7 @@ namespace TCAViewer
         explicit TCAOutput_SafeGuard(Pointers_out* pointers)
             : mPointers{ pointers }
         {
+            mPointers->EnableGuard();
         }
 
         ~TCAOutput_SafeGuard() { mPointers->DisableGuard(); }

--- a/neuland/shared/TCAViewer.h
+++ b/neuland/shared/TCAViewer.h
@@ -1,0 +1,197 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef TCAVIEWER
+#define TCAVIEWER
+
+#include "FairRootManager.h"
+#include "TClonesArray.h"
+#include <gsl/gsl>
+#include <string_view>
+#include <utility>
+
+namespace TCAViewer
+{
+    enum Mode
+    {
+        in,
+        out
+    };
+
+    template <typename Datatype>
+    class TCAOutput_SafeGuard;
+
+    template <typename DataType, Mode mode = in>
+    class Pointers
+    {
+      public:
+        friend TCAOutput_SafeGuard<DataType>;
+        explicit Pointers(std::string branchName = "")
+            : mBranchName{ std::move(branchName) }
+        {
+        }
+
+        void SetBranch(std::string branchName) { mBranchName = std::move(branchName); }
+
+        auto GetBranchName() -> std::string& { return mBranchName; }
+
+        void Init(FairRootManager* rootMan = FairRootManager::Instance())
+        {
+            if (rootMan == nullptr)
+            {
+                LOG(fatal) << "TCAViewer: No FairRootManager for" << mBranchName;
+            }
+
+            if (mBranchName.empty())
+            {
+                LOG(fatal) << "TCAViewer: cannot init without branch name specified.";
+            }
+
+            mTCA = (mode == in) ? InputInit(rootMan) : OutputInit(rootMan);
+        }
+
+        // [[nodiscard]] auto GetData() -> gsl::span<DataType*>
+        [[nodiscard]] auto Get() -> decltype(auto)
+        {
+            if constexpr (mode == in)
+            {
+                return InputGet();
+            }
+            else if constexpr (mode == out)
+            {
+                return OutputGet();
+            }
+        }
+
+        auto GetTCA() -> TClonesArray* { return mTCA; }
+
+      private:
+        void DisableGuard() { mSafeGuard = false; }
+        void EnableGuard() { mSafeGuard = true; }
+
+        void Clear()
+        {
+            if (mTCA == nullptr)
+            {
+                LOG(error) << "TCAViewer: Cannot reset non-existed TClonesArray!";
+            }
+            mTCA->Clear("C");
+        }
+
+        auto InputInit(FairRootManager* rootMan) -> TClonesArray*
+        {
+            auto* tTCA = dynamic_cast<TClonesArray*>(rootMan->GetObject(mBranchName.data()));
+            if (tTCA == nullptr)
+            {
+                LOG(fatal) << "TCAViewer: No TClonesArray called " << mBranchName
+                           << "could be obtained from the FairRootManager!";
+            }
+            return tTCA;
+        }
+
+        auto OutputInit(FairRootManager* rootMan) -> TClonesArray*
+        {
+            mTCA_out = std::make_unique<TClonesArray>(DataType::Class_Name());
+            rootMan->Register(mBranchName.data(), "", mTCA_out.get(), kTRUE);
+            return mTCA_out.get();
+        }
+
+        [[nodiscard]] auto InputGet() -> gsl::span<DataType*>
+        {
+            static_assert(mode == in, "TCAViewer::Data cannot be called in output mode!");
+            if (mTCA == nullptr)
+            {
+                LOG(warn) << "TCAViewer: get data from a non-existed TClonesArray!";
+            }
+            auto is_sucess = (mFirstAddr == nullptr) ? SetFirstAddr() : true;
+            return is_sucess ? gsl::span<DataType*>(mFirstAddr, mTCA->GetEntriesFast()) : gsl::span<DataType*>();
+        }
+
+        [[nodiscard]] auto OutputGet() -> std::unique_ptr<TCAOutput_SafeGuard<DataType>>
+        {
+            if (mSafeGuard)
+            {
+                LOG(fatal) << "TCAViewer: Get() function can only be called once in the scope. ";
+            }
+            else
+            {
+                Clear();
+                EnableGuard();
+            }
+            return std::make_unique<TCAOutput_SafeGuard<DataType>>(this);
+        }
+
+        auto SetFirstAddr() -> bool
+        {
+            auto is_success = false;
+            if (mTCA != nullptr && mTCA->Capacity() != 0)
+            {
+                if (dynamic_cast<DataType*>((*mTCA)[0]) == nullptr)
+                {
+                    LOG(fatal) << "cannot convert the element in " << mBranchName << " to the type "
+                               << DataType::Class_Name();
+                }
+                else
+                {
+                    mFirstAddr = reinterpret_cast<DataType**>(&(*mTCA)[0]);
+                    is_success = true;
+                }
+            }
+            return is_success;
+        }
+
+        template <typename... Args>
+        void Emplace_back(Args&&... args)
+        {
+            static_assert(mode == out, "TCAViewer::Emplace_back cannot be called in input mode!");
+            if (mTCA == nullptr)
+            {
+                LOG(error) << "TCAViewer: Cannot emplace back a non-existed TClonesArray!";
+            }
+            new ((*mTCA_out)[mTCA_out->GetEntries()]) DataType(std::forward<Args>(args)...);
+        }
+
+        std::string mBranchName;
+        DataType** mFirstAddr = nullptr;
+        TClonesArray* mTCA = nullptr;
+        bool mSafeGuard = false;
+        std::unique_ptr<TClonesArray> mTCA_out; // owning
+    };
+
+    template <typename Datatype>
+    class TCAOutput_SafeGuard
+    {
+      public:
+        using Pointers_out = Pointers<Datatype, out>;
+        explicit TCAOutput_SafeGuard(Pointers_out* pointers)
+            : mPointers{ pointers }
+        {
+        }
+
+        ~TCAOutput_SafeGuard() { mPointers->DisableGuard(); }
+        TCAOutput_SafeGuard(const TCAOutput_SafeGuard&) = delete;
+        TCAOutput_SafeGuard(TCAOutput_SafeGuard&&) = delete;
+        auto operator=(const TCAOutput_SafeGuard&) -> TCAOutput_SafeGuard& = delete;
+        auto operator=(TCAOutput_SafeGuard &&) -> TCAOutput_SafeGuard& = delete;
+
+        template <typename... Args>
+        void Emplace_back(Args&&... args)
+        {
+            mPointers->Emplace_back(std::forward<Args>(args)...);
+        }
+
+      private:
+        Pointers_out* mPointers = nullptr; // non-owning
+    };
+} // namespace TCAViewer
+#endif

--- a/neuland/shared/TCAViewer.h
+++ b/neuland/shared/TCAViewer.h
@@ -31,12 +31,14 @@ namespace TCAViewer
     template <typename Datatype>
     class TCAOutput_SafeGuard;
 
-    template <typename DataType, Mode mode = in>
-    class Pointers
+    template <typename DataType,
+              Mode mode = in,
+              typename = typename std::enable_if<std::is_base_of<TObject, DataType>::value>::type>
+    class Data
     {
       public:
         friend TCAOutput_SafeGuard<DataType>;
-        explicit Pointers(std::string branchName = "")
+        explicit Data(std::string branchName = "")
             : mBranchName{ std::move(branchName) }
         {
         }
@@ -171,7 +173,7 @@ namespace TCAViewer
     class TCAOutput_SafeGuard
     {
       public:
-        using Pointers_out = Pointers<Datatype, out>;
+        using Pointers_out = Data<Datatype, out>;
         explicit TCAOutput_SafeGuard(Pointers_out* pointers)
             : mPointers{ pointers }
         {


### PR DESCRIPTION
## Motivation
Much has been discussed about castings during event loops. Ideally casting should not be used at all. The biggest reason why there are so many castings in our program is because all the input and output data are in the type `TClonesArray`, which neither has type-safety nor memory safety.  Some people, like our former colleague, @janmayer, tried to create type-safety by making a wrapping class template, called `TCAConnector`. But unfortunately, in the actual implementation, data pointers still need to be copied and casted to the correct version.  

The new wrapper `TCAViewer` solves this problem by using an array-view class called `span`. The idea of viewing an array is relatively new and was not even implemented until the latest standard C++20. With C++17, we can still fully utilize such a conception from a library called "Guideline Supported Library" (GSL). 

## Basic idea
Unlike `std::array<>`, `gsl::span` (or `std::span` in C++20) is very light weighted and does not own any data. It just requires the address of the first element and the size of the container. However, it has all features of modern C++ containers, such as iterators and range-based looping. Fortunately, the address of the first element of `TClonesArray` always stays the same throughout all events. Once such address value becomes known, a `span` object can be created per event to represent all the data from `TClonesArray` without the need to copy or cast.

## TCAViewer
_(please check the source code in `TCAViewer.h` for the full details)_

### Initialisation:
* Input mode:
```cpp
auto inputData = TCAViewer::Data<R3BNeulandPoint, TCAViewer::in>("NeulandPoints");
```
* Output mode:
```cpp
auto outputData = TCAViewer::Data<R3BNeulandHit, TCAViewer::out>("NeulandHits");
```
### Return:
* Input mode:
Note: Always keep in mind that the return in input mode is a span containing **pointers** to the data, NOT directly data.
```cpp
auto inputPtrs = inputData.Get(); // inputPtrs has the type gsl::span<R3BNeulandPoint*>

//iterator:
for(auto itr = inputPtrs.begin(); itr != inputPtrs.end(), itr++)
{
    (*itr)->GetLightYield();
    //...
}

// range-based looping
for(const auto& it : inputPtrs)
{
   it->GetLightYield();
}
```
* Output mode:
```cpp
auto outputPtr = outputData.Get(); // outputPtr has the type TCAViewer::TCAOutput_SafeGuard<R3BNeulandHit>

outputPtr.Emplace_back( R3BNeulandHit() );
outputPtr.Emplace_back( R3BNeulandHit() );
outputPtr.Emplace_back( R3BNeulandHit() );
//...
```

### Data types:
There are three important data types defined in TCAViewer:
* TCAViewer::Mode
* TCAViewer::Data
* TCAViewer::TCAOutput_SafeGuard

`TCAViewer::Mode` is an enumerator containing only two entries: `TCAViewer::in` and `TCAViewer::out`. It specifies whether the object from the class `TCAViewer::Data` represents input data or output data. If you accidentally choose the wrong mode, an error will be shown during the compilation (see below).

`TCAViewer::Data`, as a class template, is the main part of TCAViewer. Its signature and constructor are shown below:
```cpp
template <typename DataType, Mode mode = in>
class Data
{
  public:
    explicit Data(std::string branchName = "");
}
``` 
The typename _DataType_ is the type of the object, such as `R3BNeulandPoint` or `TVector3`, which must be derived from `TObject`. _mode_ shows whether you need an input data or an output data. The constructor parameter `branchName` is the name of the branch where the actual data is extracted from `TTree`. It's the same constructor parameter when you use type-unsafe `FairRootManager::GetObject()`,  such as
```cpp
fMappedTrigger = (TClonesArray*)mgr->GetObject("NeulandTrigMappedData");
```
`TCAViewer::TCAOutput_SafeGuard` is a return type of `TCAViewer::Pointer<DataType, TCAViewer::out>::Get()` and should rarely appear if you have a good C++ programming habit (using auto as much as possible. ). Remember always needing to "clear" the TClonesArray or TCAOutputConnector at the end of the event loop? With TCAViewer, there is no such need as this is automatically done (thanks to an C++ idiom called "RAII").

### Member functions of TCAViewer::Data:
To be added...

## UB?
```cpp
if (dynamic_cast<DataType*>((*mTCA)[0]) == nullptr)
 {
     LOG(fatal) << "cannot convert the element in " << mBranchName << " to the type "
           << DataType::Class_Name();
}
else
{
    mFirstAddr = reinterpret_cast<DataType**>(&(*mTCA)[0]);
    is_success = true;
}
```
To be continued...