### PR TITLE
Update FrsData tasks for s509

### DIFF
--- a/analysis/offline/R3BAnalysisIncomingID.cxx
+++ b/analysis/offline/R3BAnalysisIncomingID.cxx
@@ -12,7 +12,7 @@
  ******************************************************************************/
 
 // ----------------------------------------------------------------
-// -----       R3BAnalysisIncomingID source file              -----
+// -----             R3BAnalysisIncomingID                    -----
 // -----     Created 01/11/21 by M. Feijoo Fontan             -----
 // ----------------------------------------------------------------
 
@@ -27,6 +27,7 @@
 #include "FairRuntimeDb.h"
 
 #include "R3BAnalysisIncomingID.h"
+#include "R3BCoarseTimeStitch.h"
 #include "R3BEventHeader.h"
 #include "R3BFrsData.h"
 #include "R3BIncomingIDPar.h"
@@ -34,6 +35,7 @@
 #include "R3BLosCalData.h"
 #include "R3BLosHitData.h"
 #include "R3BLosMappedData.h"
+#include "R3BLosTCalData.h"
 #include "R3BMusicHitData.h"
 #include "R3BMusicHitPar.h"
 #include "R3BMusliHitData.h"
@@ -49,10 +51,10 @@ R3BAnalysisIncomingID::R3BAnalysisIncomingID()
 
 R3BAnalysisIncomingID::R3BAnalysisIncomingID(const char* name, Int_t iVerbose)
     : FairTask(name, iVerbose)
-    , fHeader(NULL)
     , fHitItemsMus(NULL)
     , fHitItemsMusli(NULL)
     , fHitLos(NULL)
+    , fTriggerLos(NULL)
     , fHitPspx1_x(NULL)
     , fHitPspx1_y(NULL)
     , fFrsDataCA(NULL)
@@ -68,6 +70,8 @@ R3BAnalysisIncomingID::R3BAnalysisIncomingID(const char* name, Int_t iVerbose)
     , fNumDet(1)
     , fUseLOS(kFALSE)
     , fUsePspx1(kTRUE)
+    , fUseTref(kFALSE)
+    , fTimeStitch(nullptr)
     , fCutS2(NULL)
     , fCutCave(NULL)
 {
@@ -150,6 +154,13 @@ InitStatus R3BAnalysisIncomingID::Init()
     fHitLos = (TClonesArray*)mgr->GetObject("LosHit");
     R3BLOG_IF(warn, !fHitLos, "LosHit not found");
 
+    if (fUseTref)
+    {
+        // Get access to trigger data of the LOS
+        fTriggerLos = (TClonesArray*)mgr->GetObject("LosTriggerTCal");
+        R3BLOG_IF(warn, !fTriggerLos, "LosTriggerTCal not found");
+    }
+
     // Get access to hit data of PSPX1
     fHitPspx1_x = (TClonesArray*)mgr->GetObject("Pspx1_xHit");
     R3BLOG_IF(warn, !fHitPspx1_x, "Pspx1_xHit not found");
@@ -163,6 +174,9 @@ InitStatus R3BAnalysisIncomingID::Init()
         fFrsDataCA = new TClonesArray("R3BFrsData");
         mgr->Register("FrsData", "Analysis FRS", fFrsDataCA, !fOnline);
     }
+
+    // Definition of a time stich object to correlate times coming from different systems
+    fTimeStitch = new R3BCoarseTimeStitch();
 
     SetParameter();
     return kSUCCESS;
@@ -210,6 +224,7 @@ void R3BAnalysisIncomingID::Exec(Option_t* option)
     Double_t Zlos[fNumDet];
     UInt_t nHits = 0;
     Double_t posLosX_cm[fNumDet];
+    Double_t trigTimeV[fNumDet];
     Double_t Gamma_m1 = 0., Brho_m1 = 0., AoQ_m1 = 0.;
     Double_t AoQ_m1_corr = 0.;
     Int_t multLos[fNumDet];
@@ -220,6 +235,20 @@ void R3BAnalysisIncomingID::Exec(Option_t* option)
         multLos[i] = 0;
         Zlos[i] = 0.;
         posLosX_cm[i] = 0.;
+        trigTimeV[i] = 0.;
+    }
+    // --- read Trigger data from LOS --- //
+    if (fTriggerLos && fTriggerLos->GetEntriesFast() > 0)
+    {
+        Int_t numDet = 1;
+        Int_t tHits = fTriggerLos->GetEntriesFast();
+        for (Int_t ihit = 0; ihit < tHits; ihit++)
+        {
+            R3BLosTCalData* hittcal = (R3BLosTCalData*)fTriggerLos->At(ihit);
+            numDet = hittcal->GetDetector();
+            if (hittcal->GetType() == 0)
+                trigTimeV[numDet - 1] = hittcal->GetRawTimeNs();
+        } // --- end of loop over hit data --- //
     }
 
     // --- read hit from LOS data --- //
@@ -231,12 +260,24 @@ void R3BAnalysisIncomingID::Exec(Option_t* option)
         {
             R3BLosHitData* hittcal = (R3BLosHitData*)fHitLos->At(ihit);
             numDet = hittcal->GetDetector();
-            if (multLos[numDet - 1] == 0)
+            if (fUseTref)
             {
-                posLosX_cm[numDet - 1] = hittcal->GetX_cm();
-                Zlos[numDet - 1] = hittcal->GetZ();
-                multLos[numDet - 1]++;
+                Double_t time = fTimeStitch->GetTime(hittcal->GetTime() - trigTimeV[numDet - 1], "vftx", "vftx");
+                if (time == fHeader->GetTStart())
+                {
+                    posLosX_cm[numDet - 1] = hittcal->GetX_cm();
+                    Zlos[numDet - 1] = hittcal->GetZ();
+                }
             }
+            else
+            {
+                if (multLos[numDet - 1] == 0)
+                {
+                    posLosX_cm[numDet - 1] = hittcal->GetX_cm();
+                    Zlos[numDet - 1] = hittcal->GetZ();
+                }
+            }
+            multLos[numDet - 1]++;
         } // --- end of loop over hit data --- //
     }
 
@@ -270,7 +311,7 @@ void R3BAnalysisIncomingID::Exec(Option_t* option)
         // in R3BRoot, X is increasing from right to left
         //    Bro = fBrho0 * (1 + xMwpc0/fDCC - xS2/fDS2)
 
-        if (multLos[i] >= 1)
+        if (multLos[i] > 0)
         {
             Double_t betaS2 = 0.;
             Double_t PosXS2 = 0.;
@@ -286,6 +327,8 @@ void R3BAnalysisIncomingID::Exec(Option_t* option)
                         continue;
                     betaS2 = hitfrs->GetBeta();
                     PosXS2 = hitfrs->GetXS2();
+                    if (TMath::IsNaN(PosXS2) && fHeader->GetExpId() == 509) // NaN indicator for one S2 pmt missing
+                        PosXS2 = 0.;
                 }
             }
 

--- a/analysis/offline/R3BAnalysisIncomingID.h
+++ b/analysis/offline/R3BAnalysisIncomingID.h
@@ -26,6 +26,7 @@ class R3BIncomingIDPar;
 class TClonesArray;
 class R3BEventHeader;
 class R3BTcutPar;
+class R3BCoarseTimeStitch;
 
 /**
  * This taks reads all detector data items for the analysis of incoming
@@ -97,20 +98,27 @@ class R3BAnalysisIncomingID : public FairTask
     // Accessor to select the LOS for the incoming ID
     void SetLosForPID() { fUseLOS = kTRUE, fUsePspx1 = kFALSE; }
 
+    // Acsessor to set use of trigger corrected times
+    void SetUseTref() { fUseTref = kTRUE; }
+  protected:
+    R3BEventHeader* fHeader{};   // Event header
+
   private:
     void SetParameter();
+    R3BCoarseTimeStitch* fTimeStitch;
     R3BIncomingIDPar* fIncomingID_Par; // Parameter container
     TClonesArray* fHitItemsMus;
     TClonesArray* fHitItemsMusli;
     TClonesArray* fFrsDataCA; /**< Array with FRS-output data. >*/
     TClonesArray* fHitLos;
+    TClonesArray* fTriggerLos;
     TClonesArray* fHitPspx1_x;
     TClonesArray* fHitPspx1_y;
 
-    R3BEventHeader* fHeader;   // Event header
     Bool_t fOnline;            // Don't store data for online
     Bool_t fUseLOS, fUsePspx1; // Use LOS or PSPX1 charge (otherwise MUSIC charge)
     Double_t fP0, fP1, fP2, fZprimary, fZoffset;
+    Bool_t fUseTref; // Use trigger corrected times
 
     Double_t fPos_p0;
     Double_t fPos_p1;

--- a/analysis/offline/R3BIncomingBeta.cxx
+++ b/analysis/offline/R3BIncomingBeta.cxx
@@ -23,13 +23,14 @@
 #include "FairRunOnline.h"
 #include "FairRuntimeDb.h"
 
+#include "R3BCoarseTimeStitch.h"
 #include "R3BEventHeader.h"
 #include "R3BIncomingBeta.h"
 #include "R3BIncomingIDPar.h"
 #include "R3BLogger.h"
 #include "R3BLosHitData.h"
 #include "R3BSci2HitData.h"
-#include "R3BCoarseTimeStitch.h"
+#include "R3BSci2TcalData.h"
 
 #include "TClonesArray.h"
 #include "TMath.h"
@@ -41,8 +42,8 @@ R3BIncomingBeta::R3BIncomingBeta()
 
 R3BIncomingBeta::R3BIncomingBeta(const char* name, Int_t iVerbose)
     : FairTask(name, iVerbose)
-    , fHeader(NULL)
     , fHitSci2(NULL)
+    , fTcalSci2(NULL)
     , fFrsDataCA(NULL)
     , fPos_p0(-11)
     , fPos_p1(54.7)
@@ -56,6 +57,7 @@ R3BIncomingBeta::R3BIncomingBeta(const char* name, Int_t iVerbose)
     , fIncomingID_Par(NULL)
     , fNumDet(1)
     , fUseTref(kFALSE)
+    , fUseMultHit(kFALSE)
 {
     fToFoffset = new TArrayF(fNumDet);
     fPosS2Left = new TArrayF(fNumDet);
@@ -118,6 +120,13 @@ InitStatus R3BIncomingBeta::Init()
     fHitLos = (TClonesArray*)mgr->GetObject("LosHit");
     R3BLOG_IF(warn, !fHitLos, "LosHit not found");
 
+    // Get access to Sci2 data at Tcal level
+    if (fHeader->GetExpId() == 509)
+    {
+        fTcalSci2 = (TClonesArray*)mgr->GetObject("Sci2Tcal");
+        R3BLOG_IF(warn, !fTcalSci2, "Could not find Sci2Tcal");
+    }
+
     // Output data
     fFrsDataCA = (TClonesArray*)mgr->GetObject("FrsData");
     if (fFrsDataCA == NULL)
@@ -152,13 +161,13 @@ void R3BIncomingBeta::Exec(Option_t* option)
     Double_t posLosX_cm[fNumDet][MAXMULT];
     Double_t TimeSci2_m1[fNumDet][MAXMULT];
     Double_t TimeSci2wTref_m1[fNumDet][MAXMULT];
+    Double_t TimeSci2_tcal[fNumDet * 3][MAXMULT];
     Double_t PosSci2_m1[fNumDet][MAXMULT];
     UInt_t nHits = 0;
     Double_t ToFraw_m1 = 0.;
-    Double_t ToFrawwTref_m1 = 0.;
-    Double_t Velo_m1 = 0., VelowTref_m1 = 0., Beta_m1 = 0., Gamma_m1 = 0.;
+    Double_t Velo_m1 = 0., Beta_m1 = 0., Gamma_m1 = 0.;
 
-    Int_t multSci2[fNumDet];
+    Int_t multSci2[fNumDet], multSci2Tcal[fNumDet * 3];
     Int_t multLos[fNumDet];
 
     for (Int_t i = 0; i < fNumDet; i++)
@@ -172,7 +181,33 @@ void R3BIncomingBeta::Exec(Option_t* option)
             TimeSci2wTref_m1[i][m] = 0.;
             posLosX_cm[i][m] = 0.;
             timeLosV[i][m] = 0.;
+            for (Int_t k = 0; k < 3; k++)
+            {
+                multSci2Tcal[i * 3 + k] = 0;
+                TimeSci2_tcal[i * 3 + k][m] = 0;
+            }
         }
+    }
+
+    // --- read Tcal from Sci2 data --- //
+    if (fTcalSci2 && fTcalSci2->GetEntriesFast() > 0)
+    {
+        nHits = fTcalSci2->GetEntriesFast();
+        for (Int_t ihit = 0; ihit < nHits; ihit++)
+        {
+            R3BSci2TcalData* hittcal = (R3BSci2TcalData*)fTcalSci2->At(ihit);
+            UInt_t numDet = hittcal->GetDetector();
+            UInt_t ch = hittcal->GetChannel() - 1;
+            if (numDet > fNumDet)
+            {
+                R3BLOG(warn, "Sci2 detector id:" << numDet << " is out of range!");
+                continue;
+            }
+            if (multSci2Tcal[(numDet - 1) * 3 + ch] >= MAXMULT)
+                continue;
+            TimeSci2_tcal[(numDet - 1) * 3 + ch][multSci2Tcal[(numDet - 1) * 3 + ch]] = hittcal->GetRawTimeNs();
+            multSci2Tcal[(numDet - 1) * 3 + ch]++;
+        } // --- end of loop over Sci2 Tcal data --- //
     }
 
     // --- read hit from Sci2 data --- //
@@ -218,44 +253,105 @@ void R3BIncomingBeta::Exec(Option_t* option)
         } // --- end of loop over hit data --- //
     }
 
-    Int_t num_tof_candidates = 0;
+    // Note 1: fNumDet doesn't really make sense to me in this task
+    // since the number of detectors of LOS and FRS can be
+    // different but they are for some reason treated as the
+    // same here. Doesn't really affect my analysis hence I
+    // leave it as it is.
+    // Note 2: If the objective is to use only Los Z, FRSdata can
+    // now easily be made multihit capable from this code itself,
+    // just save the Los Z and calculate the Brho and A/Q value here
+    // no need to run the separate R3BAnalysisIncomingID task which
+    // can currently take only single hits because the Z information
+    // is generally taken from other detectors
+    // -Nikhil
+    Double_t good_beta = 0., good_pos_s2 = 0., good_pos_los = 0., good_tof = 0.;
+
     for (int i = 0; i < fNumDet; i++)
     {
         for (Int_t i_L = 0; i_L < multLos[i]; i_L++)
         {
-            // if (multLos[i] >= 1 && multSci2[i] >= 1)
+            Int_t num_tof_candidates = 0;
             for (Int_t i_2 = 0; i_2 < multSci2[i]; i_2++)
             {
-                if (num_tof_candidates > 0)
-                    break;
-                ToFraw_m1 = fTimeStitch->GetTime(timeLosV[i][i_L] - TimeSci2_m1[i][i_2], "vftx", "vftx");
-
-                if (ToFraw_m1 > 0. && fHeader->GetExpId() == 515)
-                    ToFraw_m1 = ToFraw_m1 - 40960.;
-
-                ToFrawwTref_m1 = fTimeStitch->GetTime(fHeader->GetTStart() - TimeSci2wTref_m1[i][i_2], "vftx", "vftx");
-
+                if (fUseTref)
+                {
+                    ToFraw_m1 = fTimeStitch->GetTime(fHeader->GetTStart() - TimeSci2wTref_m1[i][i_2], "vftx", "vftx");
+                }
+                else
+                {
+                    ToFraw_m1 = fTimeStitch->GetTime(timeLosV[i][i_L] - TimeSci2_m1[i][i_2], "vftx", "vftx");
+                    if (ToFraw_m1 > 0. && fHeader->GetExpId() == 515)
+                        ToFraw_m1 = ToFraw_m1 - 40960.;
+                }
                 Velo_m1 = 1. / (fTof2InvV_p0->GetAt(i) +
                                 fTof2InvV_p1->GetAt(i) * (fToFoffset->GetAt(i) + ToFraw_m1)); // [m/ns]
-                VelowTref_m1 = 1. / (fTof2InvV_p0->GetAt(i) +
-                                     fTof2InvV_p1->GetAt(i) * (fToFoffset->GetAt(i) + ToFrawwTref_m1)); // [m/ns]
+                Beta_m1 = Velo_m1 / (TMath::C() / pow(10, 9));
 
-                if (fUseTref)
-                    Beta_m1 = VelowTref_m1 / 0.299792458;
-                else
-                    Beta_m1 = Velo_m1 / 0.299792458;
-
-                if (fUseTref)
-                    ToFraw_m1 = ToFrawwTref_m1;
                 // Select good ToF hit with gating beta
-                // At this moment, the multiplicity of FrsData (num_tof_candidates)
-                // is restricted to be one. The beta conditions should be optimised.
                 if (Beta_m1 < fBeta_max && Beta_m1 > fBeta_min)
                 {
-                    AddData(1, 2, 0., 0., Beta_m1, 0., PosSci2_m1[i][i_2], posLosX_cm[i][i_L], ToFraw_m1);
+                    good_beta = Beta_m1;
+                    good_tof = ToFraw_m1;
+                    good_pos_s2 = PosSci2_m1[i][i_2];
+                    good_pos_los = posLosX_cm[i][i_L];
                     num_tof_candidates++;
                 }
             }
+
+            if (num_tof_candidates == 1)
+            {
+                AddData(1, 2, 0., 0., good_beta, 0., good_pos_s2, good_pos_los, good_tof);
+                if (!fUseMultHit)
+                    break;
+            }
+
+            if (num_tof_candidates == 0 && fHeader->GetExpId() == 509)
+            {
+                Int_t num_tof_ch = 0;
+                for (Int_t nCh = 0; nCh < 2; nCh++)
+                {
+                    if (!(multSci2Tcal[i * 3 + 2] == 1))
+                        break;
+                    for (Int_t i0 = 0; i0 < multSci2Tcal[i * 3 + nCh]; i0++)
+                    {
+                        if (fUseTref)
+                        {
+                            ToFraw_m1 = fTimeStitch->GetTime(
+                                fHeader->GetTStart() - (TimeSci2_tcal[i * 3 + nCh][i0] - TimeSci2_tcal[i * 3 + 2][0]),
+                                "vftx",
+                                "vftx");
+                        }
+                        else
+                        {
+                            ToFraw_m1 = fTimeStitch->GetTime(
+                                timeLosV[i][i_L] - (TimeSci2_tcal[i * 3 + nCh][i0]), "vftx", "vftx");
+                        }
+                        Velo_m1 = 1. / (fTof2InvV_p0->GetAt(i) +
+                                        fTof2InvV_p1->GetAt(i) * (fToFoffset->GetAt(i) + ToFraw_m1)); // [m/ns]
+                        Beta_m1 = Velo_m1 / (TMath::C() / pow(10, 9));
+                        // Select good ToF hit with gating beta
+                        if (Beta_m1 < fBeta_max && Beta_m1 > fBeta_min)
+                        {
+                            good_beta = Beta_m1;
+                            good_tof = ToFraw_m1;
+                            good_pos_los = posLosX_cm[i][i_L];
+                            num_tof_ch++;
+                        }
+                    }
+                    if (num_tof_ch > 0)
+                        break;
+                }
+                if (num_tof_ch == 1)
+                {
+                    AddData(1, 2, 0., 0., good_beta, 0., 0. / 0., good_pos_los, good_tof); // NaN indicator of only one
+                                                                                           // S2 pmt present
+                    if (!fUseMultHit)
+                        break;
+                }
+            }
+            if (fUseTref)
+                break;
         }
     }
 }

--- a/analysis/offline/R3BIncomingBeta.h
+++ b/analysis/offline/R3BIncomingBeta.h
@@ -14,7 +14,7 @@
 #ifndef R3BIncomingBeta_H
 #define R3BIncomingBeta_H 1
 
-// ROOT headers
+// ROOT header
 #include "TMath.h"
 #include <TArrayF.h>
 #include <array>
@@ -99,6 +99,9 @@ class R3BIncomingBeta : public FairTask
     // Accessor to select online mode
     void SetOnline(Bool_t option) { fOnline = option; }
     void SetUseTref() { fUseTref = kTRUE; }
+    void SetUseMultHit() { fUseMultHit = kTRUE; }
+  protected:
+    R3BEventHeader* fHeader{}; // Event header
 
   private:
     void SetParameter();
@@ -106,22 +109,23 @@ class R3BIncomingBeta : public FairTask
     R3BIncomingIDPar* fIncomingID_Par; // Parameter container
     TClonesArray* fFrsDataCA;          /**< Array with FRS-output data. >*/
 
-    TClonesArray* fHitSci2; /**< Array with Tcal items. */
+    TClonesArray* fHitSci2;
     TClonesArray* fHitLos;
+    TClonesArray* fTcalSci2; /**< Array with Tcal items. */
 
-    R3BEventHeader* fHeader; // Event header
     Bool_t fOnline;          // Don't store data for online
     Double_t fP0, fP1, fP2, fZprimary, fZoffset;
 
     Double_t fPos_p0;
     Double_t fPos_p1;
 
-    Int_t fNumDet;
+    UInt_t fNumDet;
     TArrayF* fToFoffset;
     TArrayF *fPosS2Left, *fPosS2Right;
     TArrayF *fTof2InvV_p0, *fTof2InvV_p1;
     Float_t fBeta_max, fBeta_min;
     Bool_t fUseTref;
+    Bool_t fUseMultHit;
 
     /** Private method FrsData **/
     //** Adds a FrsData to the analysis


### PR DESCRIPTION
New tasks for Incoming ID analysis to correct for loss of statistics problem in S2  for s509 experiment due to both PMTs not being present in ~20-25% events. 
The R3BIncomingBeta509 does most of the things as the older existing task to keep it backwards compatible. In addition to the fixing of the problem mentioned above it is also multi-hit capable when using Los Z (check comments in the task).

In addition made R3BAnalysisIncomingID509 consistent with the above problem and improvements when selecting Los charge. It is also mostly backwards compatible except when using Los charge expectation is that LosProvideTstart is use for beta calculation and one has to at least run new Task R3BLosMapped2TCal even if they wish to use the older Los tasks. If other detectors are used for Z measurement then its fully backwards compatible.

Of course one has the choice to ignore these new tasks and use the older tasks since I didn't touch them. These new tasks are however mandatory for s509 and heavily recommended for s522.       