### PR TITLE
TwiM drift time calib fixed, suppress unnecessary cout

### DIFF
--- a/califa/sim/R3BCalifa.cxx
+++ b/califa/sim/R3BCalifa.cxx
@@ -133,8 +133,11 @@ Bool_t R3BCalifa::ProcessHits(FairVolume* vol)
     // stack when they crash (e.g. because of SIGFPE, which GEANT4 helpfully
     // activates on Tuesdays and Debug builds (->G4FPE_debug).
 
-    auto makeCompFun = [](std::array<double, 5> p)
-    { return [p](double x) { return (x > 0.0) ? 1. / (p[0] + p[1] * pow(x, p[2]) + p[3] / pow(x, p[4])) : 0.0; }; };
+    auto makeCompFun = [](std::array<double, 5> par)
+    {
+        return [par](double val)
+        { return (val > 0.0) ? 1. / (par[0] + par[1] * pow(val, par[2]) + par[3] / pow(val, par[4])) : 0.0; };
+    };
     auto tf_dNf_dE = makeCompFun({ -1.79, 1.36e-2, 7.84e-1, 4.97, 1.75e-1 });
     auto tf_dNs_dE = makeCompFun({ -1.24e2, 6.3e-3, 1.27, 1.262e2, 2.3e-3 });
 
@@ -220,8 +223,10 @@ Bool_t R3BCalifa::ProcessHits(FairVolume* vol)
 
 void R3BCalifa::EndOfEvent()
 {
-    // if (fVerboseLevel > 1)
-    Print();
+    if (fVerboseLevel > 1)
+    {
+        Print();
+    }
     fCalifaCollection->Clear();
     ResetParameters();
 }

--- a/r3bdata/R3BMCStack.cxx
+++ b/r3bdata/R3BMCStack.cxx
@@ -384,11 +384,11 @@ void R3BStack::Register() { FairRootManager::Instance()->Register("MCTrack", "St
 // -----   Public method Print  --------------------------------------------
 void R3BStack::PrintStack(Int_t iVerbose) const
 {
-    LOG(info) << "R3BStack: Number of primaries = " << fNPrimaries;
-    LOG(info) << "          Total number of particles = " << fNParticles;
-    LOG(info) << "          Number of tracks in output = " << fNTracks;
     if (1 == iVerbose)
     {
+        LOG(info) << "R3BStack: Number of primaries = " << fNPrimaries;
+        LOG(info) << "          Total number of particles = " << fNParticles;
+        LOG(info) << "          Number of tracks in output = " << fNTracks;
         for (Int_t iTrack = 0; iTrack < fNTracks; iTrack++)
         {
             char str[100];

--- a/r3bsource/trloii/R3BTrloiiTpatReader.cxx
+++ b/r3bsource/trloii/R3BTrloiiTpatReader.cxx
@@ -43,7 +43,7 @@ R3BTrloiiTpatReader::R3BTrloiiTpatReader(EXT_STR_h101_TPAT* data, size_t offset)
 {
 }
 
-R3BTrloiiTpatReader::~R3BTrloiiTpatReader() { R3BLOG(info, ""); }
+R3BTrloiiTpatReader::~R3BTrloiiTpatReader() { R3BLOG(debug, ""); }
 
 Bool_t R3BTrloiiTpatReader::Init(ext_data_struct_info* a_struct_info)
 {

--- a/r3bsource/twim/R3BTwimReader.h
+++ b/r3bsource/twim/R3BTwimReader.h
@@ -47,12 +47,13 @@ class R3BTwimReader : public R3BReader
     // Accessor to select events without pileup
     void SetSkipPileup() { fPileup = kTRUE; }
 
-  private:
-    Bool_t ReadData(EXT_STR_h101_SOFTWIM_onion*, UShort_t);
     void SetNumSections(Int_t num) { fSections = num; }
     void SetNumAnodes(Int_t num) { fAnodes = num; }
     void SetNumTref(Int_t num) { fTref = num; }
     void SetNumTtrig(Int_t num) { fTtrig = num; }
+
+  private:
+    Bool_t ReadData(EXT_STR_h101_SOFTWIM_onion*, UShort_t);
 
     /* Reader specific data structure from ucesb */
     EXT_STR_h101_SOFTWIM* fData;


### PR DESCRIPTION
The drift time calibration for TwiM in s467/s444 (2020) has to be independent of the standard configuration since two MDPP16 were used for section 0 for those cases. The mapping of the time reference was wrong previously, and the R3BCoarseTimeStitch has been removed since it was causing fake reconstructions. The code has been simplified.

Describe your proposal.

Mention any issue this PR is resolved or is related to.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
