### PR TITLE
Add a template reader and a data type for sync check

### DIFF
--- a/r3bdata/CMakeLists.txt
+++ b/r3bdata/CMakeLists.txt
@@ -58,6 +58,7 @@ ${R3BROOT_SOURCE_DIR}/r3bdata/rpcData
 ${R3BROOT_SOURCE_DIR}/r3bdata/mwpcData
 ${R3BROOT_SOURCE_DIR}/r3bdata/twimData
 ${R3BROOT_SOURCE_DIR}/r3bdata/musliData
+${R3BROOT_SOURCE_DIR}/r3bdata/synccheckData
 )
 
 include_directories(${INCLUDE_DIRECTORIES})
@@ -209,6 +210,7 @@ twimData/R3BTwimHitData.cxx
 musliData/R3BMusliMappedData.cxx
 musliData/R3BMusliCalData.cxx
 musliData/R3BMusliHitData.cxx
+synccheckData/R3BSyncCheckData.cxx
 )
 
 # fill list of header files from list of source files by exchanging the file extension

--- a/r3bdata/DataLinkDef.h
+++ b/r3bdata/DataLinkDef.h
@@ -170,5 +170,6 @@
 #pragma link C++ class R3BSfibCalData+;
 #pragma link C++ class R3BSfibHitData+;
 #pragma link C++ class R3BFrsData+;
+#pragma link C++ class R3BSyncCheckData+;
 
 #endif

--- a/r3bdata/synccheckData/R3BSyncCheckData.cxx
+++ b/r3bdata/synccheckData/R3BSyncCheckData.cxx
@@ -1,0 +1,44 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "R3BSyncCheckData.h"
+
+R3BSyncCheckData::R3BSyncCheckData()
+    : fMaster(0)
+    , fMasterRef(0)
+    , fMusic(0)
+    , fRpc(0)
+    , fS2(0)
+    , fFoot1(0)
+    , fFoot2(0)
+{
+}
+
+R3BSyncCheckData::R3BSyncCheckData(uint32_t master,
+                                   uint32_t masterref,
+                                   uint32_t music,
+                                   uint32_t rpc,
+                                   uint32_t s2,
+                                   uint32_t foot1,
+                                   uint32_t foot2)
+    : fMaster(master)
+    , fMasterRef(masterref)
+    , fMusic(music)
+    , fRpc(rpc)
+    , fS2(s2)
+    , fFoot1(foot1)
+    , fFoot2(foot2)
+{
+}
+
+ClassImp(R3BSyncCheckData);

--- a/r3bdata/synccheckData/R3BSyncCheckData.h
+++ b/r3bdata/synccheckData/R3BSyncCheckData.h
@@ -1,0 +1,56 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BSyncCheckData_H
+#define R3BSyncCheckData_H 1
+
+#include "TObject.h"
+#include <Rtypes.h>
+
+class R3BSyncCheckData : public TObject
+{
+  public:
+    R3BSyncCheckData();
+    R3BSyncCheckData(uint32_t master,
+                     uint32_t masterref,
+                     uint32_t music,
+                     uint32_t rpc,
+                     uint32_t s2,
+                     uint32_t foot1,
+                     uint32_t foot2);
+
+    virtual ~R3BSyncCheckData() {}
+
+    inline const uint32_t& GetMaster() const { return fMaster; }
+    inline const uint32_t& GetMasterRef() const { return fMasterRef; }
+    inline const uint32_t& GetMusic() const { return fMusic; }
+    inline const uint32_t& GetRpc() const { return fRpc; }
+    inline const uint32_t& GetS2() const { return fS2; }
+    inline const uint32_t& GetFoot1() const { return fFoot1; }
+    inline const uint32_t& GetFoot2() const { return fFoot2; }
+
+  protected:
+    // following the order from ext file
+    uint32_t fMaster;
+    uint32_t fMasterRef;
+    uint32_t fMusic;
+    uint32_t fRpc;
+    uint32_t fS2;
+    uint32_t fFoot1;
+    uint32_t fFoot2;
+
+  public:
+    ClassDef(R3BSyncCheckData, 1)
+};
+
+#endif /* R3BSyncCheckData_H */

--- a/r3bsource/CMakeLists.txt
+++ b/r3bsource/CMakeLists.txt
@@ -48,6 +48,7 @@ ${R3BROOT_SOURCE_DIR}/r3bsource/fibers
 ${R3BROOT_SOURCE_DIR}/r3bsource/tofd
 ${R3BROOT_SOURCE_DIR}/r3bsource/tofi
 ${R3BROOT_SOURCE_DIR}/r3bsource/rpc
+${R3BROOT_SOURCE_DIR}/r3bsource/sync_check
 ${R3BROOT_SOURCE_DIR}/r3bbase
 ${R3BROOT_SOURCE_DIR}/r3bdata/beammonitorData
 ${R3BROOT_SOURCE_DIR}/r3bdata/califaData
@@ -75,6 +76,7 @@ ${R3BROOT_SOURCE_DIR}/r3bdata/twimData
 ${R3BROOT_SOURCE_DIR}/r3bdata/musliData
 ${R3BROOT_SOURCE_DIR}/r3bdata/mwpcData
 ${R3BROOT_SOURCE_DIR}/r3bdata/sampData
+${R3BROOT_SOURCE_DIR}/r3bdata/synccheckData
 )
 
 set(LINK_DIRECTORIES
@@ -145,6 +147,7 @@ set(SRCS
 ./twim/R3BTwimReader.cxx
 ./musli/R3BMusliReader.cxx
 ./mwpc/R3BMwpcReader.cxx
+./sync_check/R3BSyncCheckReader.cxx
 )
 
 Set(STRUCT_HEADERS
@@ -212,6 +215,7 @@ Set(STRUCT_HEADERS
 ./trloii/ext_h101_samplosms.h
 ./pdc/ext_h101_pdc.h
 ./rpc/ext_h101_rpc.h
+./sync_check/ext_h101_sync_check.h
 )
 
 # fill list of header files from list of source files

--- a/r3bsource/SourceLinkDef.h
+++ b/r3bsource/SourceLinkDef.h
@@ -77,6 +77,7 @@
 #pragma link C++ class R3BTwimReader+;
 #pragma link C++ class R3BMusliReader+;
 #pragma link C++ class R3BMwpcReader+;
+#pragma link C++ class R3BSyncCheckReader+;
 
 
 #pragma link C++ class EXT_STR_h101_unpack_t;
@@ -138,5 +139,6 @@
 #pragma link C++ class EXT_STR_h101_PDC_onion_t;
 #pragma link C++ class EXT_STR_h101_LOS_t;
 #pragma link C++ class EXT_STR_h101_RPC_t;
+#pragma link C++ class EXT_STR_h101_SYNC_CHECK_t;
 
 #endif

--- a/r3bsource/sync_check/R3BSyncCheckReader.cxx
+++ b/r3bsource/sync_check/R3BSyncCheckReader.cxx
@@ -1,0 +1,78 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "FairLogger.h"
+#include "FairRootManager.h"
+
+#include "R3BEventHeader.h"
+#include "R3BLogger.h"
+#include "R3BSyncCheckData.h"
+#include "R3BSyncCheckReader.h"
+#include "TClonesArray.h"
+
+extern "C"
+{
+#include "ext_data_client.h"
+#include "ext_h101_sync_check.h"
+}
+
+R3BSyncCheckReader::R3BSyncCheckReader(EXT_STR_h101_SYNC_CHECK* data, size_t offset)
+    : R3BReader("R3BSyncCheckReader")
+    , fNEvent(1)
+    , fData(data)
+    , fOffset(offset)
+    , fArray(new TClonesArray("R3BSyncCheckData"))
+{
+}
+
+R3BSyncCheckReader::~R3BSyncCheckReader()
+{
+    if (fArray)
+    {
+        delete fArray;
+    }
+}
+
+Bool_t R3BSyncCheckReader::Init(ext_data_struct_info* a_struct_info)
+{
+    Int_t ok;
+    R3BLOG(info, "");
+    EXT_STR_h101_SYNC_CHECK_ITEMS_INFO(ok, *a_struct_info, fOffset, EXT_STR_h101_SYNC_CHECK, 0);
+    if (!ok)
+    {
+        R3BLOG(fatal, "Failed to setup structure information");
+        return kFALSE;
+    }
+    // Register output array in tree
+    FairRootManager::Instance()->Register("SyncCheckData", "SyncCheck", fArray, kTRUE);
+    Reset();
+    memset(fData, 0, sizeof *fData);
+    return kTRUE;
+}
+
+Bool_t R3BSyncCheckReader::R3BRead()
+{
+    new ((*fArray)[fArray->GetEntriesFast()]) R3BSyncCheckData(fData->SYNC_CHECK_MASTER,
+                                                               fData->SYNC_CHECK_MASTERRR,
+                                                               fData->SYNC_CHECK_MUSIC,
+                                                               fData->SYNC_CHECK_RPC,
+                                                               fData->SYNC_CHECK_STWO,
+                                                               fData->SYNC_CHECK_FT1V,
+                                                               fData->SYNC_CHECK_FT2V);
+    fNEvent++;
+    return kTRUE;
+}
+
+void R3BSyncCheckReader::Reset() { fArray->Clear(); }
+
+ClassImp(R3BSyncCheckReader);

--- a/r3bsource/sync_check/R3BSyncCheckReader.h
+++ b/r3bsource/sync_check/R3BSyncCheckReader.h
@@ -1,0 +1,56 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BSyncCheckReader_H
+#define R3BSyncCheckReader_H 1
+
+#include "R3BReader.h"
+#include <Rtypes.h>
+
+struct EXT_STR_h101_SYNC_CHECK_t;
+typedef struct EXT_STR_h101_SYNC_CHECK_t EXT_STR_h101_SYNC_CHECK;
+class ext_data_struct_info;
+class TClonesArray;
+
+class R3BSyncCheckReader : public R3BReader
+{
+  public:
+    // Standard constructor
+    R3BSyncCheckReader(EXT_STR_h101_SYNC_CHECK*, size_t);
+
+    // Destructor
+    virtual ~R3BSyncCheckReader();
+
+    // Setup structure information
+    virtual Bool_t Init(ext_data_struct_info*) override;
+
+    // Read data from full event structure
+    virtual Bool_t R3BRead() override;
+
+    // Reset
+    virtual void Reset() override;
+
+  private:
+    // An event counter
+    UInt_t fNEvent;
+    // Reader specific data structure from ucesb
+    EXT_STR_h101_SYNC_CHECK* fData;
+    // Offset of detector specific data in full data structure
+    size_t fOffset;
+    // Output array
+    TClonesArray* fArray;
+
+  public:
+    ClassDefOverride(R3BSyncCheckReader, 0);
+};
+#endif // R3BSyncCheckReader_H

--- a/r3bsource/sync_check/ext_h101_sync_check.h
+++ b/r3bsource/sync_check/ext_h101_sync_check.h
@@ -1,0 +1,103 @@
+/********************************************************
+ *
+ * Structure for ext_data_fetch_event() filling.
+ *
+ * Do not edit - automatically generated.
+ */
+
+#ifndef __GUARD_H101_SYNC_CHECK_EXT_H101_SYNC_CHECK_H__
+#define __GUARD_H101_SYNC_CHECK_EXT_H101_SYNC_CHECK_H__
+
+#ifndef __CINT__
+#include <stdint.h>
+#else
+/* For CINT (old version trouble with stdint.h): */
+#ifndef uint32_t
+typedef unsigned int uint32_t;
+typedef int int32_t;
+#endif
+#endif
+#ifndef EXT_STRUCT_CTRL
+#define EXT_STRUCT_CTRL(x)
+#endif
+
+/********************************************************
+ *
+ * Plain structure (layout as ntuple/root file):
+ */
+
+typedef struct EXT_STR_h101_SYNC_CHECK_t
+{
+    /* RAW */
+    uint32_t SYNC_CHECK_MASTER /* [0,65535] */;
+    uint32_t SYNC_CHECK_MASTERRR /* [0,65535] */;
+    uint32_t SYNC_CHECK_MUSIC /* [0,65535] */;
+    uint32_t SYNC_CHECK_MUSICRR /* [0,65535] */;
+    uint32_t SYNC_CHECK_RPC /* [0,65535] */;
+    uint32_t SYNC_CHECK_RPCRR /* [0,65535] */;
+    uint32_t SYNC_CHECK_STWO /* [0,65535] */;
+    uint32_t SYNC_CHECK_STWORR /* [0,65535] */;
+    uint32_t SYNC_CHECK_FT1V /* [0,65535] */;
+    uint32_t SYNC_CHECK_FT1RR /* [0,65535] */;
+    uint32_t SYNC_CHECK_FT2V /* [0,65535] */;
+    uint32_t SYNC_CHECK_FT2RR /* [0,65535] */;
+
+} EXT_STR_h101_SYNC_CHECK;
+
+/********************************************************
+ *
+ * Structure with multiple levels of arrays (partially)
+ * recovered (recommended):
+ */
+
+typedef struct EXT_STR_h101_SYNC_CHECK_onion_t
+{
+    /* RAW */
+    uint32_t SYNC_CHECK_MASTER;
+    uint32_t SYNC_CHECK_MASTERRR;
+    uint32_t SYNC_CHECK_MUSIC;
+    uint32_t SYNC_CHECK_MUSICRR;
+    uint32_t SYNC_CHECK_RPC;
+    uint32_t SYNC_CHECK_RPCRR;
+    uint32_t SYNC_CHECK_STWO;
+    uint32_t SYNC_CHECK_STWORR;
+    struct
+    {
+        uint32_t V;
+        uint32_t RR;
+    } SYNC_CHECK_FT[2];
+
+} EXT_STR_h101_SYNC_CHECK_onion;
+
+/*******************************************************/
+
+#define EXT_STR_h101_SYNC_CHECK_ITEMS_INFO(ok, si, offset, struct_t, printerr)                                        \
+    do                                                                                                                \
+    {                                                                                                                 \
+        ok = 1;                                                                                                       \
+        /* RAW */                                                                                                     \
+        EXT_STR_ITEM_INFO_LIM(                                                                                        \
+            ok, si, offset, struct_t, printerr, SYNC_CHECK_MASTER, UINT32, "SYNC_CHECK_MASTER", 65535);               \
+        EXT_STR_ITEM_INFO_LIM(                                                                                        \
+            ok, si, offset, struct_t, printerr, SYNC_CHECK_MASTERRR, UINT32, "SYNC_CHECK_MASTERRR", 65535);           \
+        EXT_STR_ITEM_INFO_LIM(                                                                                        \
+            ok, si, offset, struct_t, printerr, SYNC_CHECK_MUSIC, UINT32, "SYNC_CHECK_MUSIC", 65535);                 \
+        EXT_STR_ITEM_INFO_LIM(                                                                                        \
+            ok, si, offset, struct_t, printerr, SYNC_CHECK_MUSICRR, UINT32, "SYNC_CHECK_MUSICRR", 65535);             \
+        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, SYNC_CHECK_RPC, UINT32, "SYNC_CHECK_RPC", 65535);   \
+        EXT_STR_ITEM_INFO_LIM(                                                                                        \
+            ok, si, offset, struct_t, printerr, SYNC_CHECK_RPCRR, UINT32, "SYNC_CHECK_RPCRR", 65535);                 \
+        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, SYNC_CHECK_STWO, UINT32, "SYNC_CHECK_STWO", 65535); \
+        EXT_STR_ITEM_INFO_LIM(                                                                                        \
+            ok, si, offset, struct_t, printerr, SYNC_CHECK_STWORR, UINT32, "SYNC_CHECK_STWORR", 65535);               \
+        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, SYNC_CHECK_FT1V, UINT32, "SYNC_CHECK_FT1V", 65535); \
+        EXT_STR_ITEM_INFO_LIM(                                                                                        \
+            ok, si, offset, struct_t, printerr, SYNC_CHECK_FT1RR, UINT32, "SYNC_CHECK_FT1RR", 65535);                 \
+        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, SYNC_CHECK_FT2V, UINT32, "SYNC_CHECK_FT2V", 65535); \
+        EXT_STR_ITEM_INFO_LIM(                                                                                        \
+            ok, si, offset, struct_t, printerr, SYNC_CHECK_FT2RR, UINT32, "SYNC_CHECK_FT2RR", 65535);                 \
+                                                                                                                      \
+    } while (0);
+#endif /*__GUARD_H101_SYNC_CHECK_EXT_H101_SYNC_CHECK_H__*/
+
+/*******************************************************/


### PR DESCRIPTION
This allows to read sync values from different detectors which is mandatory for the online analysis of the upcoming experiments. Some updates as well as the online task for plotting the sync correlations will follow with the next pull request(s) 

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
