### PR TITLE
[HOT FIX] Fix the crash in the end of neuland Map2CalPar process

### DIFF
--- a/neuland/calibration/R3BNeulandMapped2CalPar.cxx
+++ b/neuland/calibration/R3BNeulandMapped2CalPar.cxx
@@ -51,10 +51,6 @@ R3BNeulandMapped2CalPar::R3BNeulandMapped2CalPar(const char* name, Int_t iVerbos
 
 R3BNeulandMapped2CalPar::~R3BNeulandMapped2CalPar()
 {
-    if (fCal_Par)
-    {
-        delete fCal_Par;
-    }
     if (fEngine)
     {
         delete fEngine;

--- a/tcal/R3BTCalEngine.cxx
+++ b/tcal/R3BTCalEngine.cxx
@@ -39,27 +39,6 @@ R3BTCalEngine::R3BTCalEngine(R3BTCalPar* param, Int_t minStats)
     }
 }
 
-R3BTCalEngine::~R3BTCalEngine()
-{
-    for (Int_t i = 0; i < N_PLANE_MAX; i++)
-    {
-        for (Int_t j = 0; j < N_PADDLE_MAX; j++)
-        {
-            for (Int_t k = 0; k < N_SIDE_MAX; k++)
-            {
-                if (fhData[i][j][k])
-                {
-                    delete fhData[i][j][k];
-                }
-                if (fhTime[i][j][k])
-                {
-                    delete fhTime[i][j][k];
-                }
-            }
-        }
-    }
-}
-
 void R3BTCalEngine::Fill(Int_t plane, Int_t paddle, Int_t side, Int_t tdc)
 {
     if (plane < 1 || plane > N_PLANE_MAX || paddle < 1 || paddle > N_PADDLE_MAX || side < 1 || side > N_SIDE_MAX)

--- a/tcal/R3BTCalEngine.h
+++ b/tcal/R3BTCalEngine.h
@@ -70,7 +70,6 @@ class R3BTCalEngine : public TObject
      * Destructor.
      * Releases memory used by the object.
      */
-    virtual ~R3BTCalEngine();
 
     /**
      * A method to fill TDC distribution for a specific module.


### PR DESCRIPTION
Program crashes when using R3BNeulandMapped2CalPar to create cal-level parameter.

This is due to the deletion of non-owning memory (namely TH1F and FairParSet).

When I suggested we should use
```cpp
auto* hist = R3B::root_owned<TH1F>("hist", "hist", 0, 1, 10);
```
to specify the ownership of ROOT histograms. I remember someone said this is totally not necessary because people would never delete histograms. Well, it turns out people do. 

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
