### PR TITLE
Restoring Event header definition in Musli task

### DIFF
--- a/musli/calibration/R3BMusliMapped2Cal.cxx
+++ b/musli/calibration/R3BMusliMapped2Cal.cxx
@@ -128,6 +128,8 @@ InitStatus R3BMusliMapped2Cal::Init()
         return kFATAL;
     }
 
+    fHeader = dynamic_cast<R3BEventHeader*>(rootManager->GetObject("EventHeader."));
+
     fMusliMappedDataCA = dynamic_cast<TClonesArray*>(rootManager->GetObject("MusliMappedData"));
     if (!fMusliMappedDataCA)
     {


### PR DESCRIPTION
Someone seems to have removed EventHeader definition inside R3BMusliMapped2Cal task in previous commits. Fixed.

---

Checklist:

* [x] Rebased against `dev` branch
* [ ] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
