### PR TITLE
Rewrite R3BFileSource

### DIFF
--- a/neuland/digitizing/R3BNeulandDigitizer.cxx
+++ b/neuland/digitizing/R3BNeulandDigitizer.cxx
@@ -80,12 +80,12 @@ InitStatus R3BNeulandDigitizer::Init()
 
     // Initialize control histograms
     auto const PaddleMulSize = 3000;
-    hMultOne = r3b::root_owned<TH1I>(
+    hMultOne = R3B::root_owned<TH1I>(
         "MultiplicityOne", "Paddle multiplicity: only one PMT per paddle", PaddleMulSize, 0, PaddleMulSize);
-    hMultTwo = r3b::root_owned<TH1I>(
+    hMultTwo = R3B::root_owned<TH1I>(
         "MultiplicityTwo", "Paddle multiplicity: both PMTs of a paddle", PaddleMulSize, 0, PaddleMulSize);
     auto const timeBinSize = 200;
-    hRLTimeToTrig = r3b::root_owned<TH1F>("hRLTimeToTrig", "R/Ltime-triggerTime", timeBinSize, -100., 100.);
+    hRLTimeToTrig = R3B::root_owned<TH1F>("hRLTimeToTrig", "R/Ltime-triggerTime", timeBinSize, -100., 100.);
 
     return kSUCCESS;
 }

--- a/neuland/digitizing/R3BNeulandHitMon.cxx
+++ b/neuland/digitizing/R3BNeulandHitMon.cxx
@@ -52,7 +52,7 @@ InitStatus R3BNeulandHitMon::Init()
         const auto xbinN = 60;
         const auto ybinN = 50;
         const auto zbinN = 50;
-        fh3 = r3b::root_owned<TH3D>("hHits", "hHits", xbinN, 1400., 1700., ybinN, -125., 125., zbinN, -125., 125.);
+        fh3 = R3B::root_owned<TH3D>("hHits", "hHits", xbinN, 1400., 1700., ybinN, -125., 125., zbinN, -125., 125.);
         fh3->SetTitle("NeuLAND Hits");
         fh3->GetXaxis()->SetTitle("Z");
         fh3->GetYaxis()->SetTitle("X");
@@ -69,31 +69,31 @@ InitStatus R3BNeulandHitMon::Init()
     const auto posXYBinN = 300;
     const auto velocityBinN = 200;
 
-    hTime = r3b::root_owned<TH1D>("hTime", "Hit time", timeBinN, -1000., 1000.);
-    hTimeAdj = r3b::root_owned<TH1D>("hTimeAdj", "Hit Time adjusted for flight path", timeBinN, -1000., 1000.);
+    hTime = R3B::root_owned<TH1D>("hTime", "Hit time", timeBinN, -1000., 1000.);
+    hTimeAdj = R3B::root_owned<TH1D>("hTimeAdj", "Hit Time adjusted for flight path", timeBinN, -1000., 1000.);
 
-    hMult = r3b::root_owned<TH1I>("hMult", "Hit Multiplicity", maxHitNum, 0, maxHitNum);
+    hMult = R3B::root_owned<TH1I>("hMult", "Hit Multiplicity", maxHitNum, 0, maxHitNum);
 
-    hDepth = r3b::root_owned<TH1D>("hDepth", "Maxial penetration depth", zDepBinN, 1400., 1700.);
-    hDepthVSForemostEnergy = r3b::root_owned<TH2D>(
+    hDepth = R3B::root_owned<TH1D>("hDepth", "Maxial penetration depth", zDepBinN, 1400., 1700.);
+    hDepthVSForemostEnergy = R3B::root_owned<TH2D>(
         "hDepthVSFrontEnergy", "Depth vs Foremost Energy", zDepBinN, 1400., 1700., energyBinN, 0., 100.);
-    hDepthVSSternmostEnergy = r3b::root_owned<TH2D>(
+    hDepthVSSternmostEnergy = R3B::root_owned<TH2D>(
         "hDepthVSSternmostEnergy", "Depth vs Sternmost Energy", zDepBinN, 1400., 1700., energyBinN, 0, 100.);
     hDepthVSEtot =
-        r3b::root_owned<TH2D>("hDepthVSEtot", "Depth vs Total Energy", zDepBinN, 1400., 1700., totenergyBinN, 0, 1000.);
-    hForemostEnergy = r3b::root_owned<TH1D>("hForemostEnergy", "Foremost energy deposition", energyBinN, 0, 100.);
-    hSternmostEnergy = r3b::root_owned<TH1D>("hSternmostEnergy", "Sternmost energy deposition", energyBinN, 0, 100.);
-    hEtot = r3b::root_owned<TH1D>("hEtot", "Total Energy", totenergyBinN, 0, 10000.);
-    hdeltaEE = r3b::root_owned<TH2D>(
+        R3B::root_owned<TH2D>("hDepthVSEtot", "Depth vs Total Energy", zDepBinN, 1400., 1700., totenergyBinN, 0, 1000.);
+    hForemostEnergy = R3B::root_owned<TH1D>("hForemostEnergy", "Foremost energy deposition", energyBinN, 0, 100.);
+    hSternmostEnergy = R3B::root_owned<TH1D>("hSternmostEnergy", "Sternmost energy deposition", energyBinN, 0, 100.);
+    hEtot = R3B::root_owned<TH1D>("hEtot", "Total Energy", totenergyBinN, 0, 10000.);
+    hdeltaEE = R3B::root_owned<TH2D>(
         "hdeltaEE", "Energy in Foremost Plane vs Etot", energyBinN, 0, 2000., energyBinN, 0, 250.);
-    hPosVSEnergy = r3b::root_owned<TH2D>(
+    hPosVSEnergy = R3B::root_owned<TH2D>(
         "hPosVSEnergy", "Position vs Energy deposition", zDepBinN, 1400., 1700., totenergyBinN, 0, 1000.);
-    hBeta = r3b::root_owned<TH1D>("hBeta", "Velocity", velocityBinN, 0., 1.);
-    hE = r3b::root_owned<TH1D>("hE", "Hit Energy", energyBinN, 0., 100.);
-    hX = r3b::root_owned<TH1D>("hX", "Hit X", posXYBinN, -150., 150.);
-    hY = r3b::root_owned<TH1D>("hY", "Hit Y", posXYBinN, -150., 150.);
-    hT = r3b::root_owned<TH1D>("hT", "Hit Delta T", timeBinN, -15., -15.);
-    hTNeigh = r3b::root_owned<TH1D>("hTNeigh", "Hit Neigh Delta T", timeBinN, -15., -15.);
+    hBeta = R3B::root_owned<TH1D>("hBeta", "Velocity", velocityBinN, 0., 1.);
+    hE = R3B::root_owned<TH1D>("hE", "Hit Energy", energyBinN, 0., 100.);
+    hX = R3B::root_owned<TH1D>("hX", "Hit X", posXYBinN, -150., 150.);
+    hY = R3B::root_owned<TH1D>("hY", "Hit Y", posXYBinN, -150., 150.);
+    hT = R3B::root_owned<TH1D>("hT", "Hit Delta T", timeBinN, -15., -15.);
+    hTNeigh = R3B::root_owned<TH1D>("hTNeigh", "Hit Neigh Delta T", timeBinN, -15., -15.);
 
     return kSUCCESS;
 }

--- a/neuland/executables/neulandAna.cxx
+++ b/neuland/executables/neulandAna.cxx
@@ -8,6 +8,7 @@
 #include "R3BDigitizingPaddleNeuland.h"
 #include "R3BDigitizingTacQuila.h"
 #include "R3BDigitizingTamex.h"
+#include "R3BFileSource2.h"
 #include "R3BNeulandDigitizer.h"
 #include "R3BNeulandHitMon.h"
 #include "R3BProgramOptions.h"
@@ -29,12 +30,12 @@ using Digitizing::UsePaddle;
 //     return []() { Digitizing::Neuland::Tamex::Channel::GetHitPar("test"); };
 // }
 
-int main(int argc, const char** argv)
+auto main(int argc, const char** argv) -> int
 {
     auto timer = TStopwatch{};
     timer.Start();
 
-    auto programOptions = r3b::ProgramOptions("options for neuland data analysis");
+    auto programOptions = R3B::ProgramOptions("options for neuland data analysis");
     auto help = programOptions.Create_Option<bool>("help,h", "help message", false);
     auto paddleName =
         programOptions.Create_Option<std::string>("paddle", R"(set the paddle name. e.g. "neuland")", "neuland");
@@ -92,7 +93,7 @@ int main(int argc, const char** argv)
     FairLogger::GetLogger()->SetLogScreenLevel(logLevel->value().c_str());
 
     auto run = std::make_unique<FairRunAna>();
-    auto filesource = std::make_unique<FairFileSource>(simuFileName->value().c_str());
+    auto filesource = std::make_unique<R3BFileSource2>(simuFileName->value().c_str());
     auto filesink = std::make_unique<FairRootFileSink>(digiFileName->value().c_str());
     run->SetSource(filesource.release());
     run->SetSink(filesink.release());

--- a/neuland/executables/neulandSim.cxx
+++ b/neuland/executables/neulandSim.cxx
@@ -24,7 +24,7 @@ int main(int argc, const char** argv)
     auto const defaultEventNum = 10;
     timer.Start();
 
-    auto programOptions = r3b::ProgramOptions("options for neuland simulation");
+    auto programOptions = R3B::ProgramOptions("options for neuland simulation");
 
     auto help = programOptions.Create_Option<bool>("help,h", "help message", false);
     auto eventNum = programOptions.Create_Option<int>("eventNum", "set total event number", defaultEventNum);

--- a/neuland/executables/templates/ex_digi.cxx
+++ b/neuland/executables/templates/ex_digi.cxx
@@ -30,7 +30,7 @@ auto main(int argc, const char** argv) -> int
     auto timer = TStopwatch{};
     timer.Start();
 
-    auto programOptions = r3b::ProgramOptions("options for neuland data analysis");
+    auto programOptions = R3B::ProgramOptions("options for neuland data analysis");
     auto help = programOptions.Create_Option<bool>("help,h", "help message", false);
     auto paraFileName =
         programOptions.Create_Option<std::string>("paraFile", "set the filename of parameter sink", "para.root");

--- a/neuland/shared/R3BProgramOptions.cxx
+++ b/neuland/shared/R3BProgramOptions.cxx
@@ -1,6 +1,6 @@
 #include "R3BProgramOptions.h"
 
-namespace r3b
+namespace R3B
 {
     bool ProgramOptions::Verify(int argc, const char** argv)
     {
@@ -32,4 +32,4 @@ namespace r3b
         }
         return true;
     }
-} // namespace r3b
+} // namespace R3B

--- a/neuland/shared/R3BProgramOptions.h
+++ b/neuland/shared/R3BProgramOptions.h
@@ -5,7 +5,7 @@
 #include <unordered_map>
 #include <utility>
 
-namespace r3b
+namespace R3B
 {
     using std::runtime_error;
 
@@ -147,4 +147,4 @@ namespace r3b
         Type value_{};
         ProgramOptions* program_;
     };
-}; // namespace r3b
+}; // namespace R3B

--- a/r3bbase/BaseLinkDef.h
+++ b/r3bbase/BaseLinkDef.h
@@ -25,6 +25,7 @@
 #pragma link C++ class R3BWhiterabbitPropagator+;
 #pragma link C++ class R3BDataPropagator+;
 #pragma link C++ class R3BFileSource+;
+#pragma link C++ class R3BFileSource2+;
 #pragma link C++ class R3BEventHeaderPropagator+;
 #pragma link C++ class R3BLogger+;
 #pragma link C++ class R3BTcutPar+;

--- a/r3bbase/CMakeLists.txt
+++ b/r3bbase/CMakeLists.txt
@@ -12,30 +12,19 @@
 ##############################################################################
 
 # Create a library called "libR3BBase" which includes the source files given in
-# the array. The extension is already found. Any number of sources could be 
+# the array. The extension is already found. Any number of sources could be
 # listed here.
 
-Set(SYSTEM_INCLUDE_DIRECTORIES
-${SYSTEM_INCLUDE_DIRECTORIES}
-${BASE_INCLUDE_DIRECTORIES}
-)
+set(SYSTEM_INCLUDE_DIRECTORIES ${SYSTEM_INCLUDE_DIRECTORIES} ${BASE_INCLUDE_DIRECTORIES})
 
-set(INCLUDE_DIRECTORIES
-#put here all directories where header files are located
-${R3BROOT_SOURCE_DIR}/r3bbase
-${R3BROOT_SOURCE_DIR}/tcal
-${R3BROOT_SOURCE_DIR}/r3bdata
-${R3BROOT_SOURCE_DIR}/r3bdata/wrData
-)
+set(INCLUDE_DIRECTORIES #put here all directories where header files are located
+    ${R3BROOT_SOURCE_DIR}/r3bbase ${R3BROOT_SOURCE_DIR}/tcal ${R3BROOT_SOURCE_DIR}/r3bdata
+    ${R3BROOT_SOURCE_DIR}/r3bdata/wrData ${Boost_INCLUDE_DIRS})
 
-include_directories( ${INCLUDE_DIRECTORIES})
+include_directories(${INCLUDE_DIRECTORIES})
 include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
 
 link_directories(${FAIRROOT_LIBRARY_DIR} ${ROOT_LIBRARY_DIR})
-
-file(GLOB SRCS 
-*.cxx 
-)
 
 set(SRCS
     R3BCoarseTimeStitch.cxx
@@ -43,40 +32,59 @@ set(SRCS
     R3BDetector.cxx
     R3BEventHeader.cxx
     R3BEventHeaderPropagator.cxx
+    R3BException.cxx
     R3BFileSource.cxx
+    R3BFileSource2.cxx
     R3BLogger.cxx
     R3BModule.cxx
     R3BTcutPar.cxx
     R3BTsplinePar.cxx
-    R3BWhiterabbitPropagator.cxx
-    )
+    R3BWhiterabbitPropagator.cxx)
 
-set(HEADERS 
+set(HEADERS
     R3BCoarseTimeStitch.h
     R3BDataPropagator.h
     R3BDetector.h
     R3BEventHeader.h
     R3BEventHeaderPropagator.h
+    R3BException.h
     R3BFileSource.h
+    R3BFileSource2.h
     R3BLogger.h
     R3BModule.h
     R3BShared.h
     R3BTcutPar.h
     R3BTsplinePar.h
-    R3BWhiterabbitPropagator.h
-    )
+    R3BWhiterabbitPropagator.h)
 
-Set(LINKDEF BaseLinkDef.h)
+set(LINKDEF BaseLinkDef.h)
 
-Set(DEPENDENCIES
-    GeoBase ParBase MbsAPI Base FairTools R3BData Core Geom GenVector Physics
-    Matrix MathCore Hist Graf Gpad Net Imt RIO RHTTP Spectrum)
+set(DEPENDENCIES
+    GeoBase
+    ParBase
+    Base
+    FairTools
+    R3BData
+    Core
+    Geom
+    GenVector
+    Physics
+    Matrix
+    MathCore
+    Hist
+    Graf
+    Gpad
+    Net
+    Imt
+    RIO
+    RHTTP
+    Spectrum
+    stdc++fs)
 
-if( "${FairRoot_VERSION}"  VERSION_GREATER_EQUAL 18.8.0 )
+if("${FairRoot_VERSION}" VERSION_GREATER_EQUAL 18.8.0)
     set(DEPENDENCIES ${DEPENDENCIES} Online)
 endif()
 
-Set(LIBRARY_NAME R3BBase)
+set(LIBRARY_NAME R3BBase)
 
-GENERATE_LIBRARY()
-
+generate_library()

--- a/r3bbase/R3BException.cxx
+++ b/r3bbase/R3BException.cxx
@@ -1,0 +1,29 @@
+#include "R3BException.h"
+#include <filesystem>
+#include <fmt/core.h>
+
+namespace fs = std::filesystem;
+
+namespace
+{
+
+    std::string Print_msg_with_loc(const std::string& err, const boost::source_location& loc)
+    {
+        auto filepath = fs::path{ loc.file_name() };
+        return fmt::format("{}:{}:{}: {}", filepath.filename().string(), loc.line(), loc.function_name(), err);
+    }
+
+} // namespace
+namespace R3B
+{
+
+    runtime_error::runtime_error(const std::string& err, const boost::source_location& loc)
+        : std::runtime_error{ Print_msg_with_loc(err, loc) }
+    {
+    }
+
+    logic_error::logic_error(const std::string& err, const boost::source_location& loc)
+        : std::logic_error{ Print_msg_with_loc(err, loc) }
+    {
+    }
+} // namespace R3B

--- a/r3bbase/R3BException.h
+++ b/r3bbase/R3BException.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// TODO: C++20
+// use std::source_location
+#include <boost/assert/source_location.hpp>
+#include <stdexcept>
+#include <string>
+
+namespace R3B
+{
+
+    class runtime_error : public std::runtime_error
+    {
+      public:
+        explicit runtime_error(const std::string& err, const boost::source_location& loc = BOOST_CURRENT_LOCATION);
+    };
+
+    class logic_error : public std::logic_error
+    {
+      public:
+        explicit logic_error(const std::string& err, const boost::source_location& loc = BOOST_CURRENT_LOCATION);
+    };
+} // namespace R3B

--- a/r3bbase/R3BFileSource2.cxx
+++ b/r3bbase/R3BFileSource2.cxx
@@ -1,0 +1,424 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "R3BFileSource2.h"
+#include "R3BException.h"
+#include "R3BLogger.h"
+#include <FairEventHeader.h>
+#include <FairFileHeader.h>
+#include <FairRootManager.h>
+#include <TFolder.h>
+#include <TKey.h>
+#include <vector>
+
+namespace
+{
+    constexpr auto DEFAULT_TITLE = "InputRootFile";
+
+    template <typename ContainerType, typename DataType>
+    auto Vector2TContainer(std::vector<DataType>& vec) -> std::unique_ptr<ContainerType>
+    {
+        using RawType = std::remove_reference_t<std::remove_pointer_t<DataType>>;
+        static_assert(std::is_base_of_v<TObject, RawType>);
+        auto list = std::make_unique<ContainerType>();
+        for (auto& iter : vec)
+        {
+            if constexpr (std::is_pointer_v<DataType>)
+            {
+                list->Add(iter);
+            }
+            else
+            {
+                list->Add(&iter);
+            }
+        }
+        return list;
+    }
+
+    template <typename StringType = std::string>
+    auto GetBranchList(TFile* rootFile, std::string_view listName) -> std::vector<StringType>
+    {
+        auto branchList = std::vector<StringType>{};
+        if (auto* list = dynamic_cast<TList*>(rootFile->Get(listName.data())); list != nullptr)
+        {
+            for (const auto& str : TRangeDynCast<TObjString>(list))
+            {
+                branchList.emplace_back(str->GetString().Data());
+            }
+        }
+        else
+        {
+            throw R3B::logic_error(
+                fmt::format("No branch list named {0} in input file {1}", listName, rootFile->GetName()));
+        }
+        return branchList;
+    }
+
+    auto HasBranchList(TFile* rootFile, const std::vector<std::string>& branchList) -> bool
+    {
+        auto const newBranchList = GetBranchList(rootFile, "BranchList");
+        auto view1 = std::vector<std::string_view>(branchList.begin(), branchList.end());
+        auto view2 = std::vector<std::string_view>(newBranchList.begin(), newBranchList.end());
+
+        std::sort(view1.begin(), view1.end());
+        std::sort(view2.begin(), view2.end());
+        return view1 == view2;
+    }
+
+    template <typename ContainerType>
+    auto GetDataFromAnyFolder(TFile* rootFile, const ContainerType& folderNames) -> std::optional<TKey*>
+    {
+        for (auto const& name : folderNames)
+        {
+            R3BLOG(debug, "looking for " + name);
+            auto* dataFolder = dynamic_cast<TKey*>(rootFile->FindKey(name.c_str()));
+            if (dataFolder != nullptr)
+            {
+                R3BLOG(debug, name + " has been found!");
+                return dataFolder;
+            }
+        }
+        return {};
+    }
+
+    auto Get_TChain_FromFairRM(FairRootManager* rootMan) -> TChain*
+    {
+        auto const chainTitle = "/" + std::string{ FairRootManager::GetFolderName() };
+        auto inChain = std::make_unique<TChain>(FairRootManager::GetTreeName(), chainTitle.c_str());
+        R3BLOG(debug, "Chain created");
+        LOG(info) << "chain name: " << FairRootManager::GetTreeName();
+        rootMan->SetInChain(inChain.release());
+        return FairRootManager::Instance()->GetInChain();
+    }
+} // namespace
+
+auto R3BInputRootFiles::AddFileName(std::string fileName) -> std::optional<std::string>
+{
+    auto const msg = fmt::format("Adding {} to file source\n", fileName);
+    R3BLOG(info, msg);
+    if (fileNames_.empty())
+    {
+        Intitialize(fileName);
+    }
+    if (!ValidateFile(fileName))
+    {
+        return fileName;
+    }
+    fileNames_.emplace_back(std::move(fileName));
+    return {};
+}
+
+void R3BInputRootFiles::SetInputFileChain(TChain* chain)
+{
+    if (rootChain_ != nullptr)
+    {
+        throw R3B::logic_error("TChain has already been created!");
+    }
+    rootChain_ = chain;
+    for (auto const& filename : fileNames_)
+    {
+        rootChain_->AddFile(filename.c_str(), TTree::kMaxEntries, treeName_.c_str());
+    }
+}
+void R3BInputRootFiles::RegisterTo(FairRootManager* rootMan)
+{
+    if (is_friend_)
+    {
+        return;
+    }
+
+    if (validMainFolders_.empty())
+    {
+        throw R3B::runtime_error("There is no maian folder to be registered!");
+    }
+
+    if (!is_friend_)
+    {
+        auto listOfFolders = Vector2TContainer<TObjArray>(validMainFolders_);
+        R3BLOG(debug, fmt::format("Set {} main folder(s) to FairRootManager.", listOfFolders->GetEntries()));
+        rootMan->SetListOfFolders(listOfFolders.release());
+        rootMan->SetTimeBasedBranchNameList(Vector2TContainer<TList>(timeBasedBranchList_).release());
+        SetInputFileChain(Get_TChain_FromFairRM(rootMan));
+    }
+}
+
+auto R3BInputRootFiles::ExtractMainFolder(TFile* rootFile) -> std::optional<TKey*>
+{
+    auto const folderNames =
+        std::array<std::string, 4>{ FairRootManager::GetFolderName(), "r3broot", "cbmout", "cbmroot" };
+
+    return GetDataFromAnyFolder(rootFile, folderNames);
+}
+
+auto R3BInputRootFiles::ValidateFile(const std::string& filename) -> bool
+{
+    auto rootFile = R3B::make_rootfile(filename.c_str());
+    auto folderKey = ExtractMainFolder(rootFile.get());
+    auto res = folderKey.has_value() && HasBranchList(rootFile.get(), branchList_);
+    if (res)
+    {
+        if (!folderName_.empty() && (folderKey.value()->GetName() != folderName_))
+        {
+            R3BLOG(warn, "Different folder name!");
+        }
+        if (!is_friend_)
+        {
+            validRootFiles_.push_back(std::move(rootFile));
+            validMainFolders_.push_back((folderKey.value())->ReadObject<TFolder>());
+        }
+    }
+    return res;
+}
+
+auto R3BInputRootFiles::ExtractRunId(TFile* rootFile) -> std::optional<uint>
+{
+    //
+    auto* header = rootFile->Get<FairFileHeader>(fileHeader_.c_str());
+    if (header == nullptr)
+    {
+        return {};
+    }
+    auto runID = header->GetRunId();
+    return runID;
+}
+
+void R3BInputRootFiles::Intitialize(std::string_view filename)
+{
+    auto file = R3B::make_rootfile(filename.data());
+
+    if (const auto runID = ExtractRunId(file.get()); runID.has_value() && runID.value() != 0)
+    {
+        auto const msg = fmt::format(R"(Successfully extract RunID "{}" from root file "{}")", runID.value(), filename);
+        R3BLOG(debug, msg);
+        initial_RunID_ = runID.value();
+    }
+    else
+    {
+        auto const msg = fmt::format("Failed to extract RunID from root file \"{}\"", filename);
+        R3BLOG(error, msg);
+    }
+
+    if (auto folderKey = ExtractMainFolder(file.get()); folderKey.has_value())
+    {
+        folderName_ = folderKey.value()->GetName();
+    }
+    else
+    {
+        throw R3B::logic_error(fmt::format("Cannot find main folder from the root file {}!", filename));
+    }
+
+    branchList_ = GetBranchList(file.get(), "BranchList");
+    for (auto const& branchName : branchList_)
+    {
+        FairRootManager::Instance()->AddBranchToList(branchName.c_str());
+    }
+
+    if (timeBasedBranchList_ = GetBranchList<TObjString>(file.get(), "TimeBasedBranchList");
+        timeBasedBranchList_.empty())
+    {
+        LOG(warn) << "No time based branch list in input file";
+    }
+}
+
+void R3BInputRootFiles::SetFriend(R3BInputRootFiles& friendFiles)
+{
+    if (is_friend_)
+    {
+        throw R3B::logic_error("Can not set friendFiles with another friendFile!");
+    }
+    auto chain = std::make_unique<TChain>(friendFiles.GetTitle().c_str(), friendFiles.GetFolderName().c_str());
+    friendFiles.SetInputFileChain(chain.get());
+    rootChain_->AddFriend(chain.release());
+}
+
+[[nodiscard]] auto R3BInputRootFiles::GetEntries() const -> int64_t
+{
+    if (rootChain_ == nullptr)
+    {
+        throw R3B::logic_error("Can't get entries before being initialized!");
+    }
+    return rootChain_->GetEntries();
+}
+
+R3BFileSource2::R3BFileSource2(std::vector<std::string> fileNames, std::string_view title)
+{
+    LOG(debug) << "Creating a new R3BFileSource!";
+    inputDataFiles_.SetTitle(title);
+    inputDataFiles_.SetFileHeaderName("FileHeader");
+    for (auto& name : fileNames)
+    {
+        if (name.empty())
+        {
+            continue;
+        }
+        AddFile(std::move(name));
+    }
+}
+
+R3BFileSource2::R3BFileSource2(std::string file, std::string_view title)
+    : R3BFileSource2(std::vector<std::string>{ std::move(file) }, title)
+{
+}
+
+R3BFileSource2::R3BFileSource2(std::vector<std::string> fileNames)
+    : R3BFileSource2(std::move(fileNames), DEFAULT_TITLE)
+{
+}
+
+R3BFileSource2::R3BFileSource2()
+    : R3BFileSource2(std::string{})
+{
+}
+
+void R3BFileSource2::AddFile(std::string fileName)
+{
+
+    if (auto const res = inputDataFiles_.AddFileName(std::move(fileName)); res.has_value())
+    {
+        R3BLOG(error,
+               fmt::format(
+                   "Root file {0} is incompatible with the first root file {1}", res.value(), dataFileNames_.front()));
+    }
+    dataFileNames_.emplace_back(fileName);
+}
+
+void R3BFileSource2::AddFriend(std::string_view fileName)
+{
+    //
+    auto rootfile = R3B::make_rootfile(fileName.data());
+    auto friendGroup = std::find_if(inputFriendFiles_.begin(),
+                                    inputFriendFiles_.end(),
+                                    [&rootfile](const auto& friends)
+                                    { return HasBranchList(rootfile.get(), friends.GetBranchListRef()); });
+    if (friendGroup == inputFriendFiles_.end())
+    {
+        auto newFriendGroup = R3BInputRootFiles{};
+        newFriendGroup.Make_as_friend();
+        inputFriendFiles_.push_back(std::move(newFriendGroup));
+        friendGroup = --inputFriendFiles_.end();
+        friendGroup->SetTitle(fmt::format("FriendTree_{}", inputFriendFiles_.size()));
+    }
+    auto res = friendGroup->AddFileName(std::string{ fileName });
+    if (res.has_value())
+    {
+        R3BLOG(error,
+               fmt::format("Friend file {0} is incompatible with the first friend file {1}",
+                           res.value(),
+                           friendGroup->GetBaseFileName()));
+    }
+    else
+    {
+        // TODO: really need it?
+        friendFileNames_.emplace_back(fileName);
+    }
+}
+
+Bool_t R3BFileSource2::Init()
+{
+    inputDataFiles_.RegisterTo(FairRootManager::Instance());
+
+    for (auto& friendGroup : inputFriendFiles_)
+    {
+        inputDataFiles_.SetFriend(friendGroup);
+    }
+
+    return true;
+}
+
+void R3BFileSource2::FillEventHeader(FairEventHeader* evtHeader)
+{
+    if (evtHeader == nullptr)
+    {
+        throw R3B::logic_error("Filled event header is empty!");
+    }
+    evtHeader_ = evtHeader;
+
+    // Set runID for event header:
+    auto const init_runID = inputDataFiles_.GetInitialRunID();
+
+    if (init_runID == 0)
+    {
+        throw R3B::logic_error("RunId is not being set!");
+    }
+
+    if (init_runID != GetRunId())
+    {
+        R3BLOG(
+            error,
+            fmt::format("runID {} being set is different from the runID {} in the data file!", GetRunId(), init_runID));
+    }
+    SetRunId(init_runID); // NOLINT
+    evtHeader->SetRunId(init_runID);
+}
+
+Int_t R3BFileSource2::CheckMaxEventNo(Int_t EvtEnd)
+{
+    return (EvtEnd == 0) ? inputDataFiles_.GetEntries() : EvtEnd; // NOLINT
+}
+
+//----------------------------------------------------------------
+void R3BFileSource2::ReadBranchEvent(const char* BrName)
+{
+    auto const currentEventID = evtHeader_->GetMCEntryNumber();
+    ReadBranchEvent(BrName, currentEventID);
+}
+
+void R3BFileSource2::ReadBranchEvent(const char* BrName, Int_t entryID)
+{
+    auto const read_bytes = inputDataFiles_.GetChain()->FindBranch(BrName)->GetEntry(entryID);
+    if (read_bytes == 0)
+    {
+        LOG(warn) << fmt::format("Failed to read the data of the event {0} from the branch {1}", entryID, BrName);
+    }
+}
+
+Int_t R3BFileSource2::ReadEvent(UInt_t eventID)
+{
+    // fCurrentEntryNo = eventID;
+    // fEventTime = GetEventTime();
+
+    // TODO: make colors as variables
+    // TODO: add disable option
+    auto* chain = inputDataFiles_.GetChain();
+    auto const total_entries_num = chain->GetEntries();
+    if (allow_print_ && eventID > 0)
+    {
+        fmt::print("Processed: \033[32m {0} \033[0m of \033[34m {1} \033[0m (\033[33m {2:8.2f} \033[0m of "
+                   "100), current RunId \033[31m {3:3d} \033[0m \r",
+                   (eventID + 1),
+                   total_entries_num,
+                   100. * (eventID / static_cast<double>(total_entries_num)),
+                   fRunId);
+        std::cout << std::flush;
+    }
+
+    // TODO: clean this mess
+
+    auto read_bytes = chain->GetEntry(eventID);
+    if (read_bytes == 0)
+    {
+        LOG(warn) << fmt::format("Failed to read the data of the event {0} from the source", eventID);
+        return 1;
+    }
+    return 0;
+}
+
+Bool_t R3BFileSource2::ActivateObject(TObject** obj, const char* BrName)
+{
+    auto* chain = inputDataFiles_.GetChain();
+    chain->SetBranchStatus(BrName, true);
+    chain->SetBranchAddress(BrName, obj);
+    return kTRUE;
+}
+
+ClassImp(R3BFileSource2);

--- a/r3bbase/R3BFileSource2.h
+++ b/r3bbase/R3BFileSource2.h
@@ -1,0 +1,123 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include "FairSource.h"
+#include "R3BShared.h"
+#include <TObjString.h>
+
+class FairRootManager;
+class TChain;
+class TFolder;
+
+class R3BInputRootFiles
+{
+  public:
+    using Strings = std::vector<std::string>;
+    R3BInputRootFiles() = default;
+    auto AddFileName(std::string name) -> std::optional<std::string>;
+    void SetInputFileChain(TChain* chain);
+    void RegisterTo(FairRootManager*);
+
+    [[nodiscard]] auto is_friend() const -> bool { return is_friend_; }
+    void Make_as_friend() { is_friend_ = true; }
+    void SetFriend(R3BInputRootFiles& friendFiles);
+    // Getters:
+    [[nodiscard]] auto GetBranchListRef() const -> const auto& { return branchList_; }
+    [[nodiscard]] auto GetBaseFileName() const -> const auto& { return fileNames_.front(); }
+    [[nodiscard]] auto GetTreeName() const -> const auto& { return treeName_; }
+    [[nodiscard]] auto GetFolderName() const -> const auto& { return folderName_; }
+    [[nodiscard]] auto GetTitle() const -> const auto& { return title_; }
+    [[nodiscard]] auto GetEntries() const -> int64_t;
+    [[nodiscard]] auto GetChain() const -> TChain* { return rootChain_; }
+    [[nodiscard]] auto GetInitialRunID() const { return initial_RunID_; }
+
+    // Setters:
+    void SetTreeName(std::string_view treeName) { treeName_ = treeName; }
+    void SetTitle(std::string_view title) { title_ = title; }
+    void SetFileHeaderName(std::string_view fileHeader) { fileHeader_ = fileHeader; }
+
+    // rule of five:
+    ~R3BInputRootFiles() = default;
+    R3BInputRootFiles(const R3BInputRootFiles&) = delete;
+    R3BInputRootFiles(R3BInputRootFiles&&) = default;
+    R3BInputRootFiles& operator=(const R3BInputRootFiles&) = delete;
+    R3BInputRootFiles& operator=(R3BInputRootFiles&&) = default;
+
+  private:
+    bool is_friend_ = false;
+    uint initial_RunID_ = 0;
+    // title of each file group seems not necessary. Consider to remove it in the future.
+    std::string title_;
+    std::string treeName_ = "evt";
+    std::string folderName_;
+    std::string fileHeader_;
+    Strings fileNames_;
+    Strings branchList_;
+    std::vector<TObjString> timeBasedBranchList_;
+    std::vector<R3B::unique_rootfile> validRootFiles_;
+    std::vector<TFolder*> validMainFolders_;
+    TChain* rootChain_ = nullptr;
+
+    void Intitialize(std::string_view filename);
+    auto ValidateFile(const std::string& filename) -> bool;
+    static auto ExtractMainFolder(TFile*) -> std::optional<TKey*>;
+    auto ExtractRunId(TFile* rootFile) -> std::optional<uint>;
+};
+
+class R3BFileSource2 : public FairSource
+{
+  public:
+    // constructors:
+    R3BFileSource2();
+    explicit R3BFileSource2(std::string file, std::string_view title = "InputRootFile");
+    R3BFileSource2(std::vector<std::string> fileNames, std::string_view title);
+    explicit R3BFileSource2(std::vector<std::string> fileNames);
+
+    // public interface:
+    void AddFile(std::string);
+    void AddFriend(std::string_view);
+    void SetFileHeaderName(std::string_view fileHeaderName) { inputDataFiles_.SetFileHeaderName(fileHeaderName); }
+    void DisablePrint() { allow_print_ = false; }
+    void EnablePrint() { allow_print_ = true; }
+
+  private:
+    bool allow_print_ = false;
+    R3BInputRootFiles inputDataFiles_;
+    FairEventHeader* evtHeader_ = nullptr;
+    std::vector<R3BInputRootFiles> inputFriendFiles_;
+    std::vector<std::string> dataFileNames_;
+    std::vector<std::string> friendFileNames_;
+
+    // virtual functions should be private!
+    Bool_t Init() override;
+    Int_t ReadEvent(UInt_t eventID = 0) override;
+    void Close() override {}
+    void Reset() override {}
+    Bool_t InitUnpackers() override { return kTRUE; }
+    Bool_t ReInitUnpackers() override { return kTRUE; }
+    Source_Type GetSourceType() override { return kFILE; }
+    void SetParUnpackers() override {}
+    Int_t CheckMaxEventNo(Int_t EvtEnd = 0) override;
+    void ReadBranchEvent(const char* BrName) override;
+    void ReadBranchEvent(const char* BrName, Int_t Entry) override;
+    void FillEventHeader(FairEventHeader* evtHeader) override;
+    Bool_t ActivateObject(TObject** obj, const char* BrName) override;
+
+    // WTF is this?
+    Bool_t SpecifyRunId() override { return ReadEvent(0) == 0; }
+
+  public:
+    ClassDefOverride(R3BFileSource2, 0) // NOLINT
+};


### PR DESCRIPTION
* Rewrite whole R3BFileSource into new R3BFileSource2, which includes most essential functionalities and keep the same interfaces. Users just need to change the name from `R3BFileSource` to `R3BFileSource2`. RunID determination is not implemented as it should not be done in the file source, but rather in the file header or event header.
* Change namespace from `r3b` to `R3B`
* Add two exception classes. Their only difference from the C++ standard version is the exception message now includes the source location information (just like R3BLOG).

The new R3BFileSource2 has been tested with NeulandMap2CalPar and NeulandDigitizer.

Feel free to comment below if you have more suggestions. If there is no problem for the new file source, we could consider replacing the old file source with it in the future.


---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
