### PR TITLE
[CI] Adding url link to cdash webpages

### DIFF
--- a/cmake/CI_CD/CDash.cmake
+++ b/cmake/CI_CD/CDash.cmake
@@ -22,6 +22,6 @@ cdash_build()
 
 cdash_test()
 
-ctest_submit(RETRY_COUNT 3 RETRY_DELAY 2)
+cdash_submit()
 
 print_error()

--- a/cmake/CI_CD/Macros.cmake
+++ b/cmake/CI_CD/Macros.cmake
@@ -128,3 +128,24 @@ macro(print_error)
         message(FATAL_ERROR "End of failed tests output.")
     endif()
 endmacro()
+
+macro(cdash_submit)
+    ctest_submit(RETURN_VALUE _ctest_submit_ret_val BUILD_ID cdash_build_id RETRY_COUNT 3 RETRY_DELAY 2)
+    if(_ctest_submit_ret_val)
+        message(WARNING " ctest_submit() failed. Continueing")
+    endif()
+
+    if(cdash_build_id)
+        message(
+            STATUS
+                " CDash Build Summary ..: "
+                "${CTEST_DROP_METHOD}://${CTEST_DROP_SITE}/buildSummary.php?buildid=${cdash_build_id}"
+        )
+        message(
+            STATUS
+                " CDash Test List ......: "
+                "${CTEST_DROP_METHOD}://${CTEST_DROP_SITE}/viewTest.php?buildid=${cdash_build_id}")
+    else()
+        message(STATUS "  /!\\  CDash submit likely failed")
+    endif()
+endmacro()


### PR DESCRIPTION
In the end of CI workflow (tab ctest-cdash), there will be two url links to the gsi cdash website.
```text
    Submission successful
--  CDash Build Summary ..: https://cdash.gsi.de/buildSummary.php?buildid=391787
--  CDash Test List ......: https://cdash.gsi.de/viewTest.php?buildid=391787
```

Adapted from FairRoot CI workflow.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
