### PR TITLE
Static analysis: .clang-tidy configuration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,370 +1,45 @@
-#Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-diagnostic-unknown-warning-option,-clang-analyzer-deadcode.DeadStores'
----
-Checks:           'cppcoreguidelines-pro-type-cstyle-cast'
-WarningsAsErrors: ''
-HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
-FormatStyle:     none
-User:            land
-CheckOptions:
-  hicpp-move-const-arg.CheckMoveToConstRef: 'true'
-  readability-suspicious-call-argument.PrefixSimilarAbove: '30'
-  cppcoreguidelines-no-malloc.Reallocations: '::realloc'
-  llvmlibc-restrict-system-libc-headers.Includes: '-*'
-  cppcoreguidelines-owning-memory.LegacyResourceConsumers: '::free;::realloc;::freopen;::fclose'
-  modernize-use-auto.MinTypeNameLength: '5'
-  bugprone-reserved-identifier.Invert: 'false'
-  bugprone-narrowing-conversions.PedanticMode: 'false'
-  altera-struct-pack-align.MaxConfiguredAlignment: '128'
-  bugprone-unused-return-value.CheckedFunctions: '::std::async;::std::launder;::std::remove;::std::remove_if;::std::unique;::std::unique_ptr::release;::std::basic_string::empty;::std::vector::empty;::std::back_inserter;::std::distance;::std::find;::std::find_if;::std::inserter;::std::lower_bound;::std::make_pair;::std::map::count;::std::map::find;::std::map::lower_bound;::std::multimap::equal_range;::std::multimap::upper_bound;::std::set::count;::std::set::find;::std::setfill;::std::setprecision;::std::setw;::std::upper_bound;::std::vector::at;::bsearch;::ferror;::feof;::isalnum;::isalpha;::isblank;::iscntrl;::isdigit;::isgraph;::islower;::isprint;::ispunct;::isspace;::isupper;::iswalnum;::iswprint;::iswspace;::isxdigit;::memchr;::memcmp;::strcmp;::strcoll;::strncmp;::strpbrk;::strrchr;::strspn;::strstr;::wcscmp;::access;::bind;::connect;::difftime;::dlsym;::fnmatch;::getaddrinfo;::getopt;::htonl;::htons;::iconv_open;::inet_addr;::isascii;::isatty;::mmap;::newlocale;::openat;::pathconf;::pthread_equal;::pthread_getspecific;::pthread_mutex_trylock;::readdir;::readlink;::recvmsg;::regexec;::scandir;::semget;::setjmp;::shm_open;::shmget;::sigismember;::strcasecmp;::strsignal;::ttyname'
-  readability-magic-numbers.IgnoredIntegerValues: '1;2;3;4;'
-  cert-dcl51-cpp.AggressiveDependentMemberLookup: 'false'
-  hicpp-use-auto.MinTypeNameLength: '5'
-  readability-inconsistent-declaration-parameter-name.Strict: 'false'
-  hicpp-use-override.IgnoreDestructors: 'false'
-  cppcoreguidelines-macro-usage.CheckCapsOnly: 'false'
-  readability-suspicious-call-argument.DiceDissimilarBelow: '60'
-  cert-dcl37-c.AllowedIdentifiers: ''
-  cert-dcl16-c.IgnoreMacros: 'true'
-  hicpp-use-emplace.SmartPointers: '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
-  bugprone-assert-side-effect.IgnoredFunctions: __builtin_expect
-  hicpp-member-init.IgnoreArrays: 'false'
-  openmp-exception-escape.IgnoredExceptions: ''
-  readability-suspicious-call-argument.Equality: 'true'
-  hicpp-use-override.AllowOverrideAndFinal: 'false'
-  misc-uniqueptr-reset-release.IncludeStyle: llvm
-  abseil-string-find-str-contains.StringLikeClasses: '::std::basic_string;::std::basic_string_view;::absl::string_view'
-  readability-const-return-type.IgnoreMacros: 'true'
-  hicpp-signed-bitwise.IgnorePositiveIntegerLiterals: 'false'
-  bugprone-easily-swappable-parameters.QualifiersMix: 'false'
-  cert-err09-cpp.WarnOnLargeObjects: 'false'
-  bugprone-suspicious-string-compare.WarnOnImplicitComparison: 'true'
-  bugprone-argument-comment.CommentNullPtrs: '0'
-  android-comparison-in-temp-failure-retry.RetryMacros: TEMP_FAILURE_RETRY
-  hicpp-use-equals-delete.IgnoreMacros: 'true'
-  cppcoreguidelines-narrowing-conversions.WarnOnFloatingPointNarrowingConversion: 'true'
-  cppcoreguidelines-init-variables.IncludeStyle: llvm
-  modernize-use-nodiscard.ReplacementString: '[[nodiscard]]'
-  modernize-loop-convert.MakeReverseRangeHeader: ''
-  readability-avoid-const-params-in-decls.IgnoreMacros: 'true'
-  readability-suspicious-call-argument.SuffixSimilarAbove: '30'
-  misc-definitions-in-headers.HeaderFileExtensions: ';h;hh;hpp;hxx'
-  hicpp-uppercase-literal-suffix.NewSuffixes: ''
-  modernize-use-emplace.ContainersWithPush: '::std::stack;::std::queue;::std::priority_queue'
-  cppcoreguidelines-narrowing-conversions.WarnOnIntegerNarrowingConversion: 'true'
-  bugprone-easily-swappable-parameters.IgnoredParameterNames: '"";iterator;Iterator;begin;Begin;end;End;first;First;last;Last;lhs;LHS;rhs;RHS'
-  modernize-loop-convert.UseCxx20ReverseRanges: 'true'
-  cppcoreguidelines-prefer-member-initializer.UseAssignment: 'false'
-  hicpp-function-size.VariableThreshold: '4294967295'
-  cert-oop57-cpp.MemSetNames: ''
-  hicpp-no-malloc.Deallocations: '::free'
-  performance-type-promotion-in-math-fn.IncludeStyle: llvm
-  google-readability-function-size.LineThreshold: '4294967295'
-  readability-function-cognitive-complexity.DescribeBasicIncrements: 'true'
-  bugprone-suspicious-include.ImplementationFileExtensions: 'c;cc;cpp;cxx'
-  hicpp-use-emplace.ContainersWithPushFront: '::std::forward_list;::std::list;::std::deque'
-  modernize-loop-convert.MakeReverseRangeFunction: ''
-  readability-inconsistent-declaration-parameter-name.IgnoreMacros: 'true'
-  bugprone-suspicious-missing-comma.SizeThreshold: '5'
-  readability-identifier-naming.IgnoreFailedSplit: 'false'
-  hicpp-multiway-paths-covered.WarnOnMissingElse: 'false'
-  readability-qualified-auto.AddConstToQualified: 'true'
-  bugprone-sizeof-expression.WarnOnSizeOfThis: 'true'
-  bugprone-string-constructor.WarnOnLargeLength: 'true'
-  cppcoreguidelines-explicit-virtual-functions.OverrideSpelling: override
-  hicpp-no-malloc.Allocations: '::malloc;::calloc'
-  hicpp-use-noexcept.UseNoexceptFalse: 'true'
-  abseil-string-find-startswith.IncludeStyle: llvm
-  google-global-names-in-headers.HeaderFileExtensions: ';h;hh;hpp;hxx'
-  readability-uppercase-literal-suffix.IgnoreMacros: 'true'
-  modernize-make-shared.IgnoreMacros: 'true'
-  modernize-use-emplace.ContainersWithPushFront: '::std::forward_list;::std::list;::std::deque'
-  misc-const-correctness.TransformValues: 'true'
-  cert-dcl59-cpp.HeaderFileExtensions: ';h;hh;hpp;hxx'
-  bugprone-suspicious-enum-usage.StrictMode: 'false'
-  performance-unnecessary-copy-initialization.AllowedTypes: ''
-  bugprone-suspicious-missing-comma.MaxConcatenatedTokens: '5'
-  modernize-use-transparent-functors.SafeMode: 'false'
-  readability-suspicious-call-argument.Levenshtein: 'true'
-  misc-throw-by-value-catch-by-reference.CheckThrowTemporaries: 'true'
-  bugprone-not-null-terminated-result.WantToUseSafeFunctions: 'true'
-  bugprone-string-constructor.LargeLengthThreshold: '8388608'
-  bugprone-dynamic-static-initializers.HeaderFileExtensions: ';h;hh;hpp;hxx'
-  readability-simplify-boolean-expr.ChainedConditionalAssignment: 'false'
-  cppcoreguidelines-avoid-magic-numbers.IgnoreAllFloatingPointValues: 'false'
-  cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField: 'false'
-  cert-err09-cpp.CheckThrowTemporaries: 'true'
-  performance-inefficient-vector-operation.EnableProto: 'false'
-  bugprone-exception-escape.FunctionsThatShouldNotThrow: ''
-  modernize-loop-convert.MaxCopySize: '16'
-  readability-suspicious-call-argument.PrefixDissimilarBelow: '25'
-  readability-function-size.LineThreshold: '4294967295'
-  bugprone-easily-swappable-parameters.MinimumLength: '2'
-  portability-simd-intrinsics.Suggest: 'false'
-  hicpp-deprecated-headers.CheckHeaderFile: 'false'
-  modernize-use-override.IgnoreDestructors: 'false'
-  cppcoreguidelines-pro-bounds-constant-array-index.GslHeader: ''
-  modernize-make-shared.MakeSmartPtrFunctionHeader: '<memory>'
-  modernize-make-shared.MakeSmartPtrFunction: 'std::make_shared'
-  misc-non-private-member-variables-in-classes.IgnorePublicMemberVariables: 'false'
-  bugprone-sizeof-expression.WarnOnSizeOfConstant: 'true'
-  readability-redundant-string-init.StringNames: '::std::basic_string_view;::std::basic_string'
-  modernize-make-unique.IgnoreDefaultInitialization: 'true'
-  modernize-use-emplace.ContainersWithPushBack: '::std::vector;::std::list;::std::deque'
-  readability-magic-numbers.IgnoreBitFieldsWidths: 'true'
-  modernize-make-unique.IncludeStyle: llvm
-  modernize-use-override.OverrideSpelling: override
-  google-readability-function-size.NestingThreshold: '4294967295'
-  google-build-namespaces.HeaderFileExtensions: ';h;hh;hpp;hxx'
-  readability-suspicious-call-argument.LevenshteinDissimilarBelow: '50'
-  bugprone-argument-comment.CommentStringLiterals: '0'
-  concurrency-mt-unsafe.FunctionSet: any
-  readability-identifier-length.IgnoredExceptionVariableNames: '^[e]$'
-  google-readability-braces-around-statements.ShortStatementLines: '1'
-  bugprone-reserved-identifier.AllowedIdentifiers: ''
-  cppcoreguidelines-pro-type-member-init.IgnoreArrays: 'false'
-  readability-else-after-return.WarnOnUnfixable: 'true'
-  cppcoreguidelines-avoid-magic-numbers.IgnoredFloatingPointValues: '1.0;100.0;'
-  modernize-use-emplace.IgnoreImplicitConstructors: 'false'
-  cppcoreguidelines-macro-usage.IgnoreCommandLineMacros: 'true'
-  readability-suspicious-call-argument.Substring: 'true'
-  modernize-use-equals-delete.IgnoreMacros: 'true'
-  objc-forbidden-subclassing.ForbiddenSuperClassNames: 'ABNewPersonViewController;ABPeoplePickerNavigationController;ABPersonViewController;ABUnknownPersonViewController;NSHashTable;NSMapTable;NSPointerArray;NSPointerFunctions;NSTimer;UIActionSheet;UIAlertView;UIImagePickerController;UITextInputMode;UIWebView'
-  readability-identifier-length.IgnoredVariableNames: ''
-  readability-magic-numbers.IgnoreAllFloatingPointValues: 'false'
-  cppcoreguidelines-pro-bounds-constant-array-index.IncludeStyle: llvm
-  hicpp-use-auto.RemoveStars: 'false'
-  readability-suspicious-call-argument.Abbreviations: 'arr=array;cnt=count;idx=index;src=source;stmt=statement;cpy=copy;dest=destination;dist=distancedst=distance;ptr=pointer;wdth=width;str=string;ln=line;srv=server;attr=attribute;ref=reference;buf=buffer;col=column;nr=number;vec=vector;len=length;elem=element;val=value;i=index;var=variable;hght=height;cl=client;num=number;pos=position;lst=list;addr=address'
-  bugprone-misplaced-widening-cast.CheckImplicitCasts: 'false'
-  readability-uppercase-literal-suffix.NewSuffixes: ''
-  modernize-loop-convert.MinConfidence: reasonable
-  performance-unnecessary-value-param.AllowedTypes: ''
-  readability-uniqueptr-delete-release.PreferResetCall: 'false'
-  readability-identifier-length.MinimumExceptionNameLength: '2'
-  misc-definitions-in-headers.UseHeaderFileExtension: 'true'
-  google-readability-namespace-comments.SpacesBeforeComments: '2'
-  cppcoreguidelines-avoid-magic-numbers.IgnoreBitFieldsWidths: 'true'
-  cert-err61-cpp.CheckThrowTemporaries: 'true'
-  cppcoreguidelines-avoid-magic-numbers.IgnoredIntegerValues: '1;2;3;4;'
-  cppcoreguidelines-no-malloc.Allocations: '::malloc;::calloc'
-  misc-throw-by-value-catch-by-reference.MaxSize: '-1'
-  cppcoreguidelines-avoid-magic-numbers.IgnorePowersOf2IntegerValues: 'false'
-  bugprone-narrowing-conversions.IgnoreConversionFromTypes: ''
-  readability-function-size.BranchThreshold: '4294967295'
-  bugprone-suspicious-missing-comma.RatioThreshold: '0.200000'
-  hicpp-function-size.LineThreshold: '4294967295'
-  readability-implicit-bool-conversion.AllowIntegerConditions: 'false'
-  readability-identifier-length.IgnoredParameterNames: '^[n]$'
-  readability-function-size.StatementThreshold: '800'
-  hicpp-use-noexcept.ReplacementString: ''
-  readability-identifier-naming.IgnoreMainLikeFunctions: 'false'
-  cppcoreguidelines-init-variables.MathHeader: '<math.h>'
-  google-runtime-int.SignedTypePrefix: int
-  google-readability-function-size.StatementThreshold: '800'
-  cert-msc51-cpp.DisallowedSeedTypes: 'time_t,std::time_t'
-  hicpp-use-emplace.TupleMakeFunctions: '::std::make_pair;::std::make_tuple'
-  bugprone-reserved-identifier.AggressiveDependentMemberLookup: 'false'
-  readability-suspicious-call-argument.DiceSimilarAbove: '70'
-  modernize-use-equals-default.IgnoreMacros: 'true'
-  readability-suspicious-call-argument.Abbreviation: 'true'
-  cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor: 'false'
-  cert-dcl37-c.AggressiveDependentMemberLookup: 'false'
-  readability-identifier-length.MinimumLoopCounterNameLength: '2'
-  abseil-string-find-str-contains.AbseilStringsMatchHeader: 'absl/strings/match.h'
-  bugprone-dangling-handle.HandleClasses: 'std::basic_string_view;std::experimental::basic_string_view'
-  cert-msc54-cpp.AsyncSafeFunctionSet: POSIX
-  modernize-use-emplace.SmartPointers: '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
-  readability-magic-numbers.IgnorePowersOf2IntegerValues: 'false'
-  misc-const-correctness.TransformPointersAsValues: 'false'
-  readability-suspicious-call-argument.JaroWinklerSimilarAbove: '85'
-  misc-unused-parameters.StrictMode: 'false'
-  cppcoreguidelines-no-malloc.Deallocations: '::free'
-  readability-simplify-subscript-expr.Types: '::std::basic_string;::std::basic_string_view;::std::vector;::std::array'
-  performance-unnecessary-copy-initialization.ExcludedContainerTypes: ''
-  modernize-replace-auto-ptr.IncludeStyle: llvm
-  performance-move-const-arg.CheckTriviallyCopyableMove: 'true'
-  misc-const-correctness.TransformReferences: 'true'
-  hicpp-move-const-arg.CheckTriviallyCopyableMove: 'true'
-  readability-function-size.VariableThreshold: '4294967295'
-  readability-static-accessed-through-instance.NameSpecifierNestingThreshold: '3'
-  cert-dcl16-c.NewSuffixes: 'L;LL;LU;LLU'
-  misc-const-correctness.AnalyzeValues: 'true'
-  readability-identifier-naming.GetConfigPerFile: 'true'
-  bugprone-narrowing-conversions.WarnOnFloatingPointNarrowingConversion: 'true'
-  cert-sig30-c.AsyncSafeFunctionSet: POSIX
-  hicpp-member-init.UseAssignment: 'false'
-  cert-err61-cpp.MaxSize: '-1'
-  modernize-use-default-member-init.UseAssignment: 'false'
-  readability-simplify-boolean-expr.SimplifyDeMorgan: 'true'
-  readability-function-size.NestingThreshold: '4294967295'
-  google-readability-function-size.BranchThreshold: '4294967295'
-  bugprone-sizeof-expression.WarnOnSizeOfPointerToAggregate: 'true'
-  llvm-namespace-comment.ShortNamespaceLines: '1'
-  llvm-namespace-comment.SpacesBeforeComments: '1'
-  modernize-use-override.AllowOverrideAndFinal: 'false'
-  cppcoreguidelines-narrowing-conversions.IgnoreConversionFromTypes: ''
-  readability-function-size.ParameterThreshold: '4294967295'
-  hicpp-function-size.NestingThreshold: '4294967295'
-  modernize-pass-by-value.ValuesOnly: 'false'
-  readability-function-cognitive-complexity.IgnoreMacros: 'false'
-  modernize-loop-convert.IncludeStyle: llvm
-  cert-str34-c.DiagnoseSignedUnsignedCharComparisons: 'false'
-  bugprone-narrowing-conversions.WarnWithinTemplateInstantiation: 'false'
-  cert-err33-c.CheckedFunctions: '::aligned_alloc;::asctime_s;::at_quick_exit;::atexit;::bsearch;::bsearch_s;::btowc;::c16rtomb;::c32rtomb;::calloc;::clock;::cnd_broadcast;::cnd_init;::cnd_signal;::cnd_timedwait;::cnd_wait;::ctime_s;::fclose;::fflush;::fgetc;::fgetpos;::fgets;::fgetwc;::fopen;::fopen_s;::fprintf;::fprintf_s;::fputc;::fputs;::fputwc;::fputws;::fread;::freopen;::freopen_s;::fscanf;::fscanf_s;::fseek;::fsetpos;::ftell;::fwprintf;::fwprintf_s;::fwrite;::fwscanf;::fwscanf_s;::getc;::getchar;::getenv;::getenv_s;::gets_s;::getwc;::getwchar;::gmtime;::gmtime_s;::localtime;::localtime_s;::malloc;::mbrtoc16;::mbrtoc32;::mbsrtowcs;::mbsrtowcs_s;::mbstowcs;::mbstowcs_s;::memchr;::mktime;::mtx_init;::mtx_lock;::mtx_timedlock;::mtx_trylock;::mtx_unlock;::printf_s;::putc;::putwc;::raise;::realloc;::remove;::rename;::scanf;::scanf_s;::setlocale;::setvbuf;::signal;::snprintf;::snprintf_s;::sprintf;::sprintf_s;::sscanf;::sscanf_s;::strchr;::strerror_s;::strftime;::strpbrk;::strrchr;::strstr;::strtod;::strtof;::strtoimax;::strtok;::strtok_s;::strtol;::strtold;::strtoll;::strtoul;::strtoull;::strtoumax;::strxfrm;::swprintf;::swprintf_s;::swscanf;::swscanf_s;::thrd_create;::thrd_detach;::thrd_join;::thrd_sleep;::time;::timespec_get;::tmpfile;::tmpfile_s;::tmpnam;::tmpnam_s;::tss_create;::tss_get;::tss_set;::ungetc;::ungetwc;::vfprintf;::vfprintf_s;::vfscanf;::vfscanf_s;::vfwprintf;::vfwprintf_s;::vfwscanf;::vfwscanf_s;::vprintf_s;::vscanf;::vscanf_s;::vsnprintf;::vsnprintf_s;::vsprintf;::vsprintf_s;::vsscanf;::vsscanf_s;::vswprintf;::vswprintf_s;::vswscanf;::vswscanf_s;::vwprintf_s;::vwscanf;::vwscanf_s;::wcrtomb;::wcschr;::wcsftime;::wcspbrk;::wcsrchr;::wcsrtombs;::wcsrtombs_s;::wcsstr;::wcstod;::wcstof;::wcstoimax;::wcstok;::wcstok_s;::wcstol;::wcstold;::wcstoll;::wcstombs;::wcstombs_s;::wcstoul;::wcstoull;::wcstoumax;::wcsxfrm;::wctob;::wctrans;::wctype;::wmemchr;::wprintf_s;::wscanf;::wscanf_s;'
-  bugprone-suspicious-string-compare.WarnOnLogicalNotComparison: 'false'
-  hicpp-braces-around-statements.ShortStatementLines: '0'
-  cppcoreguidelines-explicit-virtual-functions.AllowOverrideAndFinal: 'false'
-  google-readability-function-size.ParameterThreshold: '4294967295'
-  readability-redundant-smartptr-get.IgnoreMacros: 'true'
-  readability-identifier-naming.AggressiveDependentMemberLookup: 'false'
-  cert-err61-cpp.WarnOnLargeObjects: 'false'
-  misc-const-correctness.WarnPointersAsValues: 'false'
-  readability-identifier-length.MinimumParameterNameLength: '3'
-  modernize-use-emplace.TupleTypes: '::std::pair;::std::tuple'
-  hicpp-use-emplace.IgnoreImplicitConstructors: 'false'
-  modernize-use-emplace.TupleMakeFunctions: '::std::make_pair;::std::make_tuple'
-  bugprone-narrowing-conversions.WarnOnIntegerToFloatingPointNarrowingConversion: 'true'
-  cppcoreguidelines-owning-memory.LegacyResourceProducers: '::malloc;::aligned_alloc;::realloc;::calloc;::fopen;::freopen;::tmpfile'
-  bugprone-easily-swappable-parameters.SuppressParametersUsedTogether: 'true'
-  bugprone-argument-comment.StrictMode: '0'
-  hicpp-uppercase-literal-suffix.IgnoreMacros: 'true'
-  misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: 'false'
-  modernize-replace-random-shuffle.IncludeStyle: llvm
-  modernize-use-bool-literals.IgnoreMacros: 'true'
-  bugprone-easily-swappable-parameters.NamePrefixSuffixSilenceDissimilarityTreshold: '1'
-  bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField: 'true'
-  google-readability-namespace-comments.ShortNamespaceLines: '10'
-  readability-suspicious-call-argument.JaroWinklerDissimilarBelow: '75'
-  bugprone-suspicious-string-compare.StringCompareLikeFunctions: ''
-  modernize-avoid-bind.PermissiveParameterList: 'false'
-  readability-suspicious-call-argument.Suffix: 'true'
-  cert-err09-cpp.MaxSize: '-1'
-  modernize-use-override.FinalSpelling: final
-  hicpp-use-equals-default.IgnoreMacros: 'true'
-  modernize-use-noexcept.ReplacementString: ''
-  modernize-use-using.IgnoreMacros: 'true'
-  hicpp-use-override.FinalSpelling: final
-  cppcoreguidelines-explicit-virtual-functions.FinalSpelling: final
-  hicpp-use-override.OverrideSpelling: override
-  readability-suspicious-call-argument.MinimumIdentifierNameLength: '3'
-  bugprone-narrowing-conversions.WarnOnIntegerNarrowingConversion: 'true'
-  modernize-loop-convert.NamingStyle: CamelCase
-  cppcoreguidelines-pro-type-member-init.UseAssignment: 'false'
-  bugprone-suspicious-include.HeaderFileExtensions: ';h;hh;hpp;hxx'
-  hicpp-function-size.StatementThreshold: '800'
-  readability-suspicious-call-argument.SubstringDissimilarBelow: '40'
-  hicpp-no-malloc.Reallocations: '::realloc'
-  bugprone-stringview-nullptr.IncludeStyle: llvm
-  performance-for-range-copy.WarnOnAllAutoCopies: 'false'
-  google-runtime-int.UnsignedTypePrefix: uint
-  performance-no-automatic-move.AllowedTypes: ''
-  modernize-pass-by-value.IncludeStyle: llvm
-  bugprone-argument-comment.CommentIntegerLiterals: '0'
-  bugprone-argument-comment.CommentFloatLiterals: '0'
-  bugprone-too-small-loop-variable.MagnitudeBitsUpperLimit: '16'
-  abseil-string-find-startswith.AbseilStringsMatchHeader: 'absl/strings/match.h'
-  readability-simplify-boolean-expr.ChainedConditionalReturn: 'false'
-  readability-else-after-return.WarnOnConditionVariables: 'true'
-  modernize-use-nullptr.NullMacros: 'NULL'
-  readability-suspicious-call-argument.SuffixDissimilarBelow: '25'
-  bugprone-argument-comment.CommentCharacterLiterals: '0'
-  cppcoreguidelines-macro-usage.AllowedRegexp: '^DEBUG_*'
-  llvm-header-guard.HeaderFileExtensions: ';h;hh;hpp;hxx'
-  readability-suspicious-call-argument.LevenshteinSimilarAbove: '66'
-  cppcoreguidelines-narrowing-conversions.PedanticMode: 'false'
-  modernize-make-shared.IgnoreDefaultInitialization: 'true'
-  readability-suspicious-call-argument.JaroWinkler: 'true'
-  bugprone-implicit-widening-of-multiplication-result.UseCXXHeadersInCppSources: 'true'
-  modernize-make-shared.IncludeStyle: llvm
-  readability-suspicious-call-argument.Prefix: 'true'
-  hicpp-special-member-functions.AllowMissingMoveFunctions: 'false'
-  cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions: 'false'
-  bugprone-implicit-widening-of-multiplication-result.UseCXXStaticCastsInCppSources: 'true'
-  bugprone-signed-char-misuse.CharTypdefsToIgnore: ''
-  cert-dcl51-cpp.Invert: 'false'
-  hicpp-special-member-functions.AllowSoleDefaultDtor: 'false'
-  modernize-deprecated-headers.CheckHeaderFile: 'false'
-  hicpp-use-emplace.EmplacyFunctions: 'vector::emplace_back;vector::emplace;deque::emplace;deque::emplace_front;deque::emplace_back;forward_list::emplace_after;forward_list::emplace_front;list::emplace;list::emplace_back;list::emplace_front;set::emplace;set::emplace_hint;map::emplace;map::emplace_hint;multiset::emplace;multiset::emplace_hint;multimap::emplace;multimap::emplace_hint;unordered_set::emplace;unordered_set::emplace_hint;unordered_map::emplace;unordered_map::emplace_hint;unordered_multiset::emplace;unordered_multiset::emplace_hint;unordered_multimap::emplace;unordered_multimap::emplace_hint;stack::emplace;queue::emplace;priority_queue::emplace'
-  cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors: 'false'
-  modernize-make-unique.IgnoreMacros: 'true'
-  performance-for-range-copy.AllowedTypes: ''
-  hicpp-function-size.BranchThreshold: '4294967295'
-  misc-const-correctness.AnalyzeReferences: 'true'
-  bugprone-unchecked-optional-access.IgnoreSmartPointerDereference: 'false'
-  bugprone-argument-comment.CommentBoolLiterals: '0'
-  readability-braces-around-statements.ShortStatementLines: '0'
-  bugprone-argument-comment.CommentUserDefinedLiterals: '0'
-  hicpp-use-emplace.ContainersWithPushBack: '::std::vector;::std::list;::std::deque'
-  abseil-string-find-startswith.StringLikeClasses: '::std::basic_string'
-  hicpp-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted: 'false'
-  readability-redundant-declaration.IgnoreMacros: 'true'
-  performance-inefficient-string-concatenation.StrictMode: 'false'
-  readability-magic-numbers.IgnoredFloatingPointValues: '1.0;100.0;'
-  bugprone-easily-swappable-parameters.IgnoredParameterTypeSuffixes: 'bool;Bool;_Bool;it;It;iterator;Iterator;inputit;InputIt;forwardit;ForwardIt;bidirit;BidirIt;constiterator;const_iterator;Const_Iterator;Constiterator;ConstIterator;RandomIt;randomit;random_iterator;ReverseIt;reverse_iterator;reverse_const_iterator;ConstReverseIterator;Const_Reverse_Iterator;const_reverse_iterator;Constreverseiterator;constreverseiterator'
-  modernize-make-unique.MakeSmartPtrFunction: 'std::make_unique'
-  google-runtime-int.TypeSuffix: ''
-  hicpp-function-size.ParameterThreshold: '4294967295'
-  cert-dcl51-cpp.AllowedIdentifiers: ''
-  abseil-cleanup-ctad.IncludeStyle: llvm
-  cert-oop57-cpp.MemCpyNames: ''
-  modernize-make-unique.MakeSmartPtrFunctionHeader: '<memory>'
-  bugprone-signal-handler.AsyncSafeFunctionSet: POSIX
-  bugprone-easily-swappable-parameters.ModelImplicitConversions: 'true'
-  readability-suspicious-call-argument.SubstringSimilarAbove: '50'
-  cppcoreguidelines-narrowing-conversions.WarnWithinTemplateInstantiation: 'false'
-  portability-restrict-system-includes.Includes: '*'
-  performance-move-const-arg.CheckMoveToConstRef: 'true'
-  readability-identifier-length.MinimumVariableNameLength: '3'
-  modernize-use-emplace.EmplacyFunctions: 'vector::emplace_back;vector::emplace;deque::emplace;deque::emplace_front;deque::emplace_back;forward_list::emplace_after;forward_list::emplace_front;list::emplace;list::emplace_back;list::emplace_front;set::emplace;set::emplace_hint;map::emplace;map::emplace_hint;multiset::emplace;multiset::emplace_hint;multimap::emplace;multimap::emplace_hint;unordered_set::emplace;unordered_set::emplace_hint;unordered_map::emplace;unordered_map::emplace_hint;unordered_multiset::emplace;unordered_multiset::emplace_hint;unordered_multimap::emplace;unordered_multimap::emplace_hint;stack::emplace;queue::emplace;priority_queue::emplace'
-  zircon-temporary-objects.Names: ''
-  hicpp-use-emplace.TupleTypes: '::std::pair;::std::tuple'
-  cppcoreguidelines-narrowing-conversions.WarnOnEquivalentBitWidth: 'true'
-  cppcoreguidelines-non-private-member-variables-in-classes.IgnorePublicMemberVariables: 'false'
-  fuchsia-header-anon-namespaces.HeaderFileExtensions: ';h;hh;hpp;hxx'
-  cppcoreguidelines-special-member-functions.AllowMissingMoveFunctionsWhenCopyIsDeleted: 'false'
-  cert-oop57-cpp.MemCmpNames: ''
-  modernize-use-noexcept.UseNoexceptFalse: 'true'
-  readability-function-cognitive-complexity.Threshold: '25'
-  cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: 'true'
-  readability-simplify-boolean-expr.SimplifyDeMorganRelaxed: 'false'
-  bugprone-narrowing-conversions.WarnOnEquivalentBitWidth: 'true'
-  bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression: 'false'
-  performance-faster-string-find.StringLikeClasses: '::std::basic_string;::std::basic_string_view'
-  bugprone-assert-side-effect.CheckFunctionCalls: 'false'
-  google-readability-function-size.VariableThreshold: '4294967295'
-  cppcoreguidelines-narrowing-conversions.WarnOnIntegerToFloatingPointNarrowingConversion: 'true'
-  bugprone-string-constructor.StringNames: '::std::basic_string;::std::basic_string_view'
-  bugprone-assert-side-effect.AssertMacros: assert,NSAssert,NSCAssert
-  bugprone-exception-escape.IgnoredExceptions: ''
-  bugprone-signed-char-misuse.DiagnoseSignedUnsignedCharComparisons: 'true'
-  modernize-use-default-member-init.IgnoreMacros: 'true'
-  llvm-qualified-auto.AddConstToQualified: 'false'
-  hicpp-use-emplace.ContainersWithPush: '::std::stack;::std::queue;::std::priority_queue'
-  altera-unroll-loops.MaxLoopIterations: '100'
-  cert-str34-c.CharTypdefsToIgnore: ''
-  misc-use-anonymous-namespace.HeaderFileExtensions: ';h;hh;hpp;hxx'
-  llvm-else-after-return.WarnOnConditionVariables: 'false'
-  bugprone-sizeof-expression.WarnOnSizeOfCompareToConstant: 'true'
-  bugprone-argument-comment.IgnoreSingleArgument: '0'
-  modernize-raw-string-literal.DelimiterStem: lit
-  readability-suspicious-call-argument.Dice: 'true'
-  misc-throw-by-value-catch-by-reference.WarnOnLargeObjects: 'false'
-  readability-identifier-length.IgnoredLoopCounterNames: '^[ijk_]$'
-  cert-dcl37-c.Invert: 'false'
-  altera-single-work-item-barrier.AOCVersion: '1600'
-  cppcoreguidelines-avoid-do-while.IgnoreMacros: 'false'
-  modernize-raw-string-literal.ReplaceShorterLiterals: 'false'
-  readability-implicit-bool-conversion.AllowPointerConditions: 'false'
-  performance-inefficient-vector-operation.VectorLikeClasses: '::std::vector'
-  modernize-use-auto.RemoveStars: 'false'
-  abseil-string-find-str-contains.IncludeStyle: llvm
-  bugprone-implicit-widening-of-multiplication-result.IncludeStyle: llvm
-  portability-simd-intrinsics.Std: ''
-  hicpp-use-nullptr.NullMacros: ''
-  readability-redundant-member-init.IgnoreBaseInCopyConstructors: 'false'
-  modernize-replace-disallow-copy-and-assign-macro.MacroName: DISALLOW_COPY_AND_ASSIGN
-  performance-unnecessary-value-param.IncludeStyle: llvm
-  llvm-else-after-return.WarnOnUnfixable: 'false'
-  cert-msc32-c.DisallowedSeedTypes: 'time_t,std::time_t'
-...
+# vi: ft=yaml
+Checks: >
+  -*,
+  bugprone-*,
+  cert-dcl21-cpp,
+  cert-dcl50-cpp,
+  cert-env33-c,
+  cert-err34-c,
+  cert-err52-cpp,
+  cert-err60-cpp,
+  cert-flp30-c,
+  cert-msc50-cpp,
+  cert-msc51-cpp,
+  clang-analyzer-*,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  google-build-using-namespace,
+  google-explicit-constructor,
+  google-global-names-in-headers,
+  google-readability-casting,
+  google-runtime-int,
+  google-runtime-operator,
+  hicpp-*,
+  -hicpp-vararg,
+  misc-*,
+  modernize-*,
+  performance-*,
+  readability-*,
+  -hicpp-new-delete-operators,
+  -modernize-use-trailing-return-type
 
+CheckOptions:
+  - key: bugprone-argument-comment.StrictMode
+    value: 1
+  - key: bugprone-easily-swappable-parameters.MinimumLength
+    value: 4
+  - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value: 1
+  - key: readability-identifier-length.IgnoredVariableNames
+    value: '^it$'
+  - key: readability-magic-numbers.IgnoreAllFloatingPointValues
+    value: 'true'
+  - key: cppcoreguidelines-avoid-magic-numbers.IgnoreAllFloatingPointValues
+    value: 'true'
+FormatStyle: 'file'


### PR DESCRIPTION
Applying stricter rules for clang-tidy checks.

@klenze I changed most of your settings to the default values of clang-tidy 15. I didn't check your settings one by one and am very glad to know what should be kept.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
