### PR TITLE
CI/CD: Add clang-tidy github auto review

### DIFF
--- a/.github/workflows/clangtidy.yml
+++ b/.github/workflows/clangtidy.yml
@@ -13,26 +13,40 @@ jobs:
   clang-tidy:
     runs-on: ubuntu-latest
     container: 
-      image: yanzhaowang/fairroot:v18.8.0
-      options: --user root
+      image: yanzhaowang/cvmfs_clang:v15
+      volumes:
+        - /tmp:/cvmfs
+      env:
+        CVMDIR: /cvmfs/fairsoft.gsi.de
+      options: --user root --privileged  --ulimit nofile=10000:10000 --cap-add SYS_ADMIN --device /dev/fuse
     steps:
-    - name: install deps
-      run: |
-        apt-get update -y && apt-get install -y git
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
+    - name: mount cvmfs
+      run: |
+        wget https://cernbox.cern.ch/remote.php/dav/public-files/RmnTeeOZpYjCJQb/masterkey.gsi.de.pub
+        mv masterkey.gsi.de.pub /etc/cvmfs/keys
+        cp .githubfiles/fairsoft.gsi.de.conf /etc/cvmfs/config.d
+        mkdir -p ${CVMDIR}
+        mount -t cvmfs fairsoft.gsi.de ${CVMDIR}
+
     - name: cmake configure
       run: |
+        export SIMPATH=${CVMDIR}/debian10/fairsoft/nov22p1
+        export FAIRROOTPATH=${CVMDIR}/debian10/fairroot/v18.8.0_fs_nov22p1
+        export PATH=${SIMPATH}/bin:$PATH
         git config --global --add safe.directory $GITHUB_WORKSPACE
         git clone https://github.com/R3BRootGroup/macros.git
-        cmake . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=on 
+        cmake . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=on -DBUILD_GEOMETRY=OFF -DUSE_DIFFERENT_COMPILER=TRUE
 
     - name: clang-tidy check
       run: |
         mkdir -p clang-tidy-result
-        git diff -U0 HEAD^ | clang-tidy-diff-15.py -p1 -path build -export-fixes clang-tidy-result/fixes.yml |\
+        git diff -U0 HEAD^ | clang-tidy-diff-15.py -p1 -path build \
+        -iregex '.*\.(cpp|cc|c\+\+|cxx|cl|h|hh|hpp|m|mm|inc)' \
+        -export-fixes clang-tidy-result/fixes.yml |\
         sed 's/\(^.*\):\([0-9]*\):\([0-9]*\): warning:/::warning file=\1,line=\2,col=\3::/'
         echo "WARN_NUM=$(grep -w "^ *Message:" clang-tidy-result/fixes.yml | wc -l | xargs)" >> $GITHUB_ENV
 
@@ -46,3 +60,4 @@ jobs:
             exit 1
           fi
       shell: bash
+

--- a/.github/workflows/clangtidy.yml
+++ b/.github/workflows/clangtidy.yml
@@ -1,0 +1,48 @@
+name: static analysis
+on:
+  push:
+    branches: [ dev ]
+  pull_request:
+    branches: [ dev ]
+
+  workflow_dispatch:
+
+permissions: write-all
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-latest
+    container: 
+      image: yanzhaowang/fairroot:v18.8.0
+      options: --user root
+    steps:
+    - name: install deps
+      run: |
+        apt-get update -y && apt-get install -y git
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: cmake configure
+      run: |
+        git config --global --add safe.directory $GITHUB_WORKSPACE
+        git clone https://github.com/R3BRootGroup/macros.git
+        cmake . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=on 
+
+    - name: clang-tidy check
+      run: |
+        mkdir -p clang-tidy-result
+        git diff -U0 HEAD^ | clang-tidy-diff-15.py -p1 -path build -export-fixes clang-tidy-result/fixes.yml |\
+        sed 's/\(^.*\):\([0-9]*\):\([0-9]*\): warning:/::warning file=\1,line=\2,col=\3::/'
+        echo "WARN_NUM=$(grep -w "^ *Message:" clang-tidy-result/fixes.yml | wc -l | xargs)" >> $GITHUB_ENV
+
+    - name: clang-tidy results
+      run: |
+          if [ "${{ env.WARN_NUM }}" -eq "0" ]; then
+            echo "::notice::All clean, LGTM!"
+          else
+            cat clang-tidy-result/fixes.yml
+            echo "::notice::Clang-tidy generates ${{ env.WARN_NUM }} warnings! Please fix them before being merged."
+            exit 1
+          fi
+      shell: bash

--- a/.githubfiles/fairsoft.gsi.de.conf
+++ b/.githubfiles/fairsoft.gsi.de.conf
@@ -1,0 +1,3 @@
+CVMFS_SERVER_URL="http://cvmfs-s1.gsi.de/cvmfs/fairsoft.gsi.de"
+CVMFS_HTTP_PROXY="DIRECT"
+CVMFS_PUBLIC_KEY="/etc/cvmfs/keys/masterkey.gsi.de.pub"

--- a/neuland/executables/neuland.cxx
+++ b/neuland/executables/neuland.cxx
@@ -8,6 +8,35 @@
 #include "TStopwatch.h"
 #include <iostream>
 
+// trailing return
+int myfun() { return 0; }
+
+void test()
+{
+    // uninitialzed variable:
+    int num;
+
+    // c array:
+    int c_arr[3];
+
+    // magic number:
+    int magic = 78;
+
+    // delete:
+    auto file = new TString{};
+    delete file;
+
+    // mordenize using
+    typedef int intv;
+
+    // ranged for loop:
+    auto vec = std::vector<intv>(10, 0);
+    for (int i = 0; i < vec.size(); i++)
+    {
+        vec[i] = 1;
+    }
+}
+
 int main()
 {
     TStopwatch timer;

--- a/neuland/executables/neuland.cxx
+++ b/neuland/executables/neuland.cxx
@@ -8,35 +8,6 @@
 #include "TStopwatch.h"
 #include <iostream>
 
-// trailing return
-int myfun() { return 0; }
-
-void test()
-{
-    // uninitialzed variable:
-    int num;
-
-    // c array:
-    int c_arr[3];
-
-    // magic number:
-    int magic = 78;
-
-    // delete:
-    auto file = new TString{};
-    delete file;
-
-    // mordenize using
-    typedef int intv;
-
-    // ranged for loop:
-    auto vec = std::vector<intv>(10, 0);
-    for (int i = 0; i < vec.size(); i++)
-    {
-        vec[i] = 1;
-    }
-}
-
 int main()
 {
     TStopwatch timer;


### PR DESCRIPTION
Add clang-tidy auto review for all pull requests.

Version info:
* clang: 15
* FairRoot: 18.8.0
* FairSoft: nov22

Checking filetype: '*\.(cpp|cc|c\+\+|cxx|cl|h|hh|hpp|m|mm|inc)'

ROOT MACROS with .C will not be checked with clang-tidy.

@klenze We can open another issue to discuss what should be put inside .clang-tidy.

check "Files changed" tab above to see the effect.

~Task failure is intentional because of the new bad code added with the PR.~

Current docker image contains FairSoft/FairRoot/Clang15 and has size of ~8GB in total. Therefore the clang-tidy checking needs to take a while (~3 mins ). I will try to create another docker image using cvmfs of FairSoft. ( FairRoot still needs to be compiled and built in the container since its version in cvmfs is bit old. )

---

Checklist:

* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Rebased against `dev` branch
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
