### PR TITLE
Implementation of Parameter finder for Tprev/Tnext calculation

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -20,6 +20,7 @@ Labiche, Marc
 Lagni, Andrea
 Lihtar, Ivana
 Loeher, Bastian
+Milhomens da Fonseca, Leandro
 Mozumdar, Nikhil
 Panin, Valerii
 Plag, Ralf

--- a/r3bbase/CMakeLists.txt
+++ b/r3bbase/CMakeLists.txt
@@ -17,9 +17,15 @@
 
 set(SYSTEM_INCLUDE_DIRECTORIES ${SYSTEM_INCLUDE_DIRECTORIES} ${BASE_INCLUDE_DIRECTORIES})
 
-set(INCLUDE_DIRECTORIES #put here all directories where header files are located
-    ${R3BROOT_SOURCE_DIR}/r3bbase ${R3BROOT_SOURCE_DIR}/tcal ${R3BROOT_SOURCE_DIR}/r3bdata
-    ${R3BROOT_SOURCE_DIR}/r3bdata/wrData ${Boost_INCLUDE_DIRS})
+set(INCLUDE_DIRECTORIES
+#put here all directories where header files are located
+${R3BROOT_SOURCE_DIR}/r3bbase
+${R3BROOT_SOURCE_DIR}/tcal
+${R3BROOT_SOURCE_DIR}/r3bdata
+${R3BROOT_SOURCE_DIR}/r3bdata/sampData
+${R3BROOT_SOURCE_DIR}/r3bdata/wrData
+${R3BROOT_SOURCE_DIR}/r3bbase/pars
+)
 
 include_directories(${INCLUDE_DIRECTORIES})
 include_directories(SYSTEM ${SYSTEM_INCLUDE_DIRECTORIES})
@@ -39,7 +45,11 @@ set(SRCS
     R3BModule.cxx
     R3BTcutPar.cxx
     R3BTsplinePar.cxx
-    R3BWhiterabbitPropagator.cxx)
+    R3BWhiterabbitPropagator.cxx
+    ./pars/R3BMSOffsetPar.cxx
+    ./pars/R3BMSOffsetContFact.cxx
+    ./pars/R3BMSOffsetFinder.cxx
+    )
 
 set(HEADERS
     R3BCoarseTimeStitch.h
@@ -55,7 +65,11 @@ set(HEADERS
     R3BShared.h
     R3BTcutPar.h
     R3BTsplinePar.h
-    R3BWhiterabbitPropagator.h)
+    R3BWhiterabbitPropagator.h
+    ./pars/R3BMSOffsetPar.h
+    ./pars/R3BMSOffsetContFact.h
+    ./pars/R3BMSOffsetFinder.h
+    )
 
 set(LINKDEF BaseLinkDef.h)
 

--- a/r3bbase/pars/R3BMSOffsetContFact.cxx
+++ b/r3bbase/pars/R3BMSOffsetContFact.cxx
@@ -1,0 +1,69 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+//
+//  R3BMSOffsetContFact
+//
+//  Factory for the parameter containers in libR3BMSOffset
+//
+
+#include "R3BMSOffsetContFact.h"
+#include "R3BMSOffsetPar.h"
+
+#include "FairParAsciiFileIo.h"
+#include "FairParRootFileIo.h"
+#include "FairRuntimeDb.h"
+
+#include "R3BLogger.h"
+
+#include "TClass.h"
+
+static const R3BMSOffsetContFact gR3BMSOffsetContFact;
+
+R3BMSOffsetContFact::R3BMSOffsetContFact()
+{
+    // Constructor (called when the library is loaded)
+    fName = "R3BMSOffsetContFact";
+    fTitle = "Factory for parameter containers in libR3BMSOffset";
+    setAllContainers();
+    FairRuntimeDb::instance()->addContFactory(this);
+}
+
+void R3BMSOffsetContFact::setAllContainers()
+{
+    // Creates the Container objects with all accepted contexts and adds them to
+    // the list of containers for the STS library.
+
+    auto pOffset = std::make_unique<FairContainer>("MSOffsetPar", "MSOffsetPar Offset Parameters", "MSOffsetPar");
+    pOffset->addContext("MSOffsetPar");
+
+    containers->Add(pOffset.release());
+}
+
+FairParSet* R3BMSOffsetContFact::createContainer(FairContainer* cOffset)
+{
+    // Trals the constructor of the corresponding parameter container.
+    // For an actual context, which is not an empty string and not the default context
+    // of this container, the name is concatinated with the context.
+
+    const auto name = std::string_view{ cOffset->GetName() };
+    R3BLOG(info, name);
+    FairParSet* pOff = nullptr;
+    if (name == "MSOffsetPar")
+    {
+        pOff = new R3BMSOffsetPar(cOffset->getConcatName().Data(), cOffset->GetTitle(), cOffset->getContext());
+    }
+    return pOff;
+}
+
+ClassImp(R3BMSOffsetContFact);

--- a/r3bbase/pars/R3BMSOffsetContFact.h
+++ b/r3bbase/pars/R3BMSOffsetContFact.h
@@ -1,5 +1,3 @@
-// clang-format off
-
 /******************************************************************************
  *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
  *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
@@ -12,26 +10,24 @@
  * granted to it by virtue of its status as an Intergovernmental Organization *
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
+#pragma once
 
-#ifdef __CINT__
+#include "FairContFact.h"
 
-#pragma link off all globals;
-#pragma link off all classes;
-#pragma link off all functions;
+class FairContainer;
 
-#pragma link C++ class R3BModule+;
-#pragma link C++ class R3BDetector+;
-#pragma link C++ class R3BEventHeader+;
-#pragma link C++ class R3BWhiterabbitPropagator+;
-#pragma link C++ class R3BDataPropagator+;
-#pragma link C++ class R3BFileSource+;
-#pragma link C++ class R3BFileSource2+;
-#pragma link C++ class R3BEventHeaderPropagator+;
-#pragma link C++ class R3BLogger+;
-#pragma link C++ class R3BTcutPar+;
-#pragma link C++ class R3BTsplinePar+;
-#pragma link C++ class R3BCoarseTimeStitch+;
-#pragma link C++ class R3BMSOffsetContFact+;
-#pragma link C++ class R3BMSOffsetPar+;
-#pragma link C++ class R3BMSOffsetFinder+;
-#endif
+class R3BMSOffsetContFact : public FairContFact
+{
+  private:
+    void setAllContainers();
+
+  public:
+    R3BMSOffsetContFact();
+    R3BMSOffsetContFact(const R3BMSOffsetContFact&) = delete;
+    R3BMSOffsetContFact(R3BMSOffsetContFact&&) = delete;
+    R3BMSOffsetContFact& operator=(const R3BMSOffsetContFact&) = delete;
+    R3BMSOffsetContFact& operator=(R3BMSOffsetContFact&&) = delete;
+    ~R3BMSOffsetContFact() override = default;
+    FairParSet* createContainer(FairContainer* /*unused*/) override;
+    ClassDefOverride(R3BMSOffsetContFact, 0) // Factory for all MSOffset parameter containers
+};

--- a/r3bbase/pars/R3BMSOffsetFinder.cxx
+++ b/r3bbase/pars/R3BMSOffsetFinder.cxx
@@ -1,0 +1,167 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+// ROOT headers
+#include "R3BSamplerMappedData.h"
+#include "R3BShared.h"
+#include "TClonesArray.h"
+#include "TF1.h"
+#include "TH1F.h"
+#include "TMath.h"
+#include "TObjArray.h"
+#include "TRandom.h"
+#include "TVector3.h"
+#include <cstdlib>
+#include <iostream>
+// Fair headers
+#include "FairLogger.h"
+#include "FairRootManager.h"
+#include "FairRunAna.h"
+#include "FairRuntimeDb.h"
+
+// R3B headers
+#include "R3BEventHeader.h"
+#include "R3BMSOffsetFinder.h"
+#include "R3BMSOffsetPar.h"
+
+// R3BMSOffsetFinder: Default Constructor --------------------------
+R3BMSOffsetFinder::R3BMSOffsetFinder()
+    : R3BMSOffsetFinder("R3B MS Offset Finder", 1)
+{
+}
+
+// R3BMSOffsetFinder: Standard Constructor --------------------------
+R3BMSOffsetFinder::R3BMSOffsetFinder(const TString& name, Int_t iVerbose)
+    : FairTask(name, iVerbose)
+    , fMSOffset(0.0)
+    , fMinStatistics(1)
+    , fMSOffsetPar(nullptr)
+    , fSamplerMapped(nullptr)
+    , fSamplerMSMapped(nullptr)
+    , fh_Offset_Finder(nullptr)
+{
+}
+
+void R3BMSOffsetFinder::SetParContainers()
+{
+    // Parameter Container
+    if (auto* rtdb = FairRuntimeDb::instance(); rtdb == nullptr)
+    {
+        LOG(error) << "FairRuntimeDb not opened!";
+    }
+}
+
+// -----   Public method Init   --------------------------------------------
+InitStatus R3BMSOffsetFinder::Init()
+{
+
+    LOG(info) << "R3BMSOffsetFinder: Init";
+
+    FairRootManager* rootManager = FairRootManager::Instance();
+    if (rootManager == nullptr)
+    {
+        return kFATAL;
+    }
+
+    fSamplerMapped = dynamic_cast<TClonesArray*>(rootManager->GetObject("SamplerMapped"));
+    if (fSamplerMapped == nullptr)
+    {
+        return kFATAL;
+    }
+
+    fSamplerMSMapped = dynamic_cast<TClonesArray*>(rootManager->GetObject("SamplerMSMapped"));
+    if (fSamplerMSMapped == nullptr)
+    {
+        return kFATAL;
+    }
+
+    FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+    if (rtdb == nullptr)
+    {
+        return kFATAL;
+    }
+
+    fMSOffsetPar = dynamic_cast<R3BMSOffsetPar*>(rtdb->getContainer("MSOffsetPar"));
+    if (fMSOffsetPar == nullptr)
+    {
+        LOG(error) << "R3BMSOffsetFinder::Init() Couldn't get handle on MSOffsetPar container";
+        return kFATAL;
+    }
+
+    fh_Offset_Finder = R3B::root_owned<TH1F>("MSOffsetFinderHisto", "MSOffsetFinderHisto", 2000.0, -1000.0, 1000.0);
+
+    return kSUCCESS;
+}
+
+// -----   Public method ReInit   --------------------------------------------
+InitStatus R3BMSOffsetFinder::ReInit()
+{
+    SetParContainers();
+    return kSUCCESS;
+}
+
+// -----   Public method Exec   --------------------------------------------
+void R3BMSOffsetFinder::Exec(Option_t* /*opt*/)
+{
+
+    const Int_t sampHits = fSamplerMapped->GetEntriesFast();
+    const Int_t sampmsHits = fSamplerMSMapped->GetEntriesFast();
+    if ((sampHits == 0) || (sampmsHits != 1))
+    {
+        return;
+    }
+
+    if (auto* SAMPMSMapped = dynamic_cast<R3BSamplerMappedData*>(fSamplerMSMapped->At(0)); SAMPMSMapped != nullptr)
+    {
+        for (auto* SAMPMapped : TRangeDynCast<R3BSamplerMappedData>(fSamplerMapped))
+        {
+            fh_Offset_Finder->Fill(SAMPMapped->GetTime() - SAMPMSMapped->GetTime());
+        }
+    }
+    else
+    {
+        LOG(error) << "SAMPMSMapped is nullptr";
+        return;
+    }
+}
+
+// ---- Public method Reset   --------------------------------------------------
+void R3BMSOffsetFinder::Reset() {}
+
+void R3BMSOffsetFinder::FinishEvent() {}
+
+// ---- Public method Finish   --------------------------------------------------
+void R3BMSOffsetFinder::FinishTask() { SearchMSOffset(); }
+
+//------------------
+
+void R3BMSOffsetFinder::SearchMSOffset()
+{
+
+    LOG(info) << "R3BMSOffsetFinder: Search MS Offset";
+    if (fh_Offset_Finder->GetEntries() >= fMinStatistics)
+    {
+        auto MSpos = fh_Offset_Finder->GetMaximumBin();
+        auto offset =
+            (fh_Offset_Finder->GetBinCenter(MSpos)) -
+            0.5; // The bin is unitary, so the Bin Center will always be X.5 (the center of a unitary bin). To fix that
+                 // the -0.5 is added to the equation. The time here is in clock cycles, so thi -0.5 corrects that.
+        fMSOffsetPar->SetMSOffset(offset);
+    }
+
+    // Fill container:
+
+    fMSOffsetPar->setChanged();
+}
+
+ClassImp(R3BMSOffsetFinder) // NOLINT

--- a/r3bbase/pars/R3BMSOffsetFinder.h
+++ b/r3bbase/pars/R3BMSOffsetFinder.h
@@ -1,0 +1,85 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include "FairTask.h"
+#include "TH1F.h"
+
+class TClonesArray;
+class R3BMSOffsetPar;
+class R3BEventHeader;
+class R3BSamplerMappedData;
+class R3BMSOffsetFinder : public FairTask // NOLINT
+{
+
+  public:
+    /** Default constructor **/
+    R3BMSOffsetFinder();
+
+    R3BMSOffsetFinder(const R3BMSOffsetFinder&) = delete;
+    R3BMSOffsetFinder(R3BMSOffsetFinder&&) = delete;
+    R3BMSOffsetFinder& operator=(const R3BMSOffsetFinder&) = delete;
+    R3BMSOffsetFinder& operator=(R3BMSOffsetFinder&&) = delete;
+    /** Standard constructor **/
+    explicit R3BMSOffsetFinder(const TString& name, Int_t iVerbose = 1);
+
+  private:
+    /** Virtual method Init **/
+    InitStatus Init() override;
+
+    /** Virtual method Exec **/
+    void Exec(Option_t* opt) override;
+
+    /** Virtual method FinishEvent **/
+    void FinishEvent() override;
+
+    /** Virtual method FinishTask **/
+    void FinishTask() override;
+
+    /** Virtual method Reset **/
+    virtual void Reset();
+
+    /** Virtual method ReInit **/
+    InitStatus ReInit() override;
+
+    /** Virtual method Search MS Offset **/
+    virtual void SearchMSOffset();
+
+    /** Virtual method SetParContainers **/
+    void SetParContainers() override;
+
+  public:
+    /** Accessor functions **/
+    [[nodiscard]] Double_t GetMSOffset() const { return fMSOffset; }
+
+    void SetMSOffset(Double_t MSOffset) { fMSOffset = MSOffset; }
+
+    void SetMinStatistics(Int_t MinStatistics) { fMinStatistics = MinStatistics; }
+
+  private:
+    // Number of histograms, limits and bining
+    Double_t fMSOffset;
+
+    // Minimum statistics and parameters
+    Int_t fMinStatistics{};
+
+    R3BMSOffsetPar* fMSOffsetPar;   /**< Parameter container. >*/
+    TClonesArray* fSamplerMapped;   /**< Array with SAMP Mapped input data. >*/
+    TClonesArray* fSamplerMSMapped; /**< Array with SAMPMS MApped input data. >*/
+
+    TH1F* fh_Offset_Finder;
+
+  public:
+    ClassDefOverride(R3BMSOffsetFinder, 1); // NOLINT
+};

--- a/r3bbase/pars/R3BMSOffsetPar.cxx
+++ b/r3bbase/pars/R3BMSOffsetPar.cxx
@@ -1,0 +1,79 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "R3BMSOffsetPar.h"
+#include "R3BLogger.h"
+
+#include "FairDetParIo.h"
+#include "FairLogger.h"
+#include "FairParamList.h"
+
+#include "TArrayD.h"
+#include "TMath.h"
+#include "TString.h"
+
+// ---- Standard Constructor ---------------------------------------------------
+// R3BMSOffsetPar::R3BMSOffsetPar(const char* name, const char* title, const char* context)
+//    : FairParGenericSet(name, title, context)
+R3BMSOffsetPar::R3BMSOffsetPar(std::string_view name, std::string_view title, std::string_view context)
+    : FairParGenericSet(name.data(), title.data(), context.data())
+    , fMSOffset(0)
+{
+}
+
+// ----  Method clear ----------------------------------------------------------
+void R3BMSOffsetPar::clear()
+{
+    status = kFALSE;
+    resetInputVersions();
+}
+
+// ----  Method putParams ------------------------------------------------------
+void R3BMSOffsetPar::putParams(FairParamList* list)
+{
+    R3BLOG(info, "called");
+    if (list == nullptr)
+    {
+        R3BLOG(fatal, "Could not find FairParamList");
+        return;
+    }
+
+    list->add("MSOffsetPar", fMSOffset);
+}
+
+// ----  Method getParams ------------------------------------------------------
+Bool_t R3BMSOffsetPar::getParams(FairParamList* list)
+{
+    R3BLOG(info, "called");
+    if (list == nullptr)
+    {
+        R3BLOG(fatal, "Could not find FairParamList");
+        return kFALSE;
+    }
+
+    if (!list->fill("MSOffsetPar", &fMSOffset))
+    {
+        LOG(error) << "Could not initialize MSOffsetPar";
+        return kFALSE;
+    }
+
+    return kTRUE;
+}
+
+// ----  Method print ----------------------------------------------------------
+void R3BMSOffsetPar::print() { printParams(); }
+
+// ----  Method printParams ----------------------------------------------------
+void R3BMSOffsetPar::printParams() { R3BLOG(info, "Master Start Offset: " << fMSOffset); }
+
+ClassImp(R3BMSOffsetPar); // NOLINT

--- a/r3bbase/pars/R3BMSOffsetPar.h
+++ b/r3bbase/pars/R3BMSOffsetPar.h
@@ -1,0 +1,56 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include "FairParGenericSet.h"
+
+#include "TArrayD.h"
+#include <Rtypes.h>
+#include <cstdint>
+#include <vector>
+
+class FairParamList;
+
+class R3BMSOffsetPar : public FairParGenericSet
+{
+  public:
+    /** Standard constructor **/
+    explicit R3BMSOffsetPar(std::string_view name = "MSOffsetPar",
+                            std::string_view title = "MS Offset Parameter",
+                            std::string_view context = "MSOffsetContext");
+
+    /** Method to reset all parameters **/
+    void clear() override;
+
+    /** Method to store all parameters using FairRuntimeDB **/
+    void putParams(FairParamList* list) override;
+
+    /** Method to retrieve all parameters using FairRuntimeDB**/
+    Bool_t getParams(FairParamList* list) override;
+
+    /** Method to print values of parameters to the standard output **/
+    void print() override;
+    void printParams() override;
+
+    /** Accessor functions **/
+    [[nodiscard]] Double_t GetMSOffset() const { return fMSOffset; }
+
+    void SetMSOffset(Double_t n) { fMSOffset = n; }
+
+  private:
+    Double_t fMSOffset; // Master Start Offset from SAMPMSv and SAMPv
+
+  public:
+    ClassDefOverride(R3BMSOffsetPar, 1); // NOLINT
+};

--- a/r3bdata/sampData/R3BSamplerMappedData.cxx
+++ b/r3bdata/sampData/R3BSamplerMappedData.cxx
@@ -2,18 +2,16 @@
 #include "FairLogger.h"
 #include <iostream>
 
-using namespace std;
-
 R3BSamplerMappedData::R3BSamplerMappedData()
     : fTime(-1) // VULOM timestamp.
 {
 }
 
-R3BSamplerMappedData::R3BSamplerMappedData(UInt_t time)
+R3BSamplerMappedData::R3BSamplerMappedData(int time)
     : fTime(time)
 {
 }
 
-UInt_t R3BSamplerMappedData::GetTime() const { return fTime; }
+int R3BSamplerMappedData::GetTime() const { return fTime; }
 
 ClassImp(R3BSamplerMappedData)

--- a/r3bdata/sampData/R3BSamplerMappedData.h
+++ b/r3bdata/sampData/R3BSamplerMappedData.h
@@ -12,14 +12,12 @@ class R3BSamplerMappedData : public TObject
     R3BSamplerMappedData();
 
     // Standard Constructor
-    R3BSamplerMappedData(UInt_t);
+    explicit R3BSamplerMappedData(int);
 
-    UInt_t GetTime() const;
+    [[nodiscard]] int GetTime() const;
 
-  public:
-    UInt_t fTime;
+    int fTime;
 
-  public:
     ClassDef(R3BSamplerMappedData, 1)
 };
 

--- a/r3bsource/trloii/R3BTrloiiSampReader.cxx
+++ b/r3bsource/trloii/R3BTrloiiSampReader.cxx
@@ -28,91 +28,94 @@ extern "C"
 #include "ext_h101_sampms.h"
 }
 
-using namespace std;
-
-R3BTrloiiSampReader::R3BTrloiiSampReader(EXT_STR_h101_SAMP* data, size_t offset)
+R3BTrloiiSampReader::R3BTrloiiSampReader(EXT_STR_h101_SAMP_onion* data, size_t offset)
     : R3BReader("R3BTrloiiSampReader")
     , fSampData(data)
+    , fSampLosData(nullptr)
+    , fSampMSData(nullptr)
+    , fSampLosMSData(nullptr)
     , fOffset(offset)
     , fSNum(1)
     , fSCNum(1)
     , fArray(new TClonesArray("R3BSamplerMappedData"))
+    , fArrayLH(nullptr)
     , fOnline(kFALSE)
 {
 }
 
-R3BTrloiiSampReader::R3BTrloiiSampReader(EXT_STR_h101_SAMPLOS* data, size_t offset)
+R3BTrloiiSampReader::R3BTrloiiSampReader(EXT_STR_h101_SAMPLOS_onion* data, size_t offset)
     : R3BReader("R3BTrloiiSampReader")
+    , fSampData(nullptr)
     , fSampLosData(data)
+    , fSampMSData(nullptr)
+    , fSampLosMSData(nullptr)
     , fOffset(offset)
     , fSNum(1)
     , fSCNum(2)
+    , fArray(nullptr)
     , fArrayLH(new TClonesArray("R3BSampLosMappedData"))
     , fOnline(kFALSE)
 {
 }
 
-R3BTrloiiSampReader::R3BTrloiiSampReader(EXT_STR_h101_SAMPMS* data, size_t offset)
+R3BTrloiiSampReader::R3BTrloiiSampReader(EXT_STR_h101_SAMPMS_onion* data, size_t offset)
     : R3BReader("R3BTrloiiSampMSReader")
+    , fSampData(nullptr)
+    , fSampLosData(nullptr)
     , fSampMSData(data)
+    , fSampLosMSData(nullptr)
     , fOffset(offset)
     , fSNum(2)
     , fSCNum(1)
     , fArray(new TClonesArray("R3BSamplerMappedData"))
+    , fArrayLH(nullptr)
     , fOnline(kFALSE)
 {
 }
 
-R3BTrloiiSampReader::R3BTrloiiSampReader(EXT_STR_h101_SAMPLOSMS* data, size_t offset)
+R3BTrloiiSampReader::R3BTrloiiSampReader(EXT_STR_h101_SAMPLOSMS_onion* data, size_t offset)
     : R3BReader("R3BTrloiiSampMSReader")
+    , fSampData(nullptr)
+    , fSampLosData(nullptr)
+    , fSampMSData(nullptr)
     , fSampLosMSData(data)
     , fOffset(offset)
     , fSNum(2)
     , fSCNum(2)
+    , fArray(nullptr)
     , fArrayLH(new TClonesArray("R3BSampLosMappedData"))
     , fOnline(kFALSE)
 {
 }
 
-R3BTrloiiSampReader::~R3BTrloiiSampReader()
-{
-    if (fArray)
-    {
-        delete fArray;
-    }
-
-    if (fArrayLH)
-    {
-        delete fArrayLH;
-    }
-}
+R3BTrloiiSampReader::~R3BTrloiiSampReader() = default;
 
 Bool_t R3BTrloiiSampReader::Init(ext_data_struct_info* a_struct_info)
 {
-    Int_t ok = 0;
+    size_t okey = 0;
 
     if (1 == fSNum && 1 == fSCNum)
     {
-        EXT_STR_h101_SAMP_ITEMS_INFO(ok, *a_struct_info, fOffset, EXT_STR_h101_SAMP, 0);
+        EXT_STR_h101_SAMP_ITEMS_INFO(okey, *a_struct_info, fOffset, EXT_STR_h101_SAMP_onion, 0); // NOLINT
         R3BLOG(info, "R3BTrloiiSampReader::Init() SAMP");
     }
     else if (1 == fSNum && 2 == fSCNum)
     {
-        EXT_STR_h101_SAMPLOS_ITEMS_INFO(ok, *a_struct_info, fOffset, EXT_STR_h101_SAMPLOS, 0);
+        EXT_STR_h101_SAMPLOS_ITEMS_INFO(okey, *a_struct_info, fOffset, EXT_STR_h101_SAMPLOS_onion, 0); // NOLINT
         R3BLOG(info, "R3BTrloiiSampReader::Init() SAMPLOS");
     }
     else if (2 == fSNum && 1 == fSCNum)
     {
-        EXT_STR_h101_SAMPMS_ITEMS_INFO(ok, *a_struct_info, fOffset, EXT_STR_h101_SAMPMS, 0);
+        EXT_STR_h101_SAMPMS_ITEMS_INFO(okey, *a_struct_info, fOffset, EXT_STR_h101_SAMPMS_onion, 0); // NOLINT
         R3BLOG(info, "R3BTrloiiSampReader::Init() SAMP master start");
     }
     else if (2 == fSNum && 2 == fSCNum)
     {
-        EXT_STR_h101_SAMPLOSMS_ITEMS_INFO(ok, *a_struct_info, fOffset, EXT_STR_h101_SAMPLOSMS, 0);
+        EXT_STR_h101_SAMPLOSMS_ITEMS_INFO(okey, *a_struct_info, fOffset, EXT_STR_h101_SAMPLOSMS, 0); // NOLINT
         R3BLOG(info, "R3BTrloiiSampReader::Init() SAMPLOS master start");
     }
 
-    if (!ok)
+    if (okey == 0U)
     {
         perror("ext_data_struct_info_item");
         R3BLOG(error, "Failed to setup structure information.");

--- a/r3bsource/trloii/R3BTrloiiSampReader.h
+++ b/r3bsource/trloii/R3BTrloiiSampReader.h
@@ -42,10 +42,10 @@ class R3BTrloiiSampReader : public R3BReader
 {
   public:
     // Parametrized constructors
-    R3BTrloiiSampReader(EXT_STR_h101_SAMP*, size_t);
-    R3BTrloiiSampReader(EXT_STR_h101_SAMPLOS*, size_t);
-    R3BTrloiiSampReader(EXT_STR_h101_SAMPMS*, size_t);
-    R3BTrloiiSampReader(EXT_STR_h101_SAMPLOSMS*, size_t);
+    R3BTrloiiSampReader(EXT_STR_h101_SAMP_onion*, size_t);
+    R3BTrloiiSampReader(EXT_STR_h101_SAMPLOS_onion*, size_t);
+    R3BTrloiiSampReader(EXT_STR_h101_SAMPMS_onion*, size_t);
+    R3BTrloiiSampReader(EXT_STR_h101_SAMPLOSMS_onion*, size_t);
 
     // Destructor
     virtual ~R3BTrloiiSampReader();
@@ -61,10 +61,10 @@ class R3BTrloiiSampReader : public R3BReader
 
   private:
     /* Reader specific data structure from ucesb */
-    EXT_STR_h101_SAMP* fSampData;
-    EXT_STR_h101_SAMPLOS* fSampLosData;
-    EXT_STR_h101_SAMPMS* fSampMSData;
-    EXT_STR_h101_SAMPLOSMS* fSampLosMSData;
+    EXT_STR_h101_SAMP_onion* fSampData;
+    EXT_STR_h101_SAMPLOS_onion* fSampLosData;
+    EXT_STR_h101_SAMPMS_onion* fSampMSData;
+    EXT_STR_h101_SAMPLOSMS_onion* fSampLosMSData;
 
     /* Offset of detector specific data in full data structure */
     size_t fOffset;


### PR DESCRIPTION
Implementation of Parameter finder for Tprev/Tnext calculation.
The parameter is the time offset between the hit recorded in SAMPv and the same hit accepted for SAMPMSv. The time difference is due to the needed time for the Trigger Logic to approve the hit as a Master Start.
---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
