### PR TITLE
[hot fix]Disable read RunID from timpstamp when prets and nexts are both 0

### DIFF
--- a/r3bbase/R3BFileSource.cxx
+++ b/r3bbase/R3BFileSource.cxx
@@ -491,7 +491,7 @@ Int_t R3BFileSource::ReadEvent(UInt_t i)
         fflush(stdout);
     }
 
-    if (nextts >= 0 && prevts >= 0 && (fEvtHeader->GetTimeStamp() > nextts || fEvtHeader->GetTimeStamp() < prevts))
+    if (nextts > 0 && prevts >= 0 && (fEvtHeader->GetTimeStamp() > nextts || fEvtHeader->GetTimeStamp() < prevts))
     {
         fRunId = GetRunid(fEvtHeader->GetTimeStamp());
     }


### PR DESCRIPTION
Fix a crash introduced by #814.

### TODO:
`R3BFileSource.cxx` need to be rewritten totally. With the current code design, any innocent change may lead to the whole program unusable.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
