### PR TITLE
Add ucesb dependency to clang-tidy

### DIFF
--- a/.github/actions/cache-steps/action.yml
+++ b/.github/actions/cache-steps/action.yml
@@ -5,10 +5,12 @@ description: 'steps to cache R3BRoot and ucesb'
 inputs:
   r3b-dev-SHA:
     description: 'SHA for r3b dev cache'
-    required: true
+    required: false
+    default: ''
   repo:
     description: 'repository name'
-    required: true
+    required: false
+    default: 'false'
 outputs:
   ucesb-hit:
     description: 'whether ucesb cache is hit'
@@ -21,7 +23,6 @@ runs:
   using: composite
   steps:
     - name: cache ucesb
-      # if: inputs.repo == 'r3broot'
       id: cache-ucesb
       uses: actions/cache@v3
       with:
@@ -29,6 +30,7 @@ runs:
         key: ucesb-build
 
     - name: cache r3b
+      if: inputs.repo != 'false'
       id: cache-r3b
       uses: actions/cache@v3
       with:

--- a/.github/actions/r3bbuild-steps/action.yml
+++ b/.github/actions/r3bbuild-steps/action.yml
@@ -7,15 +7,14 @@ inputs:
     description: 'has ucesb build cache'
     required: false
     default: 'false'
+  build-needed:
+    description: 'build process is needed'
+    required: false
+    default: 'true'
 
 runs:
   using: composite
   steps:
-    - name: check
-      run: |
-        echo "${{ inputs.ucesb-cache-existed }}"
-      shell: bash
-
     - name: build ucesb
       if: inputs.ucesb-cache-existed != 'true'
       run: |
@@ -44,6 +43,7 @@ runs:
       shell: bash
 
     - name: cmake build ${{ matrix.repos }}
+      if: inputs.build-needed == 'true'
       run: |
         cmake --build ./build -- -j ${NUM_THREADS}
       shell: bash

--- a/.github/workflows/clangtidy.yml
+++ b/.github/workflows/clangtidy.yml
@@ -24,22 +24,20 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: mount cvmfs
-      run: |
-        wget https://cernbox.cern.ch/remote.php/dav/public-files/RmnTeeOZpYjCJQb/masterkey.gsi.de.pub
-        mv masterkey.gsi.de.pub /etc/cvmfs/keys
-        cp .githubfiles/fairsoft.gsi.de.conf /etc/cvmfs/config.d
-        mkdir -p ${CVMDIR}
-        mount -t cvmfs fairsoft.gsi.de ${CVMDIR}
+    - name: pre-build
+      uses: './.github/actions/pre-build'
 
-    - name: cmake configure
-      run: |
-        export SIMPATH=${CVMDIR}/debian10/fairsoft/nov22p1
-        export FAIRROOTPATH=${CVMDIR}/debian10/fairroot/v18.8.0_fs_nov22p1
-        export PATH=${SIMPATH}/bin:$PATH
-        git config --global --add safe.directory $GITHUB_WORKSPACE
-        git clone https://github.com/R3BRootGroup/macros.git
-        cmake . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=on -DBUILD_GEOMETRY=OFF -DUSE_DIFFERENT_COMPILER=TRUE
+    - name: caching
+      id: caching
+      uses: './.github/actions/cache-steps'
+      with: 
+        repo: 'false'
+
+    - name: configure r3broot
+      uses: './.github/actions/r3bbuild-steps'
+      with:
+        ucesb-cache-existed: ${{ steps.caching.outputs.ucesb-hit }}
+        build-needed: 'false'
 
     - name: clang-tidy check
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,6 @@ jobs:
         uses: './.github/actions/cache-steps'
         with: 
           r3b-dev-SHA: ${{ env.cacheSHA }}
-          # repo: ${{ matrix.repos }}
           repo: ${{ matrix.cache }}
 
       - name: build r3broot
@@ -64,7 +63,6 @@ jobs:
           ucesb-cache-existed: ${{ steps.caching.outputs.ucesb-hit }}
 
       - name: ctest
-        # run: source $GITHUB_WORKSPACE/Dart.sh Experimental $GITHUB_WORKSPACE/.githubfiles/dart_github_CICD.cfg
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           source $GITHUB_WORKSPACE/util/generate_geo_test.sh


### PR DESCRIPTION
Add ucesb dependency for clang-tidy checking.

Fix #712 where clang-tidy gives an error in the absence of ucesb library.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed [the seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
