### PR TITLE
Add online dependency to library R3BBase if fairroot version >= 18.8.0

### DIFF
--- a/r3bbase/CMakeLists.txt
+++ b/r3bbase/CMakeLists.txt
@@ -48,6 +48,10 @@ Set(DEPENDENCIES
     GeoBase ParBase MbsAPI Base FairTools R3BData Core Geom GenVector Physics
     Matrix MathCore Hist Graf Gpad Net Imt RIO RHTTP Spectrum)
 
+if( "${FairRoot_VERSION}"  VERSION_GREATER_EQUAL 18.8.0 )
+    set(DEPENDENCIES ${DEPENDENCIES} online)
+endif()
+
 Set(LIBRARY_NAME R3BBase)
 
 GENERATE_LIBRARY()


### PR DESCRIPTION
From version 18.8.0, FairRoot move FairRunOnline from libBase to libOnline. Therefore, without adding the online dependency to R3BBase, all R3B libraries using FairRunOnline can't be compiled successfully. This PR fixes this issue.

For the detailed information about this breaking change, please visit FairRoot [release page](https://github.com/FairRootGroup/FairRoot/releases/tag/v18.8.0).