### PR TITLE
fix R3BRoot/r3bbase/R3BFileSource2.h:29:48: error: no template named …

### DIFF
--- a/r3bbase/R3BFileSource2.h
+++ b/r3bbase/R3BFileSource2.h
@@ -16,6 +16,7 @@
 #include "FairSource.h"
 #include "R3BShared.h"
 #include <TObjString.h>
+#include <optional>
 
 class FairRootManager;
 class TChain;

--- a/r3bsource/base/utils/R3BUcesbMappingFlag.h
+++ b/r3bsource/base/utils/R3BUcesbMappingFlag.h
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <ext_data_client.h>
 #include <fmt/format.h>
+#include <ostream>
 
 constexpr auto UCESB_MAP_BITSIZE = 32;
 


### PR DESCRIPTION
…'optional' in namespace 'std'

fix error: invalid use of incomplete type ‘class std::basic_ostream<char>’

Describe your proposal.

Mention any issue this PR is resolved or is related to.

---

Checklist:

* [ ] Rebased against `dev` branch
* [ ] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [ ] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [ ] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
