### PR TITLE
Changed Y position calculation for mwpc1

### DIFF
--- a/mwpc/mwpc1/R3BMwpc1Cal2Hit.cxx
+++ b/mwpc/mwpc1/R3BMwpc1Cal2Hit.cxx
@@ -34,6 +34,9 @@
 #include "R3BMwpcCalData.h"
 #include "R3BMwpcHitData.h"
 
+constexpr int S522 = 522;
+constexpr int S509 = 509;
+
 // R3BMwpc1Cal2Hit: Default Constructor --------------------------
 R3BMwpc1Cal2Hit::R3BMwpc1Cal2Hit()
     : R3BMwpc1Cal2Hit("R3BMwpc1Cal2Hit", 1)
@@ -107,6 +110,17 @@ Double_t R3BMwpc1Cal2Hit::GetPositionX(Double_t qmax, Int_t padmax, Double_t qle
                                                     (2 * TMath::SinH(TMath::Pi() * fwx / a3)));
 
     return (-1. * padmax * fwx + (fSize / 2) - (fwx / 2) - a2); // Left is positive and right negative
+}
+
+/* ----   Protected method to obtain the position Y ---- */
+Double_t R3BMwpc1Cal2Hit::GetPositionYCoG(Double_t qmax, Int_t padmax, Double_t qdown, Double_t qup) const
+{
+   const double pos1 = (padmax-1) * fwy - (fSize / 2) + (fwy / 2);
+   const double pos2 = padmax * fwy - (fSize / 2) + (fwy / 2);
+   const double pos3 = (padmax+1) * fwy - (fSize / 2) + (fwy / 2);
+   const double center_of_mass = (pos1*qdown + pos2*qmax + pos3*qup)/(qmax+qdown+qup);
+
+   return center_of_mass;
 }
 
 /* ----   Protected method to obtain the position Y ---- */
@@ -203,8 +217,12 @@ void R3BMwpc1Cal2Hit::S467()
         // Obtain position Y ----
         qdown = fy[padmy - 1];
         qup = fy[padmy + 1];
-        if (qdown > 0 && qup > 0)
+        // TODO: check if systematic statistics loss is experiment specific, put general solution if not
+        if (header->GetExpId()==S522 ||  header->GetExpId()==S509){
+            y = GetPositionYCoG(qmy, padmy, qdown, qup);
+        } else if (qdown > 0 && qup > 0){
             y = GetPositionY(qmy, padmy, qdown, qup);
+        }
 
         AddHitData(x, y);
     }

--- a/mwpc/mwpc1/R3BMwpc1Cal2Hit.h
+++ b/mwpc/mwpc1/R3BMwpc1Cal2Hit.h
@@ -95,6 +95,8 @@ class R3BMwpc1Cal2Hit : public FairTask
     Double_t GetPositionX(Double_t qmax, Int_t padmax, Double_t qleft, Double_t qright);
     /** Private method to obtain the position Y **/
     Double_t GetPositionY(Double_t qmax, Int_t padmax, Double_t qdown, Double_t qup);
+    /** Private method to obtain the position Y **/
+    [[nodiscard]] Double_t GetPositionYCoG(Double_t qmax, Int_t padmax, Double_t qdown, Double_t qup) const ;
 
   public:
     // Class definition


### PR DESCRIPTION
We noticed that for the S522/S509 experiments, the Y position of MWPC1 seems to be set to -1000 mm in almost 50% of all data.

After looking at the code, we noticed that when the function GetPositionY is called it requires that at least 3 pads have a charge different than zero which is not the case most of the time.

The implemented code instead of calling the GetPositionY function, calls a new function named GetPositionYS522 which calculates the center of mass for the existing pads. These changes have only been applied to Y of mwpc1 as is the most problematic. I believe these changes should not affect anyone else as it is locked to expID S522 or S509.

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
