### PR TITLE
[NEW FEATURE] R3BIOConnector

### DIFF
--- a/r3bbase/CMakeLists.txt
+++ b/r3bbase/CMakeLists.txt
@@ -60,6 +60,7 @@ set(HEADERS
     R3BException.h
     R3BFileSource.h
     R3BFileSource2.h
+    R3BIOConnector.h
     R3BLogger.h
     R3BModule.h
     R3BShared.h

--- a/r3bbase/R3BIOConnector.h
+++ b/r3bbase/R3BIOConnector.h
@@ -1,0 +1,188 @@
+#pragma once
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+// TODO: use C++20 std::source_location
+#include <boost/assert/source_location.hpp>
+
+#include <FairRootManager.h>
+#include <R3BException.h>
+#include <fmt/format.h>
+#include <map>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
+
+// TODO: Use C++20 Concept to put more constains on the template parameters
+namespace R3B
+{
+    template <typename InputType>
+    class InputConnector
+    {
+      public:
+        using RawDataType = std::remove_const_t<std::remove_cv_t<InputType>>;
+        explicit InputConnector(std::string_view branchName)
+            : branch_name_{ branchName }
+        {
+        }
+
+        // rule of 5
+        ~InputConnector() = default;
+        InputConnector(const InputConnector&) = default;
+        InputConnector(InputConnector&&) = delete;
+        InputConnector& operator=(const InputConnector&) = default;
+        InputConnector& operator=(InputConnector&&) = delete;
+
+        void init(const boost::source_location& loc = BOOST_CURRENT_LOCATION)
+        {
+            if (auto* ioman = FairRootManager::Instance(); ioman != nullptr)
+            {
+                data_ = ioman->InitObjectAs<const RawDataType*>(branch_name_.c_str());
+
+                if (data_ == nullptr)
+                {
+                    throw R3B::runtime_error(
+                        fmt::format("Initialisation of the input data with the branch name \"{}\" failed!",
+                                    branch_name_),
+                        loc);
+                }
+            }
+            else
+            {
+                throw R3B::runtime_error(fmt::format("FairRootManager is nullptr during the initialisation of the "
+                                                     "input data with  the branch name \"{}\"",
+                                                     branch_name_),
+                                         loc);
+            }
+        }
+
+        [[nodiscard]] inline auto get(const boost::source_location& loc = BOOST_CURRENT_LOCATION) const
+            -> const RawDataType&
+        {
+            check_init(loc);
+            return *data_;
+        }
+
+        auto size(const boost::source_location& loc = BOOST_CURRENT_LOCATION) const
+        {
+            check_init(loc);
+            return data_->size();
+        }
+
+        // implement range-based for loop:
+        // TODO: is there a simpler way?
+        auto begin(const boost::source_location& loc = BOOST_CURRENT_LOCATION)
+        {
+            check_init(loc);
+            return data_->cbegin();
+        }
+        auto begin(const boost::source_location& loc = BOOST_CURRENT_LOCATION) const
+        {
+            check_init(loc);
+            return data_->cbegin();
+        }
+        auto end(const boost::source_location& loc = BOOST_CURRENT_LOCATION)
+        {
+            check_init(loc);
+            return data_->cend();
+        }
+        auto end(const boost::source_location& loc = BOOST_CURRENT_LOCATION) const
+        {
+            check_init(loc);
+            return data_->cend();
+        }
+
+      private:
+        std::string branch_name_;
+        const RawDataType* data_ = nullptr;
+        void check_init(const boost::source_location& loc) const
+        {
+            if (data_ == nullptr)
+            {
+                throw R3B::runtime_error(
+                    fmt::format("Input data with the branch name \"{}\" cannot be queried without an initialisation!",
+                                branch_name_),
+                    loc);
+            }
+        }
+    };
+
+    template <typename OutputType>
+    class OutputConnector
+    {
+      public:
+        using RawDataType = std::remove_const_t<std::remove_cv_t<OutputType>>;
+        explicit OutputConnector(std::string_view branchName, bool persistance = true)
+            : persistance_{ persistance }
+            , branch_name_{ branchName }
+        {
+        }
+
+        // rule of 5
+        ~OutputConnector() = default;
+        OutputConnector(const OutputConnector&) = delete;
+        OutputConnector(OutputConnector&&) = delete;
+        OutputConnector& operator=(const OutputConnector& other) = delete;
+        OutputConnector& operator=(OutputConnector&&) = delete;
+
+        void init(const boost::source_location& loc = BOOST_CURRENT_LOCATION)
+        {
+            if (auto* ioman = FairRootManager::Instance(); ioman != nullptr)
+            {
+                ioman->RegisterAny(branch_name_.c_str(), data_ptr_, true);
+            }
+            else
+            {
+                throw R3B::runtime_error(fmt::format("FairRootManager is nullptr during the initialisation of the "
+                                                     "output data with the branch name \"{}\"",
+                                                     branch_name_),
+                                         loc);
+            }
+        }
+
+        [[nodiscard]] inline auto get() -> RawDataType& { return data_; }
+
+        inline void clear() { data_.clear(); }
+
+        template <typename ResetOp>
+        inline void clear(ResetOp&& opn)
+        {
+            opn(data_);
+        }
+
+      private:
+        bool persistance_ = true;
+        std::string branch_name_;
+        RawDataType data_;
+        RawDataType* data_ptr_ = &data_;
+    };
+
+    template <typename ElementType>
+    using InputVectorConnector = InputConnector<std::vector<ElementType>>;
+
+    template <typename ElementType>
+    using OutputVectorConnector = OutputConnector<std::vector<ElementType>>;
+
+    template <typename KeyType, typename ValueType>
+    using InputMapConnector = InputConnector<std::map<KeyType, ValueType>>;
+
+    template <typename KeyType, typename ValueType>
+    using OutputMapConnector = OutputConnector<std::map<KeyType, ValueType>>;
+
+    template <typename KeyType, typename ValueType>
+    using InputHashConnector = InputConnector<std::unordered_map<KeyType, ValueType>>;
+
+    template <typename KeyType, typename ValueType>
+    using OutputHashConnector = OutputConnector<std::unordered_map<KeyType, ValueType>>;
+} // namespace R3B


### PR DESCRIPTION
Create an easy-to-use IO interface to read and write STL container type with ROOT Tree.

PR #890 has already shown C++ STL container can work directly with ROOT tree. This class eliminates the boilerplate part needed during the initialization. The interface design is inspired from TCAInputConnector, developed by @janmayer, for the easy transition.

The typename of the class templates (`InputConnector` and `OutputConnector`) should be STL container type (std::vector, std::map and std::unordered_map). 

### How to read input data:
First, users need to specify the branch name inside the class definition (normally FairTask):
```cpp
class AnyTask : public FairTask
{
    public:
      //...
    private:
      InputConnector<std::vector<MapData>> map_data_ {"branchName"};
      // or
      // InputVectorConnector<MapData> map_data_ {"branchName"};
};
```
Then, in the `Init()` function:
```cpp
InitStatus AnyTask::Init()
{
    map_data_.init();
}
```
To read:
```cpp
void AnyTask::Exec()
{
    for(const auto& element : map_data_)
    {
        // do somwthing
    }
}
```
### How to write output data:
Same with the input data:
```cpp
class AnyTask : public FairTask
{
    public:
      //...
    private:
      OutputConnector<std::vector<MapData>> map_data_ {"branchName"};
      // or
      // OutputVectorConnector<MapData> map_data_ {"branchName"};
};
```
Then, in the `Init()` function:
```cpp
InitStatus AnyTask::Init()
{
    map_data_.init();
}
```
To record an entry:
```cpp
void AnyTask::Exec()
{
    map_data_.clear();
    auto& map_data = map_data_.get();
    
    map_data.push_back(a_map_datum);
    // in case of std::map
    // map_data.insert({key, a_map_datum});
}
```
### Non-container type

For non-container type, please just use the traditional way:
```cpp
auto* rootMan = FairRootManager::Instance();
auto* eventHeader = dynamic_cast<R3BEventHeader*>(rootMan->GetObject("EventHeader.")
```

> **WARNING**
> The usage of this class alone is not enough. To work successfully with ROOT tree IO, the corresponding container type must also be added in `LinkDef.h` file, e.g. `#pragma link C++ class unordered_map<unsigned int, R3B::TCalVFTXModulePar>+;` 


After this is merged, I will adopt it in the R3BRoot/template (and also fix many other things over there).
Feel free to comment below @klenze @jose-luis-rs .

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
