### PR TITLE
Disable clang-tidy checking on files with prefix ext_

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         mkdir -p clang-tidy-result
         git diff -U0 HEAD^ | python3 $PWD/util/clang-tidy-diff.py -p1 -path build -j4 -use-color \
-        -iregex '.*\.(cpp|cc|c\+\+|cxx|cl|h|hh|hpp|m|mm|inc)' \
+        -iregex '^(.*\/)(?!ext_)([^\/]*\.(cpp|cc|c\+\+|cxx|cl|hpp|hh|h|m|mm|inc))$' \
         > clang-tidy-result/fixes.yml
         cat clang-tidy-result/fixes.yml |\
         sed -e 's/\x1b\[[0-9;]*m//g' |\


### PR DESCRIPTION
Requested from PR #896.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
