### PR TITLE
Added all crystal sorting for backwards compatibility

### DIFF
--- a/califa/calibration/R3BCalifaCrystalCal2Cluster.cxx
+++ b/califa/calibration/R3BCalifaCrystalCal2Cluster.cxx
@@ -320,6 +320,7 @@ void R3BCalifaCrystalCal2Cluster::Exec(Option_t* opt)
     // Sort all vectors by energy
     std::sort(gammaCandidatesVec.begin(), gammaCandidatesVec.end(), compareByEnergy);
     std::sort(protonCandidatesVec.begin(), protonCandidatesVec.end(), compareByEnergy);
+    std::sort(allCrystalVec.begin(), allCrystalVec.end(), compareByEnergy);
 
     TVector3 mother_angles, angles;
     Double_t fRandTheta, fRandPhi;


### PR DESCRIPTION
For those users whose code is rather old and does not include the saturation marked as nan. This sorting makes the code backward compatible. 

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
