### PR TITLE
Small update for Map2Cal FOOT

### DIFF
--- a/ssd/calibration/R3BFootMapped2StripCal.h
+++ b/ssd/calibration/R3BFootMapped2StripCal.h
@@ -63,6 +63,11 @@ class R3BFootMapped2StripCal : public FairTask
      */
     void SetThresholdSigma(Double_t th) { fTimesSigma = th; }
 
+    /**
+     * Method for setting the N of strip hit per foot: fNStrip
+     */
+    void SetNStrip(Double_t nstrip) { fNStrip = nstrip; }
+
   private:
     void SetParameter();
 
@@ -70,6 +75,7 @@ class R3BFootMapped2StripCal : public FairTask
     Int_t NumStrips;
     Int_t NumParams;
     Int_t MaxSigma;
+    Double_t fNStrip;
     Double_t fTimesSigma;
     TArrayF* CalParams;
 


### PR DESCRIPTION
I introduce a new parameter fNStrip that is the number of strip hit for FOOT. This parameter was hardcoded before, now it is possible to set the value of this parameter in the unpacking macro.