### PR TITLE
Increase clang-tidy complexity threshold and ignore macro

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -42,4 +42,9 @@ CheckOptions:
     value: 'true'
   - key: cppcoreguidelines-avoid-magic-numbers.IgnoreAllFloatingPointValues
     value: 'true'
+  - key: readability-function-cognitive-complexity.Threshold
+    value: 40
+  - key: readability-function-cognitive-complexity.IgnoreMacros
+    value: 'true'
+
 FormatStyle: 'file'


### PR DESCRIPTION
Increase threshold of complexity from clang-tidy from 25 (default) to 40. Also all macros are ignored.

For more info, please refer to [this](https://clang.llvm.org/extra/clang-tidy/checks/readability/function-cognitive-complexity.html)

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
