### PR TITLE
CI/CD: Migration to Github-hosted runners for nov22

### DIFF
--- a/.github/actions/cache-steps/action.yml
+++ b/.github/actions/cache-steps/action.yml
@@ -1,0 +1,36 @@
+name: cache-steps
+description: 'steps to cache R3BRoot and ucesb'
+
+
+inputs:
+  r3b-dev-SHA:
+    description: 'SHA for r3b dev cache'
+    required: true
+  repo:
+    description: 'repository name'
+    required: true
+outputs:
+  ucesb-hit:
+    description: 'whether ucesb cache is hit'
+    value: ${{steps.cache-ucesb.outputs.cache-hit}}
+  r3b-hit:
+    description: 'whether r3b cache is hit'
+    value: ${{steps.cache-r3b.outputs.cache-hit}}
+
+runs:
+  using: composite
+  steps:
+    - name: cache ucesb
+      # if: inputs.repo == 'r3broot'
+      id: cache-ucesb
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.UCESB_DIR }}
+        key: ucesb-build
+
+    - name: cache r3b
+      id: cache-r3b
+      uses: actions/cache@v3
+      with:
+        path: .ccache
+        key: r3b-build-${{ inputs.repo }}-${{ inputs.r3b-dev-SHA }}

--- a/.github/actions/pre-build/action.yml
+++ b/.github/actions/pre-build/action.yml
@@ -1,0 +1,37 @@
+name: pre build
+description: 'steps before building R3BRoot'
+
+runs:
+  using: composite
+  steps:
+    - name: set env variables
+      run: |
+        git config --global --add safe.directory $GITHUB_WORKSPACE
+        echo "UCESB_DIR=$GITHUB_WORKSPACE/ucesb/" >> $GITHUB_ENV
+        export SIMPATH=${CVMDIR}/debian10/fairsoft/nov22p1
+        echo "SIMPATH=${SIMPATH}" >> $GITHUB_ENV
+        echo "FAIRROOTPATH=${CVMDIR}/debian10/fairroot/v18.8.0_fs_nov22p1" >> $GITHUB_ENV
+        echo "${SIMPATH}/bin" >> $GITHUB_PATH
+        # variables for ccache
+        echo "CCACHE_BASEDIR=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
+        echo "CCACHE_DIR=${GITHUB_WORKSPACE}/.ccache" >> $GITHUB_ENV
+        echo "CCACHE_COMPRESS=true" >> $GITHUB_ENV
+        echo "CCACHE_COMPRESSLEVEL=6" >> $GITHUB_ENV
+        echo "SOURCEDIR=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+        echo "BUILDDIR=$GITHUB_WORKSPACE/build" >> $GITHUB_ENV
+        echo "cacheSHA=$([[ ${{github.event_name}} = "push" ]] && git rev-parse --short HEAD || git rev-parse --short HEAD^)" >> $GITHUB_ENV
+      shell: bash
+
+
+    - name: mount cvmfs
+      run: |
+        apt-get install -y ccache
+        wget https://cernbox.cern.ch/remote.php/dav/public-files/RmnTeeOZpYjCJQb/masterkey.gsi.de.pub
+        mv masterkey.gsi.de.pub /etc/cvmfs/keys
+        cp .githubfiles/fairsoft.gsi.de.conf /etc/cvmfs/config.d
+        mkdir -p ${CVMDIR}
+        mount -t cvmfs fairsoft.gsi.de ${CVMDIR}
+        mkdir -p ${UCESB_DIR}
+        mkdir -p ${CCACHE_DIR}
+        echo $PATH
+      shell: bash

--- a/.github/actions/r3bbuild-steps/action.yml
+++ b/.github/actions/r3bbuild-steps/action.yml
@@ -1,0 +1,49 @@
+name: build-steps
+description: 'steps to build R3BRoot and ucesb'
+
+
+inputs:
+  ucesb-cache-existed:
+    description: 'has ucesb build cache'
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: check
+      run: |
+        echo "${{ inputs.ucesb-cache-existed }}"
+      shell: bash
+
+    - name: build ucesb
+      if: inputs.ucesb-cache-existed != 'true'
+      run: |
+        echo "ucesb directory is set as ${UCESB_DIR}"
+        export LD_LIBRARY_PATH="${SIMPATH}/lib/:${LD_LIBRARY_PATH}"
+        git clone https://git.chalmers.se/expsubphys/ucesb.git ${UCESB_DIR}
+        cd ${UCESB_DIR} && make -j${NUM_THREADS} empty/empty
+      shell: bash
+
+    - if: ${{ matrix.url }}
+      name: add other repos
+      run: |
+        cd $GITHUB_WORKSPACE
+        for url in ${{ matrix.url }};
+        do
+          git clone -b dev ${url}
+        done
+      shell: bash
+
+    - name: cmake configure ${{ matrix.repos }}
+      run: |
+        git config --global --add safe.directory $GITHUB_WORKSPACE
+        git clone https://github.com/R3BRootGroup/macros.git
+        cmake --fresh . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=on -DBUILD_GEOMETRY=OFF -DUSE_DIFFERENT_COMPILER=TRUE \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+      shell: bash
+
+    - name: cmake build ${{ matrix.repos }}
+      run: |
+        cmake --build ./build -- -j ${NUM_THREADS}
+      shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 # This is a basic workflow to help you get started with Actions
-name: CI C17++
+name: CI-CD
 
 # Controls when the action will run. 
 on:
@@ -14,108 +14,63 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially
 jobs:
-  # This workflow contains a single job called "clang-format"
-  clang-format:
-    runs-on: self-hosted
+  build-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # repos: [ r3broot, sofia, frs, asyeos, glad-tpc ]
+        repos: [ r3broot, glad-tpc, sofia-frs-asy ]
+        include:
+          - repos: r3broot
+            cache: r3broot
+          - repos: glad-tpc
+            url: https://github.com/R3BRootGroup/glad-tpc.git
+            cache: r3broot
+          - repos: sofia-frs-asy
+            url: >-
+              https://github.com/R3BRootGroup/sofia.git
+              https://github.com/R3BRootGroup/frs.git
+              https://github.com/R3BRootGroup/asyeos.git
+            cache: other-repos
 
+    container: 
+      image: yanzhaowang/cvmfs_clang:v15
+      volumes:
+        - /tmp:/cvmfs
+      env:
+        CVMDIR: /cvmfs/fairsoft.gsi.de
+        NUM_THREADS: 2
+      options: --user root --privileged  --ulimit nofile=10000:10000 --cap-add SYS_ADMIN --device /dev/fuse
     steps:
       - uses: actions/checkout@v3
+        with:
+         fetch-depth: 0
 
-      - name: Code formatting
+      - name: pre-build
+        uses: './.github/actions/pre-build'
+
+      - name: caching
+        id: caching
+        uses: './.github/actions/cache-steps'
+        with: 
+          r3b-dev-SHA: ${{ env.cacheSHA }}
+          # repo: ${{ matrix.repos }}
+          repo: ${{ matrix.cache }}
+
+      - name: build r3broot
+        uses: './.github/actions/r3bbuild-steps'
+        with:
+          ucesb-cache-existed: ${{ steps.caching.outputs.ucesb-hit }}
+
+      - name: ctest
+        # run: source $GITHUB_WORKSPACE/Dart.sh Experimental $GITHUB_WORKSPACE/.githubfiles/dart_github_CICD.cfg
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
-          cd $GITHUB_WORKSPACE
-          singularity exec /data.local2/kresan/debian10-apr22-v18.6.8-ucesb.sif $PWD/util/clang-format-check.sh clang-format-8
-  # Single job called "build-r3broot"
-  build-r3broot:
-    # The type of runner that the job will run on
-    runs-on: self-hosted
-    needs: clang-format
-    if: always()
+          source $GITHUB_WORKSPACE/util/generate_geo_test.sh
+          ctest --test-dir ${BUILDDIR} --output-on-failure --rerun-failed -j${NUM_THREADS} -E "(run_gen_sim|run_digi|run_aladin_digi|califasim2|landreco|elsim)"
+        shell: bash
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-
-      # Runs a set of commands using the runners shell
-      - name: Run Dart.sh
-        run: |
-          cd $GITHUB_WORKSPACE
-          git clone -b dev https://github.com/R3BRootGroup/macros.git
-          singularity exec /data.local2/kresan/debian10-apr22-v18.6.8-ucesb.sif $PWD/.githubfiles/run_build_test_apr22.sh
-  # Single job called "build-r3broot-sofia"
-  build-r3broot-sofia:
-    # The type of runner that the job will run on
-    runs-on: self-hosted
-    needs: build-r3broot
-    if: always()
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-
-      # Runs a set of commands using the runners shell
-      - name: Run Dart.sh
-        run: |
-          cd $GITHUB_WORKSPACE
-          git clone -b dev https://github.com/R3BRootGroup/macros.git
-          git clone -b dev https://github.com/R3BRootGroup/sofia.git
-          singularity exec /data.local2/kresan/debian10-apr22-v18.6.8-ucesb.sif $PWD/.githubfiles/run_build_test_apr22.sh
-  # Single job called "build-r3broot-asyeos"
-#  build-r3broot-asyeos:
-    # The type of runner that the job will run on
-#    runs-on: self-hosted
-#    needs: build-r3broot
-#    if: always()
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-#    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-#      - uses: actions/checkout@v3
-
-      # Runs a set of commands using the runners shell
-#      - name: Run Dart.sh
-#        run: |
-#          cd $GITHUB_WORKSPACE
-#          git clone -b dev https://github.com/R3BRootGroup/macros.git
-#          git clone -b dev https://github.com/R3BRootGroup/asyeos.git
-#          singularity exec /data.local2/kresan/debian10-apr22-v18.6.8-ucesb.sif $PWD/.githubfiles/run_build_test_apr22.sh
-  # Single job called "build-r3broot-glad-tpc"
-#  build-r3broot-glad-tpc:
-    # The type of runner that the job will run on
-#    runs-on: self-hosted
-#    needs: build-r3broot
-#    if: always()
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-#    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-#      - uses: actions/checkout@v3
-
-      # Runs a set of commands using the runners shell
-      # git clone -b dev https://github.com/R3BRootGroup/glad-tpc.git
-#      - name: Run Dart.sh
-#        run: |
-#          cd $GITHUB_WORKSPACE
-#          git clone -b dev https://github.com/R3BRootGroup/macros.git
-#          singularity exec /data.local2/kresan/debian10-apr22-v18.6.8-ucesb.sif $PWD/.githubfiles/run_build_test_apr22.sh
-#  # Single job called "build-r3broot-frs"
-  build-r3broot-frs:
-    # The type of runner that the job will run on
-    runs-on: self-hosted
-    needs: build-r3broot-sofia
-    if: always()
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-
-      # Runs a set of commands using the runners shell
-      - name: Run Dart.sh
-        run: |
-          cd $GITHUB_WORKSPACE
-          git clone -b dev https://github.com/R3BRootGroup/macros.git
-          git clone -b dev https://github.com/R3BRootGroup/frs.git
-          singularity exec /data.local2/kresan/debian10-apr22-v18.6.8-ucesb.sif $PWD/.githubfiles/run_build_test_apr22.sh
+      - name: ccache stats
+        if: ${{ github.event_name == 'pull_request' }}
+        run: ccache --show-stats

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,11 +281,7 @@ if(    yaml-cpp_FOUND
   )
 endif()
 
-find_package(GTest)
-if(NOT GTEST_FOUND)
-    message(STATUS "GTest is not found in local system!")
-    include(${CMAKE_SOURCE_DIR}/cmake/scripts/fetchGTest.cmake)
-endif()
+include(${CMAKE_SOURCE_DIR}/cmake/scripts/fetchGTest.cmake)
 
 SetBasicVariables()
 

--- a/cmake/scripts/fetchGTest.cmake
+++ b/cmake/scripts/fetchGTest.cmake
@@ -11,15 +11,18 @@
 # or submit itself to any jurisdiction.                                      #
 ##############################################################################
 
-message(STATUS "Fetching GTest...")
-include(FetchContent)
-FetchContent_Declare(
-  googletest
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.12.1
-)
-FetchContent_MakeAvailable(googletest)
+find_package(GTest)
+if(NOT GTEST_FOUND)
+    message(STATUS "GTest is not found in local system!")
+    message(STATUS "Fetching GTest...")
+    include(FetchContent)
+    fetchcontent_declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG release-1.12.1)
+    fetchcontent_makeavailable(googletest)
+    set(GTEST_FOUND true)
+endif()
 
-set(GTEST_FOUND true)
 enable_testing()
 include(GoogleTest)

--- a/neuland/test/CMakeLists.txt
+++ b/neuland/test/CMakeLists.txt
@@ -42,7 +42,7 @@ if(GTEST_FOUND)
 
     add_executable(${PROJECT_TEST_NAME} ${TEST_SRC_FILES})
     target_link_libraries(${PROJECT_TEST_NAME} ${TEST_DEPENDENCIES})
-    gtest_discover_tests(${PROJECT_TEST_NAME})
+    gtest_discover_tests(${PROJECT_TEST_NAME} DISCOVERY_TIMEOUT 600)
 endif(GTEST_FOUND)
 
 generate_root_test_script(${R3BROOT_SOURCE_DIR}/neuland/test/testNeulandSimulation.C)

--- a/util/generate_geo_test.sh
+++ b/util/generate_geo_test.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+if [ -z "${GITHUB_WORKSPACE}" ];
+then
+    echo "Not in github CI/CD test!"
+    exit 0
+fi
+
+config=${GITHUB_WORKSPACE}/build/config.sh
+if [ -f "${config}" ]; 
+then
+    source ${config}
+else
+    echo "Failed to source config.sh in the build folder!"
+    exit 1
+fi
+
+root -l -q -x ${GITHUB_WORKSPACE}/music/geobase/create_music_geo.C
+root -l -q -x ${GITHUB_WORKSPACE}/rpc/geobase/create_rpc_geo.C
+root -l -q -x ${GITHUB_WORKSPACE}/alpide/geobase/create_target_area_2023_geo.C
+root -l -q -x ${GITHUB_WORKSPACE}/mwpc/geobase/create_mwpc0_geo.C
+root -l -q -x ${GITHUB_WORKSPACE}/mwpc/geobase/create_mwpc1and2_geo.C
+root -l -q -x ${GITHUB_WORKSPACE}/twim/geobase/create_twin_geo.C
+
+if [ -d "${GITHUB_WORKSPACE}/sofia" ];
+then
+    root -l -q -x ${GITHUB_WORKSPACE}/sofia/tofwall/geobase/create_softofw_geo.C
+fi


### PR DESCRIPTION
Change to Github hosted runners for CI/CD test.

### Main features:
1. Use cvmfs inside a docker container to create an environment for the R3BRoot configuration, compilation and test.
2. Use cache and ccache to speed up the compilation process. An uncached process takes around 20 mins in total while a cached process takes only 10 mins in our case.
3. There are two caches for each PR, namely, `r3b-build-r3broot` and `r3b-build-sofia`.
4. New caches named with different SHA will be automatically created when PR is merged into the dev branch.
5. Every cache can only last 7 days unused. 
6. ctest is run with the `ctest` command.

### TODO:
1. There is a very small chance where tests for the PR are successful but tests for merging fail. We should keep a close eye on this rare situation.
2. All tests in `macros` are not run. For some reasons, they can't be run with the `ctest` command.
3. ~~All gtests also fail to run even though googletest has been installed in the environment. I will investigate this later.~~
4. Current runners only have 2 cores. With larger Github-hosted runners (4, 8, 16 cores), CI/CD process can even be faster.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
