### PR TITLE
Adding a factory function for ROOT owning objects

### DIFF
--- a/r3bbase/CMakeLists.txt
+++ b/r3bbase/CMakeLists.txt
@@ -37,10 +37,34 @@ file(GLOB SRCS
 *.cxx 
 )
 
-# fill list of header files from list of source files
-# by exchanging the file extension
-CHANGE_FILE_EXTENSION(*.cxx *.h HEADERS "${SRCS}")
-install(FILES "R3BLogger.h" DESTINATION include)
+set(SRCS
+    R3BCoarseTimeStitch.cxx
+    R3BDataPropagator.cxx
+    R3BDetector.cxx
+    R3BEventHeader.cxx
+    R3BEventHeaderPropagator.cxx
+    R3BFileSource.cxx
+    R3BLogger.cxx
+    R3BModule.cxx
+    R3BTcutPar.cxx
+    R3BTsplinePar.cxx
+    R3BWhiterabbitPropagator.cxx
+    )
+
+set(HEADERS 
+    R3BCoarseTimeStitch.h
+    R3BDataPropagator.h
+    R3BDetector.h
+    R3BEventHeader.h
+    R3BEventHeaderPropagator.h
+    R3BFileSource.h
+    R3BLogger.h
+    R3BModule.h
+    R3BShared.h
+    R3BTcutPar.h
+    R3BTsplinePar.h
+    R3BWhiterabbitPropagator.h
+    )
 
 Set(LINKDEF BaseLinkDef.h)
 

--- a/r3bbase/R3BShared.h
+++ b/r3bbase/R3BShared.h
@@ -1,0 +1,47 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#pragma once
+#include <type_traits>
+#include <utility>
+
+class TF1;
+class TH1;
+class TTree;
+
+namespace r3b
+{
+    // ROOT types owned by ROOT: TH1, TF1;
+    template <typename... Types>
+    struct TypeCollection
+    {
+    };
+
+    using RootTypes = TypeCollection<TF1, TH1, TTree>;
+
+    template <typename Type, typename>
+    inline constexpr bool is_based_on = false;
+
+    template <typename Type, typename... BaseTypes>
+    inline constexpr bool is_based_on<Type, TypeCollection<BaseTypes...>> = (std::is_base_of_v<BaseTypes, Type> || ...);
+
+    template <typename Type>
+    inline constexpr bool is_root_owned = is_based_on<Type, RootTypes>;
+
+    template <typename RootType, typename... Args>
+    inline auto root_owned(Args&&... args)
+    {
+        static_assert(is_root_owned<RootType>, "root_owned: such type cannot be owned by ROOT!");
+        return new RootType(std::forward<Args>(args)...); // NOLINT
+    }
+} // namespace r3b


### PR DESCRIPTION
## Factory function
Explicitly specifying the ownership of the ROOT objects (TH1 and TF1).

### Usage:
Instead of 
```cpp
auto* hist = new TH1D("hist", "hist", 100, 0., 10.); // warning from Clang-tidy
```
use
```cpp
auto* hist = r3b::root_owned<TH1D>("hist", "hist", 100, 0., 10.); // OK
```

Feel free to comment on the implementation (including naming) @klenze 

Some info about the ownership in ROOT : [object ownership](https://root.cern.ch/root/htmldoc/guides/users-guide/ObjectOwnership.html)

## Change in r3bbase/CMakeLists.txt
Explicitly writing out the source file names, according to cmake document:
> We do not recommend using GLOB to collect a list of source files from your source tree. If no CMakeLists.txt file changes when a source is added or removed then the generated build system cannot know when to ask CMake to regenerate. The CONFIGURE_DEPENDS flag may not work reliably on all generators, or if a new generator is added in the future that cannot support it, projects using it will be stuck. Even if CONFIGURE_DEPENDS works reliably, there is still a cost to perform the check on every rebuild.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
