### PR TITLE
[HOT FIX] Bug fixing in Neuland digitisation simulation

### DIFF
--- a/neuland/digitizing/R3BDigitizingPaddle.h
+++ b/neuland/digitizing/R3BDigitizingPaddle.h
@@ -15,7 +15,7 @@
 #define DIGITIZING_PADDLE_H
 
 #include "R3BDigitizingChannel.h"
-#include <FairLogger.h>
+#include <R3BLogger.h>
 #include <RtypesCore.h>
 #include <functional>
 #include <memory>

--- a/neuland/digitizing/R3BDigitizingPaddleMock.h
+++ b/neuland/digitizing/R3BDigitizingPaddleMock.h
@@ -47,13 +47,11 @@ namespace R3B::Digitizing::Neuland
         {
             if (leftSignal.side == rightSignal.side)
             {
-                LOG(fatal)
-                    << "DigitizingPaddleNeuland.cxx::ComputePosition(): cannot comput position with signals from "
-                       "same side!";
+                R3BLOG(fatal, "cannot compute position with signals from same side!");
                 return 0.F;
             }
-            return (leftSignal.side == ChannelSide::left) ? (rightSignal.tdc - leftSignal.tdc) / 2 * gCMedium
-                                                          : (leftSignal.tdc - rightSignal.tdc) / 2 * gCMedium;
+            return (leftSignal.side == ChannelSide::left) ? (leftSignal.tdc - rightSignal.tdc) / 2 * gCMedium
+                                                          : (rightSignal.tdc - leftSignal.tdc) / 2 * gCMedium;
         }
         auto ComputeChannelHits(const Hit& hit) const -> Pair<Channel::Hit> override
         {
@@ -67,7 +65,7 @@ namespace R3B::Digitizing::Neuland
         static constexpr double gCMedium = 30.;     // speed of light in material in [cm/ns]
         static auto GenerateMockChannelHit(Double_t mcTime, Double_t mcLight, Double_t dist) -> Channel::Hit
         {
-            auto time = mcTime + (MockPaddle::gHalfLength + dist) / MockPaddle::gCMedium;
+            auto time = mcTime - (MockPaddle::gHalfLength + dist) / MockPaddle::gCMedium;
             auto light = mcLight;
             return { time, light };
         }

--- a/neuland/digitizing/R3BDigitizingPaddleNeuland.cxx
+++ b/neuland/digitizing/R3BDigitizingPaddleNeuland.cxx
@@ -66,12 +66,11 @@ namespace R3B::Digitizing::Neuland
     {
         if (leftSignal.side == rightSignal.side)
         {
-            LOG(fatal) << "DigitizingPaddleNeuland.cxx::ComputePosition(): cannot comput position with signals from "
-                          "same side!";
+            R3BLOG(fatal, "cannot compute position with signals from same side!");
             return 0.F;
         }
-        return (leftSignal.side == ChannelSide::left) ? (rightSignal.tdc - leftSignal.tdc) / 2 * gCMedium
-                                                      : (leftSignal.tdc - rightSignal.tdc) / 2 * gCMedium;
+        return (leftSignal.side == ChannelSide::left) ? (leftSignal.tdc - rightSignal.tdc) / 2 * gCMedium
+                                                      : (rightSignal.tdc - leftSignal.tdc) / 2 * gCMedium;
     }
 
     auto NeulandPaddle::ComputeChannelHits(const Hit& hit) const -> Paddle::Pair<Channel::Hit>

--- a/neuland/digitizing/R3BDigitizingTamex.h
+++ b/neuland/digitizing/R3BDigitizingTamex.h
@@ -145,7 +145,7 @@ namespace R3B::Digitizing::Neuland::Tamex
         void AttachToPaddle(Digitizing::Paddle* paddle) override;
         std::vector<PMTPeak> fPMTPeaks;
         std::vector<Peak> fFQTPeaks;
-        static R3BNeulandHitPar const* fNeulandHitPar; // NOLINT
+        static R3BNeulandHitPar* fNeulandHitPar; // NOLINT
         R3BNeulandHitModulePar* fNeulandHitModulePar = nullptr;
         Tamex::Params par_;
 

--- a/neuland/digitizing/readme.md
+++ b/neuland/digitizing/readme.md
@@ -86,7 +86,7 @@ using TamexChannel = Digitizing::Neuland::Tamex::Channel;
 auto const channelInit = []() { TamexChannel::GetHitPar("NeulandHitPar"); };
 auto engine = Digitizing::CreateEngine(UsePaddle<NeulandPaddle>(), UseChannel<TamexChannel>(), channelInit);
 ```
-In the example above, the object with the name "NeulandHitPar" should have the type `R3BNeulandHitPar` in the root file "params_sync.root".
+In the example above, the object with the name "NeulandHitPar" should have the type `R3BNeulandHitPar` in the root file "params_sync.root". **Be aware that the runID in the parameter root file must be the same runID in the simulation input file.**
 
 ## DigitizingEngine
 A `DigitizingEngine` object handles the actual data processing, which requires another two objects as the input parameters for its instantiation: `UseChannel` and `UsePaddle`. As suggested by their names, these two objects behave like factories, which are used by `DigitizingEngine` to generate `Channel` and `Paddle` objects. 

--- a/neuland/executables/neulandSim.cxx
+++ b/neuland/executables/neulandSim.cxx
@@ -17,6 +17,8 @@
 #include <iostream>
 #include <string>
 
+constexpr int DEFAULT_RUNID = 999;
+
 int main(int argc, const char** argv)
 {
     auto timer = TStopwatch{};
@@ -29,13 +31,14 @@ int main(int argc, const char** argv)
     auto help = programOptions.Create_Option<bool>("help,h", "help message", false);
     auto eventNum = programOptions.Create_Option<int>("eventNum", "set total event number", defaultEventNum);
     auto eventPrintNum = programOptions.Create_Option<int>("eventPrint", "set event print number", 1);
+    auto runID = programOptions.Create_Option<int>("runID", "set runID", DEFAULT_RUNID);
     auto multi = programOptions.Create_Option<int>("multiplicity", "set particle multiplicity", 1);
     auto pEnergy = programOptions.Create_Option<double>("energy", "set energy value (GeV) of the particle", 1);
     auto simuFileName =
         programOptions.Create_Option<std::string>("simuFile", "set the base filename of simulation ouput", "simu.root");
     auto paraFileName =
         programOptions.Create_Option<std::string>("paraFile", "set the base filename of parameter sink", "para.root");
-    auto logLevel = programOptions.Create_Option<std::string>("logLevel", "set log level of fairlog", "error");
+    auto logLevel = programOptions.Create_Option<std::string>("logLevel,v", "set log level of fairlog", "error");
 
     if (!programOptions.Verify(argc, argv))
     {
@@ -60,6 +63,7 @@ int main(int argc, const char** argv)
     // Basic simulation setup
     auto run = std::make_unique<FairRunSim>();
     run->SetName("TGeant4");
+    run->SetRunId(runID->value());
     run->SetStoreTraj(false);
     run->SetMaterials("media_r3b.geo");
     run->SetSink(std::make_unique<FairRootFileSink>(simuFileName->value().c_str()));

--- a/neuland/test/digitizing/testNeulandDigitizingPaddle.cxx
+++ b/neuland/test/digitizing/testNeulandDigitizingPaddle.cxx
@@ -156,6 +156,27 @@ namespace
         ASSERT_EQ(signals.size(), 2) << "Fail to reconstruct the same number of signals!";
     }
 
+    TEST_F(testNeulandPaddle, check_output_singal) // NOLINT
+    {
+        auto* paddle = GetPaddle();
+        paddle->DepositLight(PaddleHit{ 10., 20., 0.5 * NeulandPaddle::gHalfLength });
+        const auto& leftHits = GetChannels().left->hits_;
+        const auto& rightHits = GetChannels().right->hits_;
+        AddChannelSignal<ChannelSide::left>(leftHits[0].time, leftHits[0].light);
+        AddChannelSignal<ChannelSide::right>(rightHits[0].time, rightHits[0].light);
+        EXPECT_CALL(*GetChannels().left, ConstructSignals())
+            .Times(1)
+            .WillOnce(Return(ExtractChannelSignals<ChannelSide::left>()));
+        EXPECT_CALL(*GetChannels().right, ConstructSignals())
+            .Times(1)
+            .WillOnce(Return(ExtractChannelSignals<ChannelSide::right>()));
+        auto const& signals = paddle->GetSignals();
+        ASSERT_EQ(signals.size(), 1) << "Fail to reconstruct the same number of signals!";
+        const double err = 0.1 * 0.5 * NeulandPaddle::gHalfLength;
+        ASSERT_NEAR(0.5 * NeulandPaddle::gHalfLength, signals.front().position, err)
+            << "reconstructed position is way different to predefined position!";
+    }
+
     // TEST_F(testNeulandPaddle, check_coupling_NoEQ_counts) // NOLINT
     // {
     //     auto* paddle = GetPaddle();


### PR DESCRIPTION
Thanks to @ivanalihtar and Nikhil, some bugs were found in the new NeuLAND digitizer classes.

Here are the changes to fix those bugs:

1. Make the global hit parameter non-const if user needs to read the parameter from a root file.
2. Add an option of runID in neulandSim executable such that the runID could have the same value as in the parameter root file.
3. Add additional information in the manual, explicitly saying the runIDs must be the same in both simulation file and parameter file.
4. Fix the mistake made in the distance calculation. Originally, the reconstructed signal distance is the negative of its original predefined value. For example, if a hit at position of 1 m is added to the paddle, the result of its corresponding signal has a position of -1 m.
5. Add an additional googletest for the distance checking, such that such mistake won't happen again. 

Feel free to comment below.

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
