### PR TITLE
[WIP] Migrate to GitHub-hosted runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,22 +15,22 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially
 jobs:
   # This workflow contains a single job called "clang-format"
-  clang-format:
-    runs-on: self-hosted
+  #clang-format:
+  #  runs-on: self-hosted
 
-    steps:
-      - uses: actions/checkout@v3
+  #  steps:
+  #    - uses: actions/checkout@v3
 
-      - name: Code formatting
-        run: |
-          cd $GITHUB_WORKSPACE
-          singularity exec /data.local2/kresan/debian10-apr22-v18.6.8-ucesb.sif $PWD/util/clang-format-check.sh clang-format-8
+  #    - name: Code formatting
+  #      run: |
+  #        cd $GITHUB_WORKSPACE
+  #        singularity exec /data.local2/kresan/debian10-apr22-v18.6.8-ucesb.sif $PWD/util/clang-format-check.sh clang-format-8
   # Single job called "build-r3broot"
   build-r3broot:
     # The type of runner that the job will run on
-    runs-on: self-hosted
-    needs: clang-format
-    if: always()
+    runs-on: ubuntu-18.04
+    #needs: clang-format
+    #if: always()
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -38,84 +38,30 @@ jobs:
       - uses: actions/checkout@v3
 
       # Runs a set of commands using the runners shell
-      - name: Run Dart.sh
+      - name: CVMFS
+        run: |
+          sudo apt-get install lsb-release
+          wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
+          sudo dpkg -i cvmfs-release-latest_all.deb
+          rm -f cvmfs-release-latest_all.deb
+          sudo apt-get update
+          sudo apt-get install -y cvmfs
+          wget https://cernbox.cern.ch/remote.php/dav/public-files/RmnTeeOZpYjCJQb/masterkey.gsi.de.pub
+          sudo mv masterkey.gsi.de.pub /etc/cvmfs/keys
+          cd $GITHUB_WORKSPACE 
+          sudo cp .githubfiles/fairsoft.gsi.de.conf /etc/cvmfs/config.d
+          sudo mkdir -p /cvmfs/fairsoft.gsi.de
+          sudo mount -t cvmfs fairsoft.gsi.de /cvmfs/fairsoft.gsi.de
+          ls -l /cvmfs/fairsoft.gsi.de
+
+      - name: build-r3broot
         run: |
           cd $GITHUB_WORKSPACE
-          git clone -b dev https://github.com/R3BRootGroup/macros.git
-          singularity exec /data.local2/kresan/debian10-apr22-v18.6.8-ucesb.sif $PWD/.githubfiles/run_build_test_apr22.sh
-  # Single job called "build-r3broot-sofia"
-  build-r3broot-sofia:
-    # The type of runner that the job will run on
-    runs-on: self-hosted
-    needs: build-r3broot
-    if: always()
+          git clone https://github.com/R3BRootGroup/macros.git
+          mkdir build
+          cd build
+          export SIMPATH=/cvmfs/fairsoft.gsi.de/ubuntu1804/fairsoft/nov20
+          export FAIRROOTPATH=/cvmfs/fairsoft.gsi.de/ubuntu1804/fairroot/v18.4.2_fs_nov20
+          cmake ..
+          make -j2
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-
-      # Runs a set of commands using the runners shell
-      - name: Run Dart.sh
-        run: |
-          cd $GITHUB_WORKSPACE
-          git clone -b dev https://github.com/R3BRootGroup/macros.git
-          git clone -b dev https://github.com/R3BRootGroup/sofia.git
-          singularity exec /data.local2/kresan/debian10-apr22-v18.6.8-ucesb.sif $PWD/.githubfiles/run_build_test_apr22.sh
-  # Single job called "build-r3broot-asyeos"
-#  build-r3broot-asyeos:
-    # The type of runner that the job will run on
-#    runs-on: self-hosted
-#    needs: build-r3broot
-#    if: always()
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-#    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-#      - uses: actions/checkout@v3
-
-      # Runs a set of commands using the runners shell
-#      - name: Run Dart.sh
-#        run: |
-#          cd $GITHUB_WORKSPACE
-#          git clone -b dev https://github.com/R3BRootGroup/macros.git
-#          git clone -b dev https://github.com/R3BRootGroup/asyeos.git
-#          singularity exec /data.local2/kresan/debian10-apr22-v18.6.8-ucesb.sif $PWD/.githubfiles/run_build_test_apr22.sh
-  # Single job called "build-r3broot-glad-tpc"
-#  build-r3broot-glad-tpc:
-    # The type of runner that the job will run on
-#    runs-on: self-hosted
-#    needs: build-r3broot
-#    if: always()
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-#    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-#      - uses: actions/checkout@v3
-
-      # Runs a set of commands using the runners shell
-      # git clone -b dev https://github.com/R3BRootGroup/glad-tpc.git
-#      - name: Run Dart.sh
-#        run: |
-#          cd $GITHUB_WORKSPACE
-#          git clone -b dev https://github.com/R3BRootGroup/macros.git
-#          singularity exec /data.local2/kresan/debian10-apr22-v18.6.8-ucesb.sif $PWD/.githubfiles/run_build_test_apr22.sh
-#  # Single job called "build-r3broot-frs"
-  build-r3broot-frs:
-    # The type of runner that the job will run on
-    runs-on: self-hosted
-    needs: build-r3broot-sofia
-    if: always()
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-
-      # Runs a set of commands using the runners shell
-      - name: Run Dart.sh
-        run: |
-          cd $GITHUB_WORKSPACE
-          git clone -b dev https://github.com/R3BRootGroup/macros.git
-          git clone -b dev https://github.com/R3BRootGroup/frs.git
-          singularity exec /data.local2/kresan/debian10-apr22-v18.6.8-ucesb.sif $PWD/.githubfiles/run_build_test_apr22.sh

--- a/.githubfiles/fairsoft.gsi.de.conf
+++ b/.githubfiles/fairsoft.gsi.de.conf
@@ -1,0 +1,3 @@
+CVMFS_SERVER_URL="http://cvmfs-s1.gsi.de/cvmfs/fairsoft.gsi.de"
+CVMFS_HTTP_PROXY="DIRECT"
+CVMFS_PUBLIC_KEY="/etc/cvmfs/keys/masterkey.gsi.de.pub"


### PR DESCRIPTION
Describe your proposal.

- Run R3BRoot CI on the GitHub-hosted Ubuntu 18.04
- Use FairSoft and FairRoot from CVMFS (versions will be updated soon)
- Only cvmfs package needs to be installed and configured - takes 1 min
- 2 cores are available per runner

Mention any issue this PR is resolved or is related to.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
