### PR TITLE
Add GTest dependency if not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,12 @@ if(    yaml-cpp_FOUND
   )
 endif()
 
+find_package(GTest)
+if(NOT GTEST_FOUND)
+    message(STATUS "GTest is not found in local system!")
+    include(${CMAKE_SOURCE_DIR}/cmake/scripts/fetchGTest.cmake)
+endif()
+
 SetBasicVariables()
 
 # Set the library version in the main CMakeLists.txt

--- a/cmake/scripts/fetchGTest.cmake
+++ b/cmake/scripts/fetchGTest.cmake
@@ -1,0 +1,25 @@
+##############################################################################
+#   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    #
+#   Copyright (C) 2019-2023 Members of R3B Collaboration                     #
+#                                                                            #
+#             This software is distributed under the terms of the            #
+#                 GNU General Public Licence (GPL) version 3,                #
+#                    copied verbatim in the file "LICENSE".                  #
+#                                                                            #
+# In applying this license GSI does not waive the privileges and immunities  #
+# granted to it by virtue of its status as an Intergovernmental Organization #
+# or submit itself to any jurisdiction.                                      #
+##############################################################################
+
+message(STATUS "Fetching GTest...")
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        release-1.12.1
+)
+FetchContent_MakeAvailable(googletest)
+
+set(GTEST_FOUND true)
+enable_testing()
+include(GoogleTest)

--- a/neuland/test/CMakeLists.txt
+++ b/neuland/test/CMakeLists.txt
@@ -11,57 +11,52 @@
 # or submit itself to any jurisdiction.                                      #
 ##############################################################################
 
-cmake_minimum_required(VERSION 3.0)
-
-enable_testing()
+cmake_minimum_required(VERSION 3.10)
 set(PROJECT_TEST_NAME NeulandUnitTests)
-set(GTEST_ROOT ${SIMPATH})
-find_package(GTest)
 
 if(GTEST_FOUND)
-file(GLOB TEST_SRC_FILES ${PROJECT_SOURCE_DIR}/neuland/test/*.cxx)
+    file(GLOB TEST_SRC_FILES ${PROJECT_SOURCE_DIR}/neuland/test/*.cxx)
 
-include_directories(
-    ${GTEST_INCLUDE_DIRS}
-    ${SYSTEM_INCLUDE_DIRECTORIES}
-    ${BASE_INCLUDE_DIRECTORIES}
-    ${R3BROOT_SOURCE_DIR}/r3bbase
-    ${R3BROOT_SOURCE_DIR}/r3bdata/neulandData
-    ${R3BROOT_SOURCE_DIR}/neuland/shared
-    ${R3BROOT_SOURCE_DIR}/neuland/reconstruction
-    ${R3BROOT_SOURCE_DIR}/neuland/reconstruction/multiplicity)
+    include_directories(
+        ${SYSTEM_INCLUDE_DIRECTORIES}
+        ${BASE_INCLUDE_DIRECTORIES}
+        ${R3BROOT_SOURCE_DIR}/r3bbase
+        ${R3BROOT_SOURCE_DIR}/r3bdata/neulandData
+        ${R3BROOT_SOURCE_DIR}/neuland/shared
+        ${R3BROOT_SOURCE_DIR}/neuland/reconstruction
+        ${R3BROOT_SOURCE_DIR}/neuland/reconstruction/multiplicity)
 
-link_directories(${GTEST_LIBS_DIR} ${ROOT_LIBRARY_DIR} ${FAIRROOT_LIBRARY_DIR}
-                 ${Boost_LIBRARY_DIRS})
+    link_directories(${ROOT_LIBRARY_DIR} ${FAIRROOT_LIBRARY_DIR}
+        ${Boost_LIBRARY_DIRS})
 
-set(TEST_DEPENDENCIES
-    ${GTEST_BOTH_LIBRARIES}
-    ${ROOT_LIBRARIES}
-    FairTools
-    R3BData
-    ParBase
-    GeoBase
-    R3BNeulandShared
-    R3BNeulandReconstruction
-    Alignment)
+    set(TEST_DEPENDENCIES
+        GTest::gtest_main
+        ${ROOT_LIBRARIES}
+        FairTools
+        R3BData
+        ParBase
+        GeoBase
+        R3BNeulandShared
+        R3BNeulandReconstruction
+        Alignment)
 
-add_executable(${PROJECT_TEST_NAME} ${TEST_SRC_FILES})
-target_link_libraries(${PROJECT_TEST_NAME} ${TEST_DEPENDENCIES})
-add_test(${PROJECT_TEST_NAME} ${EXECUTABLE_OUTPUT_PATH}/${PROJECT_TEST_NAME})
+    add_executable(${PROJECT_TEST_NAME} ${TEST_SRC_FILES})
+    target_link_libraries(${PROJECT_TEST_NAME} ${TEST_DEPENDENCIES})
+    gtest_discover_tests(${PROJECT_TEST_NAME})
 endif(GTEST_FOUND)
 
 generate_root_test_script(${R3BROOT_SOURCE_DIR}/neuland/test/testNeulandSimulation.C)
 add_test(NeulandSimulation ${R3BROOT_BINARY_DIR}/neuland/test/testNeulandSimulation.sh)
 set_tests_properties(NeulandSimulation PROPERTIES TIMEOUT "2000")
 set_tests_properties(NeulandSimulation PROPERTIES PASS_REGULAR_EXPRESSION
-                                                  "Macro finished successfully.")
+    "Macro finished successfully.")
 
 generate_root_test_script(${R3BROOT_SOURCE_DIR}/neuland/test/testNeulandDigitizer.C)
 add_test(NeulandDigitizer ${R3BROOT_BINARY_DIR}/neuland/test/testNeulandDigitizer.sh)
 set_tests_properties(NeulandDigitizer PROPERTIES DEPENDS NeulandSimulation)
 set_tests_properties(NeulandDigitizer PROPERTIES TIMEOUT "1000")
 set_tests_properties(NeulandDigitizer PROPERTIES PASS_REGULAR_EXPRESSION
-                                                 "Macro finished successfully.")
+    "Macro finished successfully.")
 
 generate_root_test_script(${R3BROOT_SOURCE_DIR}/neuland/test/testNeulandTrain.C)
 add_test(NeulandTrain ${R3BROOT_BINARY_DIR}/neuland/test/testNeulandTrain.sh)
@@ -74,6 +69,6 @@ add_test(NeulandReconstruction ${R3BROOT_BINARY_DIR}/neuland/test/testNeulandRec
 set_tests_properties(NeulandReconstruction PROPERTIES DEPENDS NeulandTrain)
 set_tests_properties(NeulandReconstruction PROPERTIES TIMEOUT "1000")
 set_tests_properties(NeulandReconstruction PROPERTIES PASS_REGULAR_EXPRESSION
-                                                      "Macro finished successfully.")
+    "Macro finished successfully.")
 
 add_subdirectory(calibration)


### PR DESCRIPTION
### Changes
1. Add Googletest dependency using cmake Fetchcontent if it's not found in the local system.
2. Change the gtest lib name from `${GTEST_BOTH_LIBRARIES}` to `GTest::gtest_main`. The former one has been deprecated in newer versions.

### Fixes
1. Close the issue #738 
2. Fix the PR #840 regarding being unable to run gtest.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
