### PR TITLE
Add two cal levels for FrsSci (position and tof)

### DIFF
--- a/frssci/CMakeLists.txt
+++ b/frssci/CMakeLists.txt
@@ -44,8 +44,10 @@ link_directories( ${LINK_DIRECTORIES})
 set(SRCS
 parameters/R3BFrsSciContFact.cxx
 parameters/R3BFrsSciTcalPar.cxx
+parameters/R3BFrsSciCalPar.cxx
 calibration/R3BFrsSciMapped2Tcal.cxx
 calibration/R3BFrsSciMapped2TcalPar.cxx
+calibration/R3BFrsSciTcal2Cal.cxx
 online/R3BOnlineSpectraFrsSci.cxx
 )
 

--- a/frssci/FrsSciLinkDef.h
+++ b/frssci/FrsSciLinkDef.h
@@ -21,8 +21,10 @@
  
 #pragma link C++ class R3BFrsSciContFact+;
 #pragma link C++ class R3BFrsSciTcalPar+;
+#pragma link C++ class R3BFrsSciCalPar+;
 #pragma link C++ class R3BFrsSciMapped2Tcal+;
 #pragma link C++ class R3BFrsSciMapped2TcalPar+;
+#pragma link C++ class R3BFrsSciTcal2Cal+;
 #pragma link C++ class R3BOnlineSpectraFrsSci+;
 
 #endif

--- a/frssci/calibration/R3BFrsSciTcal2Cal.cxx
+++ b/frssci/calibration/R3BFrsSciTcal2Cal.cxx
@@ -1,0 +1,398 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+// Fair headers
+#include "FairLogger.h"
+#include "FairRootManager.h"
+#include "FairRunAna.h"
+#include "FairRuntimeDb.h"
+
+// FrsSci headers
+#include "R3BFrsSciTcal2Cal.h"
+
+#define SPEED_OF_LIGHT_MNS 0.299792458
+
+// --- Default Constructor
+R3BFrsSciTcal2Cal::R3BFrsSciTcal2Cal()
+    : FairTask("R3BFrsSciTcal2Cal", 1)
+    , fNevent(0)
+    , fTcal(NULL)
+    , fCalPar(NULL)
+    , fPosCal(NULL)
+    , fTofCal(NULL)
+    , fOnline(kFALSE)
+{
+}
+
+// --- Standard Constructor
+R3BFrsSciTcal2Cal::R3BFrsSciTcal2Cal(const char* name, Int_t iVerbose)
+    : FairTask(name, iVerbose)
+    , fNevent(0)
+    , fTcal(NULL)
+    , fCalPar(NULL)
+    , fPosCal(NULL)
+    , fTofCal(NULL)
+    , fOnline(kFALSE)
+{
+}
+
+// --- Destructor
+R3BFrsSciTcal2Cal::~R3BFrsSciTcal2Cal()
+{
+    LOG(info) << "R3BFrsSciTcal2Cal: Delete instance";
+    if (fTcal)
+    {
+        delete fTcal;
+    }
+    if (fPosCal)
+    {
+        delete fPosCal;
+    }
+    if (fTofCal)
+    {
+        delete fTofCal;
+    }
+}
+
+// --- Parameter container : reading FrsSciTcalPar from FairRuntimeDb
+void R3BFrsSciTcal2Cal::SetParContainers()
+{
+    FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+    if (!rtdb)
+    {
+        LOG(error) << "FairRuntimeDb not opened!";
+    }
+
+    fCalPar = (R3BFrsSciCalPar*)rtdb->getContainer("FrsSciCalPar");
+    if (!fCalPar)
+    {
+        LOG(error) << "R3BFrsSciTcal2Cal::SetParContainers() : Could not get access to FrsSciCalPar-Container.";
+        return;
+    }
+    else
+    {
+        LOG(info) << "R3BFrsSciTcal2Cal::SetParContainers() : FrsSciCalPar-Container found with"
+                  << fCalPar->GetNumDets() << " FrsSciDets, " << fCalPar->GetNumPmts() << " Pmts and "
+                  << fCalPar->GetNumTofs() << " Tofs";
+    }
+}
+
+InitStatus R3BFrsSciTcal2Cal::Init()
+{
+    LOG(info) << "R3BFrsSciTcal2Cal::Init()";
+
+    FairRootManager* rm = FairRootManager::Instance();
+    if (!rm)
+    {
+        LOG(error) << "R3BFrsSciTcal2Cal::Init() Couldn't instance the FairRootManager";
+        return kFATAL;
+    }
+
+    // Input data
+    fTcal = (TClonesArray*)rm->GetObject("FrsSciTcalData");
+    if (!fTcal)
+    {
+        LOG(error) << "R3BFrsSciTcal2Cal::Init() Couldn't get handle on FrsSciTcalData container";
+        return kFATAL;
+    }
+    else
+        LOG(info) << "R3BFrsSciTcal2Cal::Init() FrsSciTcalData items found";
+
+    // Register output arrays in tree
+    fPosCal = new TClonesArray("R3BFrsSciPosCalData", 25);
+    if (!fOnline)
+    {
+        rm->Register("FrsSciPosCalData", "FrsSci", fPosCal, kTRUE);
+    }
+    else
+    {
+        rm->Register("FrsSciPosCalData", "FrsSci", fPosCal, kFALSE);
+    }
+
+    fTofCal = new TClonesArray("R3BFrsSciTofCalData", 25);
+    if (!fOnline)
+    {
+        rm->Register("FrsSciTofCalData", "FrsSci", fTofCal, kTRUE);
+    }
+    else
+    {
+        rm->Register("FrsSciTofCalData", "FrsSci", fTofCal, kFALSE);
+    }
+
+    return kSUCCESS;
+}
+
+InitStatus R3BFrsSciTcal2Cal::ReInit()
+{
+    SetParContainers();
+    return kSUCCESS;
+}
+
+void R3BFrsSciTcal2Cal::Exec(Option_t* option)
+{
+    // Reset entries in output arrays, local arrays
+    Reset();
+
+    // Variables to read the Tcal data
+    UShort_t nDets = (UShort_t)fCalPar->GetNumDets();
+    UShort_t nPmts = (UShort_t)fCalPar->GetNumPmts();
+    UShort_t nTofs = (UShort_t)fCalPar->GetNumTofs();
+    UShort_t iDet;
+    UShort_t iPmt;
+    Double_t iTraw[nDets * nPmts][64]; // 64 hits max per VFTX channel
+    UShort_t mult[nDets * nPmts];
+    // ULong64_t maskR[nDets];
+    // ULong64_t maskL[nDets];
+    for (UShort_t i = 0; i < nDets * nPmts; i++)
+    {
+        mult[i] = 0;
+    }
+
+    // Loop over the entries of the Tcal TClonesArray
+    UInt_t nHitsPerEvent_FrsSci = fTcal->GetEntries();
+    for (UInt_t ihit = 0; ihit < nHitsPerEvent_FrsSci; ihit++)
+    {
+        R3BFrsSciTcalData* hit = (R3BFrsSciTcalData*)fTcal->At(ihit);
+        if (!hit)
+            continue;
+        iDet = hit->GetDetector() - 1;
+        iPmt = hit->GetPmt() - 1;
+        if (mult[iDet * nPmts + iPmt] < 64) // always true, max mult=64 per vftx channel
+        {
+            iTraw[iDet * nPmts + iPmt][mult[iDet * nPmts + iPmt]] = hit->GetRawTimeNs();
+            mult[iDet * nPmts + iPmt]++;
+        }
+    }
+
+    // Select the proper hit in the multihit tcal data
+    // if nDets==1 -> Use the Position : not really selective, better use LOS (need to be coded !)
+    // if nDets>1  -> Use the Tof
+    if (nDets == 1)
+    {
+        // Variables to fill PosCal and TofCal data
+        Double_t iRawTime = -1.;
+        Float_t iRawPos = -10000.;
+        Float_t iCalPos = -10000.;
+        // maskL[0] = 0x0;
+        // maskR[0] = 0x0;
+        for (UShort_t multR = 0; multR < mult[0]; multR++)
+        {
+            for (UShort_t multL = 0; multL < mult[1]; multL++)
+            {
+                // RawPos = TrawRIGHT - TrawLEFT corresponds to x increasing from RIGHT to LEFT
+                iRawPos = iTraw[0][multR] - iTraw[1][multL];
+                // if the raw position is outside the range: continue
+                if (iRawPos < fCalPar->GetMinPosAtRank(0))
+                    continue;
+                if (iRawPos > fCalPar->GetMaxPosAtRank(0))
+                    continue;
+                // if the left or right hit has already been used, continue
+                // if ((((maskR[0] >> multR) & (0x1)) == 1) || (((maskL[0] > multL) & (0x1)) == 1))
+                //    continue;
+                iRawTime = 0.5 * (iTraw[0][multL] + iTraw[1][multR]);
+                // tag which hit is used
+                // maskR[0] |= (0x1) << multR;
+                // maskL[0] |= (0x1) << multL;
+
+                iCalPos = fCalPar->GetPosCalGainAtRank(0) * iRawPos + fCalPar->GetPosCalOffsetAtRank(0);
+                AddPosCalData(1, iRawTime, iRawPos, iCalPos);
+            } // end of loop over the hits of the left PMTs
+        }     // end of loop over the hits of the right PMTs
+    }         // end of if (nDets==1)
+    else if (nDets > 1)
+    {
+        // Variables to fill PosCal and TofCal data
+        Double_t iRawTimeSta = -1., iRawTimeSto = -1.;
+        Float_t iRawPosSta = -10000., iCalPosSta = -10000.;
+        Float_t iRawPosSto = -10000., iCalPosSto = -10000.;
+        Double_t iRawTof = -1., iCalTof = -1, iBeta = -1, iCalVelo = -1.;
+        Int_t selectLeftHit[nDets];
+        Int_t selectRightHit[nDets];
+        for (UShort_t det = 0; det < nDets; det++)
+        {
+            selectLeftHit[det] = -1;
+            selectRightHit[det] = -1;
+        }
+
+        // stop detector is the last detector
+        Int_t dSto = nDets - 1; // 0-based
+        UShort_t selectRightHit_dSto[nDets - 1];
+        UShort_t selectLeftHit_dSto[nDets - 1];
+        for (UShort_t det = 0; det < nDets - 1; det++)
+        {
+            selectLeftHit_dSto[det] = -1;
+            selectRightHit_dSto[det] = -1;
+        }
+        Bool_t selectSameHit = kTRUE;
+
+        // loop over all the start detectors
+        for (Int_t dSta = 0; dSta < nDets - 1; dSta++)
+        {
+            for (UShort_t multRsto = 0; multRsto < mult[dSto * nPmts]; multRsto++)
+            {
+                for (UShort_t multLsto = 0; multLsto < mult[dSto * nPmts + 1]; multLsto++)
+                {
+                    // process only data with valid position
+                    iRawPosSto = (iTraw[dSto * nPmts][multRsto] - iTraw[dSto * nPmts + 1][multLsto]);
+                    if ((iRawPosSto < fCalPar->GetMinPosAtRank(2 * dSto)) ||
+                        (iRawPosSto > fCalPar->GetMaxPosAtRank(2 * dSto)))
+                        continue;
+                    for (UShort_t multRsta = 0; multRsta < mult[dSta * nPmts]; multRsta++)
+                    {
+                        for (UShort_t multLsta = 0; multLsta < mult[dSta * nPmts + 1]; multLsta++)
+                        {
+                            // process only data with vali position
+                            iRawPosSta = (iTraw[dSta * nPmts][multRsta] - iTraw[dSta * nPmts + 1][multLsta]);
+                            if ((iRawPosSta < fCalPar->GetMinPosAtRank(2 * dSta)) ||
+                                (iRawPosSta > fCalPar->GetMaxPosAtRank(2 * dSta)))
+                                continue;
+                            // if position in Sta and Sto are valid, selection with Tof
+                            iRawTimeSta = 0.5 * (iTraw[dSta * nPmts][multRsta] + iTraw[dSta * nPmts + 1][multLsta]);
+                            iRawTimeSto = 0.5 * (iTraw[dSto * nPmts][multRsto] + iTraw[dSto * nPmts + 1][multLsto]);
+                            iRawTof =
+                                iRawTimeSto - iRawTimeSta + iTraw[dSta * nPmts + 2][0] - iTraw[dSto * nPmts + 2][0];
+                            if ((fCalPar->GetMinTofAtRank(dSta) <= iRawTof) &&
+                                (iRawTof <= fCalPar->GetMaxTofAtRank(dSta)))
+                            {
+                                selectLeftHit[dSta] = multLsta;
+                                selectLeftHit[dSto] = multLsto;
+
+                                selectRightHit[dSta] = multRsta;
+                                selectRightHit[dSto] = multRsto;
+
+                                selectLeftHit_dSto[dSta] = multLsto;
+                                selectRightHit_dSto[dSta] = multRsto;
+
+                                if (dSta > 0)
+                                {
+                                    for (Int_t d = dSta; d < nDets - 1; dSta++)
+                                    {
+                                        if (selectLeftHit_dSto[d] != selectLeftHit_dSto[d - 1])
+                                            selectSameHit = kFALSE;
+                                        if (selectRightHit_dSto[d] != selectRightHit_dSto[d - 1])
+                                            selectSameHit = kFALSE;
+                                    }
+                                }
+                            }
+
+                        } // end of loop over the left start mult
+                    }     // end of loop over the right start mult
+                }         // end of loop over the left stop mult
+            }             // end of loop over the right stop mult
+        }                 // end of loop over the start detectors
+
+        // Fill CalData levels
+        Double_t iRawTime[nDets];
+        Float_t iRawPos[nDets];
+        Float_t iCalPos[nDets];
+        for (UShort_t det = 0; det < nDets; det++)
+        {
+            iRawTime[det] = -1000;
+            iRawPos[det] = -1000;
+            iCalPos[det] = -1000;
+        }
+        // if hit at stop detector is the same for all Sta detector
+        if (selectSameHit == kTRUE)
+        {
+            for (UShort_t det = 0; det < nDets; det++)
+            {
+                iRawTime[det] =
+                    0.5 * (iTraw[det * nPmts][selectRightHit[det]] + iTraw[det * nPmts + 1][selectLeftHit[det]]);
+                iRawPos[det] = (iTraw[det * nPmts][selectRightHit[det]] - iTraw[det * nPmts + 1][selectLeftHit[det]]);
+                iCalPos[det] = fCalPar->GetPosCalGainAtRank(det) * iRawPos[det] + fCalPar->GetPosCalOffsetAtRank(det);
+                AddPosCalData(det + 1, iRawTime[det], iRawPos[det], iCalPos[det]);
+            }
+        }
+        else // use the hit selection from the very first to the very last FrsSci)
+        {
+            for (UShort_t det = 0; det < nDets - 1; det++)
+            {
+                iRawTime[det] =
+                    0.5 * (iTraw[det * nPmts][selectRightHit[det]] + iTraw[det * nPmts + 1][selectLeftHit[det]]);
+                iRawPos[det] = (iTraw[det * nPmts][selectRightHit[det]] - iTraw[det * nPmts + 1][selectLeftHit[det]]);
+                iCalPos[det] = fCalPar->GetPosCalGainAtRank(det) * iRawPos[det] + fCalPar->GetPosCalOffsetAtRank(det);
+                AddPosCalData(det + 1, iRawTime[det], iRawPos[det], iCalPos[det]);
+            }
+            iRawTime[nDets - 1] = 0.5 * (iTraw[(nDets - 1) * nPmts][selectRightHit_dSto[0]] +
+                                         iTraw[(nDets - 1) * nPmts + 1][selectLeftHit_dSto[0]]);
+            iRawPos[nDets - 1] = (iTraw[(nDets - 1) * nPmts][selectLeftHit_dSto[0]] -
+                                  iTraw[(nDets - 1) * nPmts + 1][selectLeftHit_dSto[0]]);
+            iCalPos[nDets - 1] = fCalPar->GetPosCalGainAtRank(nDets - 1) * iRawPos[nDets - 1] +
+                                 fCalPar->GetPosCalOffsetAtRank(nDets - 1);
+            AddPosCalData(nDets, iRawTime[nDets - 1], iRawPos[nDets - 1], iCalPos[nDets - 1]);
+        }
+        UShort_t rank = 0;
+        for (UShort_t dSta = 0; dSta < nDets - 1; dSta++)
+        {
+            for (dSto = dSta + 1; dSto < nDets; dSto++)
+            {
+                iRawTof = iRawTime[dSto] - iRawTime[dSta] + iTraw[dSta * nPmts + 2][0] - iTraw[dSto * nPmts + 2][0];
+
+                // Cal Tof
+                iCalVelo =
+                    1. / (fCalPar->GetTof2InvVOffsetAtRank(rank) + fCalPar->GetTof2InvVGainAtRank(rank) * iRawTof);
+                iCalTof = fCalPar->GetFlightLengthAtRank(rank) / iCalVelo;
+
+                // Beta
+                iBeta = iCalVelo / (Double_t)SPEED_OF_LIGHT_MNS;
+
+                AddTofCalData(rank + 1, dSta + 1, dSto + 1, iCalPos[dSta], iCalPos[dSto], iRawTof, iCalTof, iBeta);
+                rank++;
+            }
+        }
+
+    }    // end if else is (nDets>1)
+    else // nDets==0, should not happen
+    {
+    }
+
+    ++fNevent;
+    return;
+}
+
+// -----   Public method Reset   ------------------------------------------------
+void R3BFrsSciTcal2Cal::Reset()
+{
+    LOG(debug) << "Clearing TcalData Structure";
+    if (fPosCal)
+        fPosCal->Clear();
+    if (fTofCal)
+        fTofCal->Clear();
+}
+
+// -----   Private method AddPosCalData  --------------------------------------------
+R3BFrsSciPosCalData* R3BFrsSciTcal2Cal::AddPosCalData(UShort_t det, Double_t traw, Float_t rawpos, Float_t calpos)
+{
+    // It fills the R3BFrsSciTcalData
+    TClonesArray& clref = *fPosCal;
+    Int_t size = clref.GetEntriesFast();
+    return new (clref[size]) R3BFrsSciPosCalData(det, traw, rawpos, calpos);
+}
+
+// -----   Private method AddTofCalData  --------------------------------------------
+R3BFrsSciTofCalData* R3BFrsSciTcal2Cal::AddTofCalData(UShort_t rank,
+                                                      UShort_t detsta,
+                                                      UShort_t detsto,
+                                                      Float_t calpossta,
+                                                      Float_t calpossto,
+                                                      Double_t rawtof,
+                                                      Double_t caltof,
+                                                      Double_t beta)
+{
+    // It fills the R3BFrsSciTcalData
+    TClonesArray& clref = *fTofCal;
+    Int_t size = clref.GetEntriesFast();
+    return new (clref[size]) R3BFrsSciTofCalData(rank, detsta, detsto, calpossta, calpossto, rawtof, caltof, beta);
+}
+
+ClassImp(R3BFrsSciTcal2Cal);

--- a/frssci/calibration/R3BFrsSciTcal2Cal.h
+++ b/frssci/calibration/R3BFrsSciTcal2Cal.h
@@ -1,0 +1,84 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+// *** *************************************************************** *** //
+// ***                  R3BFrsSciTcal2Cal                              *** //
+// ***    convert tcal data to cal data : PosCal and TofCal            *** //
+// ***     1/ select the proper hit in the multihit tcal data          *** //
+// ***     2/ calculate PosRaw and apply calibration parameters        *** //
+// ***     2/ calculate TofRaw and apply calibration parameters        *** //
+// *** *************************************************************** *** //
+
+#ifndef R3BFRSSCI_TCAL2CAL_H
+#define R3BFRSSCI_TCAL2CAL_H 1
+
+#include "FairTask.h"
+#include "R3BFrsSciCalPar.h"
+#include "R3BFrsSciPosCalData.h"
+#include "R3BFrsSciTcalData.h"
+#include "R3BFrsSciTofCalData.h"
+#include "TClonesArray.h"
+#include "TRandom3.h"
+
+class TRandom3;
+class R3BFrsSciTcalData;
+
+class R3BFrsSciTcal2Cal : public FairTask
+{
+  public:
+    // --- Default constructor --- //
+    R3BFrsSciTcal2Cal();
+
+    // --- Standard constructor --- //
+    R3BFrsSciTcal2Cal(const char* name, Int_t iVerbose = 1);
+
+    // --- Destructor --- //
+    virtual ~R3BFrsSciTcal2Cal();
+
+    virtual void Exec(Option_t* option);
+
+    virtual void SetParContainers();
+
+    virtual InitStatus Init();
+
+    virtual InitStatus ReInit();
+
+    virtual void Reset();
+
+    void SetOnline(Bool_t option) { fOnline = option; }
+
+  private:
+    UInt_t fNevent;
+    TClonesArray* fTcal;      // input data - FrsSci
+    R3BFrsSciCalPar* fCalPar; // cal parameters container - FrsSci
+    TClonesArray* fPosCal;    // output data for position per detector
+    TClonesArray* fTofCal;    // output data for Tof
+    Bool_t fOnline;           // Don't store data for online
+
+    TRandom3 rand;
+
+    R3BFrsSciPosCalData* AddPosCalData(UShort_t det, Double_t traw, Float_t rawpos, Float_t calpos);
+    R3BFrsSciTofCalData* AddTofCalData(UShort_t rank,
+                                       UShort_t detsta,
+                                       UShort_t detsto,
+                                       Float_t calpossta,
+                                       Float_t calpossto,
+                                       Double_t rawtof,
+                                       Double_t caltof,
+                                       Double_t beta);
+
+  public:
+    ClassDef(R3BFrsSciTcal2Cal, 1)
+};
+
+#endif // R3BFRSSCI_TCAL2CAL_H

--- a/frssci/parameters/R3BFrsSciCalPar.cxx
+++ b/frssci/parameters/R3BFrsSciCalPar.cxx
@@ -1,0 +1,276 @@
+#include "R3BFrsSciCalPar.h"
+
+#include "FairDetParIo.h"
+#include "FairLogger.h"
+#include "FairParamList.h"
+#include "TArrayF.h"
+#include "TMath.h"
+#include "TString.h"
+
+#include <iostream>
+
+// ---- Standard Constructor ---------------------------------------------------
+R3BFrsSciCalPar::R3BFrsSciCalPar(const char* name, const char* title, const char* context)
+    : FairParGenericSet(name, title, context)
+    , fNumDets(3)
+    , fNumPmts(3)
+    , fNumTofs(3)
+    , fDetIdS2(1)
+    , fDetIdS8(2)
+    , fDetIdCaveC(3)
+{
+    if (fNumDets > 2)
+    {
+        fMinTofs = new TArrayD(fNumDets - 1);
+        fMaxTofs = new TArrayD(fNumDets - 1);
+        fTof2InvVGains = new TArrayD(fNumTofs);
+        fTof2InvVOffsets = new TArrayD(fNumTofs);
+        fFlightLengths = new TArrayD(fNumTofs);
+    }
+    else
+    {
+        fMinTofs = NULL;
+        fMaxTofs = NULL;
+        fTof2InvVGains = NULL;
+        fTof2InvVOffsets = NULL;
+        fFlightLengths = NULL;
+    }
+    fMinPos = new TArrayF(fNumDets);
+    fMaxPos = new TArrayF(fNumDets);
+    fPosCalGains = new TArrayF(fNumDets);
+    fPosCalOffsets = new TArrayF(fNumDets);
+}
+
+// ----  Destructor ------------------------------------------------------------
+R3BFrsSciCalPar::~R3BFrsSciCalPar()
+{
+    status = kFALSE;
+    resetInputVersions();
+    if (fMinPos != NULL)
+    {
+        delete fMinPos;
+    }
+    if (fMaxPos != NULL)
+    {
+        delete fMaxPos;
+    }
+    if (fMinTofs != NULL)
+    {
+        delete fMinTofs;
+    }
+    if (fMaxTofs != NULL)
+    {
+        delete fMaxTofs;
+    }
+    if (fPosCalGains != NULL)
+    {
+        delete fPosCalGains;
+    }
+    if (fPosCalOffsets != NULL)
+    {
+        delete fPosCalOffsets;
+    }
+    if (fTof2InvVGains != NULL)
+    {
+        delete fTof2InvVGains;
+    }
+    if (fTof2InvVOffsets != NULL)
+    {
+        delete fTof2InvVOffsets;
+    }
+    if (fFlightLengths != NULL)
+    {
+        delete fFlightLengths;
+    }
+}
+
+// ----  Method clear ----------------------------------------------------------
+void R3BFrsSciCalPar::clear()
+{
+    status = kFALSE;
+    resetInputVersions();
+}
+
+// ----  Method putParams ------------------------------------------------------
+void R3BFrsSciCalPar::putParams(FairParamList* list)
+{
+    LOG(info) << "R3BFrsSciCalPar::putParams() called";
+    if (!list)
+    {
+        return;
+    }
+
+    list->add("fNumDets_CalPar", fNumDets);
+    list->add("fNumPmts_CalPar", fNumPmts);
+    list->add("fNumTofs_CalPar", fNumTofs);
+
+    list->add("fDetIdS2_CalPar", fDetIdS2);
+    list->add("fDetIdS8_CalPar", fDetIdS2);
+    list->add("fDetIdCaveC_CalPar", fDetIdCaveC);
+
+    if (fNumDets > 1)
+    {
+        LOG(info) << "R3BFrsSciCalPar::putParams Array Size for fMinTofs and fMaxTofs: " << fNumDets - 1;
+        fMinTofs->Set(fNumDets - 1);
+        list->add("fMinTofs_CalPar", *fMinTofs);
+        fMaxTofs->Set(fNumDets - 1);
+        list->add("fMaxTofs_CalPar", *fMaxTofs);
+
+        LOG(info) << "R3BFrsSciCalPar::putParams Array Size for Tof calibration: " << fNumTofs;
+        fTof2InvVGains->Set(fNumTofs - 1);
+        list->add("fTof2InvVGains_CalPar", *fTof2InvVGains);
+        fTof2InvVOffsets->Set(fNumTofs - 1);
+        list->add("fTof2InvVOffsets_CalPar", *fTof2InvVOffsets);
+        fFlightLengths->Set(fNumTofs - 1);
+        list->add("fFlightLengths_CalPar", *fFlightLengths);
+    }
+
+    LOG(info) << "R3BFrsSciCalPar::putParams Array Size for PosCal gains and offsets: " << fNumDets;
+    fMinPos->Set(fNumDets);
+    list->add("fMinPos_CalPar", *fMinPos);
+    fMaxPos->Set(fNumDets);
+    list->add("fMaxPos_CalPar", *fMaxPos);
+    fPosCalGains->Set(fNumDets);
+    list->add("fPosCalGains_CalPar", *fPosCalGains);
+    fPosCalOffsets->Set(fNumDets);
+    list->add("fPosCalOffsets_CalPar", *fPosCalOffsets);
+}
+
+// ----  Method getParams ------------------------------------------------------
+Bool_t R3BFrsSciCalPar::getParams(FairParamList* list)
+{
+    LOG(info) << "R3BFrsSciCalPar::getParams() called";
+
+    if (!list)
+    {
+        LOG(error) << "Could not initialize FairParamList";
+        return kFALSE;
+    }
+    if (!list->fill("fNumDets_CalPar", &fNumDets))
+    {
+        LOG(error) << "Could not initialize fNumDets_CalPar";
+        return kFALSE;
+    }
+    if (!list->fill("fNumPmts_CalPar", &fNumPmts))
+    {
+        LOG(error) << "Could not initialize fNumPmts_CalPar";
+        return kFALSE;
+    }
+    if (!list->fill("fNumTofs_CalPar", &fNumTofs))
+    {
+        LOG(error) << "Could not initialize fNumTofs_CalPar";
+        return kFALSE;
+    }
+
+    if (!list->fill("fDetIdS2_CalPar", &fDetIdS2))
+    {
+        LOG(error) << "Could not initialize fDetIdS2_CalPar";
+        return kFALSE;
+    }
+    if (!list->fill("fDetIdS8_CalPar", &fDetIdS2))
+    {
+        LOG(error) << "Could not initialize fDetIdS8_CalPar";
+        return kFALSE;
+    }
+    if (!list->fill("fDetIdCaveC_CalPar", &fDetIdCaveC))
+    {
+        LOG(error) << "Could not initialize fDetIdCaveC_CalPar";
+        return kFALSE;
+    }
+
+    if (fNumDets > 1)
+    {
+
+        LOG(info) << "R3BFrsSciCalPar::getParams Array Size for fMinTofs and fMaxTofs: " << fNumDets - 1;
+        fMinTofs->Set(fNumDets - 1);
+        if (!(list->fill("fMinTofs_CalPar", fMinTofs)))
+        {
+            LOG(error) << "---R3BFrsSciCalPar::getParams Could not initialize fMinTofs";
+            return kFALSE;
+        }
+        fMaxTofs->Set(fNumDets - 1);
+        if (!(list->fill("fMaxTofs_CalPar", fMaxTofs)))
+        {
+            LOG(error) << "---R3BFrsSciCalPar::getParams Could not initialize fMaxTofs";
+            return kFALSE;
+        }
+
+        LOG(info) << "R3BFrsSciCalPar::getParams Array Size for Tof calibration: " << fNumTofs;
+        fTof2InvVGains->Set(fNumTofs - 1);
+        if (!(list->fill("fTof2InvVGains_CalPar", fTof2InvVGains)))
+        {
+            LOG(error) << "---R3BFrsSciCalPar::getParams Could not initialize fTof2InvVGains";
+            return kFALSE;
+        }
+        fTof2InvVOffsets->Set(fNumTofs - 1);
+        if (!(list->fill("fTof2InvVOffsets_CalPar", fTof2InvVOffsets)))
+        {
+            LOG(error) << "---R3BFrsSciCalPar::getParams Could not initialize fTof2InvVOffsets";
+            return kFALSE;
+        }
+        fFlightLengths->Set(fNumTofs - 1);
+        if (!(list->fill("fFlightLengths_CalPar", fFlightLengths)))
+        {
+            LOG(error) << "---R3BFrsSciCalPar::getParams Could not initialize fFlightLengths";
+            return kFALSE;
+        }
+    }
+
+    LOG(info) << "R3BFrsSciCalPar::getParams Array Size for Pos limits and PosCal gains and offsets: " << fNumDets;
+    fMinPos->Set(fNumDets);
+    if (!(list->fill("fMinPos_CalPar", fMinPos)))
+    {
+        LOG(error) << "---R3BFrsSciCalPar::getParams Could not initialize fMinPos";
+        return kFALSE;
+    }
+    fMaxPos->Set(fNumDets);
+    if (!(list->fill("fMaxPos_CalPar", fMaxPos)))
+    {
+        LOG(error) << "---R3BFrsSciCalPar::getParams Could not initialize fMaxPos";
+        return kFALSE;
+    }
+    fPosCalGains->Set(fNumDets);
+    if (!(list->fill("fPosCalGains_CalPar", fPosCalGains)))
+    {
+        LOG(error) << "---R3BFrsSciCalPar::getParams Could not initialize fPosCalGains";
+        return kFALSE;
+    }
+    fPosCalOffsets->Set(fNumDets);
+    if (!(list->fill("fPosCalOffsets_CalPar", fPosCalOffsets)))
+    {
+        LOG(error) << "---R3BFrsSciCalPar::getParams Could not initialize fPosCalOffsets";
+        return kFALSE;
+    }
+
+    return kTRUE;
+}
+
+// ----  Method printParams ----------------------------------------------------
+void R3BFrsSciCalPar::printParams()
+{
+    LOG(info) << "R3BFrsSciCalPar: FrsSciCal Parameters: ";
+    LOG(info) << "--- --------------------------------------------";
+    LOG(info) << "--- fNumDets = " << fNumDets;
+    LOG(info) << "--- fNumPmts = " << fNumPmts;
+    LOG(info) << "--- fNumTofs = " << fNumTofs;
+    LOG(info) << "--- --------------------------------------------";
+    LOG(info) << "--- fDetIdS2    = " << fDetIdS2;
+    LOG(info) << "--- fDetIdS8    = " << fDetIdS8;
+    LOG(info) << "--- fDetIdCaveC = " << fDetIdCaveC;
+    LOG(info) << "--- --------------------------------------------";
+    for (UShort_t d = 0; d < fNumDets; d++)
+    {
+        LOG(info) << " for Det " << d + 1 << ", fMinPos = " << fMinPos->GetAt(d) << ", fMaxPos = " << fMaxPos->GetAt(d);
+    }
+    LOG(info) << "--- --------------------------------------------";
+    if (fNumDets > 1)
+    {
+        for (UShort_t d = 0; d < fNumDets - 2; d++)
+        {
+            LOG(info) << "Tof ( FrsSciDet" << d + 1 << "->FrsSciDet" << d + 2 << ") : fMinTofs = " << fMinTofs->GetAt(d)
+                      << ", :fMaxTofs=" << fMaxTofs->GetAt(d);
+        }
+    }
+}
+
+ClassImp(R3BFrsSciCalPar);

--- a/frssci/parameters/R3BFrsSciCalPar.h
+++ b/frssci/parameters/R3BFrsSciCalPar.h
@@ -1,0 +1,153 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#ifndef R3BFRSSCICALPAR_H
+#define R3BFRSSCICALPAR_H
+
+#include "FairParGenericSet.h"
+#include "TArrayD.h"
+#include "TArrayF.h"
+#include "TObjArray.h"
+#include "TObject.h"
+
+#include <TObjString.h>
+
+class FairParamList;
+
+class R3BFrsSciCalPar : public FairParGenericSet
+{
+
+  public:
+    /** Standard constructor **/
+    R3BFrsSciCalPar(const char* name = "FrsSciCalPar",
+                    const char* title = "FrsSciCal Parameters",
+                    const char* context = "FrsSciCalParContext");
+
+    /** Destructor **/
+    virtual ~R3BFrsSciCalPar();
+
+    /** Method to reset all parameters **/
+    virtual void clear();
+
+    /** Method to store all parameters using FairRuntimeDB **/
+    virtual void putParams(FairParamList* list);
+
+    /** Method to retrieve all parameters using FairRuntimeDB**/
+    Bool_t getParams(FairParamList* list);
+
+    /** Method to print values of parameters to the standard output **/
+    void printParams();
+
+    /** Accessor functions **/
+
+    void SetNumDets(Int_t nDets) { fNumDets = nDets; }
+    void SetNumPmts(Int_t nPmts) { fNumPmts = nPmts; }
+    void SetNumTofs(Int_t nDets)
+    {
+        switch (nDets)
+        {
+            case 1:
+                fNumTofs = 0;
+                break;
+            case 2:
+                fNumTofs = 1;
+                break;
+            default:
+                UShort_t fact1 = 1;
+                UShort_t fact2 = 1;
+                for (Int_t i = 2; i <= nDets; i++)
+                    fact1 *= i;
+                for (Int_t i = 2; i <= (nDets - 2); i++)
+                    fact2 *= i;
+                fNumTofs = fact1 / (2 * fact2);
+        }
+    }
+
+    void SetDetIdS2(Int_t id) { fDetIdS2 = id; }
+    void SetDetIdS8(Int_t id) { fDetIdS8 = id; }
+    void SetDetIdCaveC(Int_t id) { fDetIdCaveC = id; }
+
+    void SetMinPos(Float_t min, UInt_t rank) { fMinPos->AddAt(min, rank); }
+    void SetMaxPos(Float_t max, UInt_t rank) { fMaxPos->AddAt(max, rank); }
+    void SetMinTof(Double_t min, UInt_t rank) { fMinTofs->AddAt(min, rank); }
+    void SetMaxTof(Double_t max, UInt_t rank) { fMaxTofs->AddAt(max, rank); }
+
+    void SetTof2InvVGain(Double_t gain, UInt_t rank) { fTof2InvVGains->AddAt(gain, rank); }
+    void SetTof2InvVOffset(Double_t offset, UInt_t rank) { fTof2InvVOffsets->AddAt(offset, rank); }
+    void SetFlightLength(Double_t L, UInt_t rank) { fFlightLengths->AddAt(L, rank); }
+    void SetPosCalGain(Float_t gain, UInt_t rank) { fPosCalGains->AddAt(gain, rank); }
+    void SetPosCalOffset(Float_t offset, UInt_t rank) { fPosCalOffsets->AddAt(offset, rank); }
+
+    const Int_t GetNumDets() { return fNumDets; }
+    const Int_t GetNumPmts() { return fNumPmts; }
+    const Int_t GetNumTofs() { return fNumTofs; }
+
+    const Int_t GetDetIdS2() { return fDetIdS2; }
+    const Int_t GetDetIdS8() { return fDetIdS8; }
+    const Int_t GetDetIdCaveC() { return fDetIdCaveC; }
+
+    const Float_t GetMinPosAtRank(UInt_t rank) { return fMinPos->At(rank); }
+    const Float_t GetMaxPosAtRank(UInt_t rank) { return fMaxPos->At(rank); }
+    const Double_t GetMinTofAtRank(UInt_t rank) { return fMinTofs->At(rank); }
+    const Double_t GetMaxTofAtRank(UInt_t rank) { return fMaxTofs->At(rank); }
+    TArrayF* GetAllParams_fMinPos() { return fMinPos; }
+    TArrayF* GetAllParams_fMaxPos() { return fMaxPos; }
+    TArrayD* GetAllParams_fMinTofs() { return fMinTofs; }
+    TArrayD* GetAllParams_fMaxTofs() { return fMaxTofs; }
+
+    const Double_t GetTof2InvVGainAtRank(UInt_t rank) { return fTof2InvVGains->At(rank); }
+    const Double_t GetTof2InvVOffsetAtRank(UInt_t rank) { return fTof2InvVOffsets->At(rank); }
+    const Double_t GetFlightLengthAtRank(UInt_t rank) { return fFlightLengths->At(rank); }
+    const Float_t GetPosCalGainAtRank(UInt_t rank) { return fPosCalGains->At(rank); }
+    const Float_t GetPosCalOffsetAtRank(UInt_t rank) { return fPosCalOffsets->At(rank); }
+    TArrayD* GetAllParams_fTof2InvVGains() { return fTof2InvVGains; }
+    TArrayD* GetAllParams_fTof2InvVOffsets() { return fTof2InvVOffsets; }
+    TArrayD* GetAllParams_fFlightLengths() { return fFlightLengths; }
+    TArrayF* GetAllParams_fPosCalGains() { return fPosCalGains; }
+    TArrayF* GetAllParams_fPosCalOffsets() { return fPosCalOffsets; }
+
+  private:
+    // parameters for dimension
+    Int_t fNumDets; // number of FrsSci detectors
+    Int_t fNumPmts; // number of "Pmts" (by default = 3: 2 Pmts and one Tref)
+    Int_t fNumTofs; // number of ToFs (fNumDets! / (2! * (fNumDets-2)!))
+
+    // parameters to identify the different FrsSci
+    Int_t fDetIdS2;
+    Int_t fDetIdS8;
+    Int_t fDetIdCaveC;
+
+    // parameters to select the proper hit per signal if fNumDets=1
+    TArrayF* fMinPos;
+    TArrayF* fMaxPos;
+
+    // parameters to select the proper hit per signal if fNumDets>1
+    TArrayD* fMinTofs; // size = fNumDets-1 (Cave C versus all the others)
+    TArrayD* fMaxTofs; // size = fNumDets-1 (Cave C versus all the others)
+
+    // parameters to calibrate all Tofs
+    TArrayD* fTof2InvVGains;   // number of Tofs
+    TArrayD* fTof2InvVOffsets; // number of Tofs
+    TArrayD* fFlightLengths;   // number of Tof
+
+    // parameters to calibrate the position in Mm
+    TArrayF* fPosCalGains;   // 1 gain per per detector
+    TArrayF* fPosCalOffsets; // 1 offset per per detector
+
+    const R3BFrsSciCalPar& operator=(const R3BFrsSciCalPar&);
+    R3BFrsSciCalPar(const R3BFrsSciCalPar&);
+
+    ClassDef(R3BFrsSciCalPar, 1);
+};
+
+#endif // R3BFRSSCICALPAR_H

--- a/frssci/parameters/R3BFrsSciContFact.cxx
+++ b/frssci/parameters/R3BFrsSciContFact.cxx
@@ -1,4 +1,5 @@
 #include "R3BFrsSciContFact.h"
+#include "R3BFrsSciCalPar.h"
 #include "R3BFrsSciTcalPar.h"
 
 #include "FairLogger.h"
@@ -28,6 +29,13 @@ void R3BFrsSciContFact::setAllContainers()
         "FrsSciTcalPar", "FrsSci Tcal parameters for VFTX time calibration in ns", "FrsSciTcalParContext");
     p1->addContext("FrsSciTcalParContext");
     containers->Add(p1);
+
+    FairContainer* p2 =
+        new FairContainer("FrsSciCalPar",
+                          "FrsSci Cal parameters: multi hit to single hit + params for position and Tofs",
+                          "FrsSciCalParContext");
+    p2->addContext("FrsSciCalParContext");
+    containers->Add(p2);
 }
 
 FairParSet* R3BFrsSciContFact::createContainer(FairContainer* c)
@@ -42,6 +50,11 @@ FairParSet* R3BFrsSciContFact::createContainer(FairContainer* c)
     if (strcmp(name, "FrsSciTcalPar") == 0)
     {
         p = new R3BFrsSciTcalPar(c->getConcatName().Data(), c->GetTitle(), c->getContext());
+    }
+    return p;
+    if (strcmp(name, "FrsSciCalPar") == 0)
+    {
+        p = new R3BFrsSciCalPar(c->getConcatName().Data(), c->GetTitle(), c->getContext());
     }
     return p;
 }

--- a/r3bdata/CMakeLists.txt
+++ b/r3bdata/CMakeLists.txt
@@ -135,6 +135,8 @@ roluData/R3BRoluCalData.cxx
 roluData/R3BRoluHitData.cxx
 frssciData/R3BFrsSciMappedData.cxx
 frssciData/R3BFrsSciTcalData.cxx
+frssciData/R3BFrsSciPosCalData.cxx
+frssciData/R3BFrsSciTofCalData.cxx
 sci2Data/R3BSci2MappedData.cxx
 sci2Data/R3BSci2TcalData.cxx
 sci2Data/R3BSci2CalData.cxx

--- a/r3bdata/DataLinkDef.h
+++ b/r3bdata/DataLinkDef.h
@@ -132,6 +132,8 @@
 #pragma link C++ class R3BRoluHitData+;
 #pragma link C++ class R3BFrsSciMappedData+;
 #pragma link C++ class R3BFrsSciTcalData+;
+#pragma link C++ class R3BFrsSciPosCalData+;
+#pragma link C++ class R3BFrsSciTofCalData+;
 #pragma link C++ class R3BSci2MappedData+;
 #pragma link C++ class R3BSci2TcalData+;
 #pragma link C++ class R3BSci2CalData+;

--- a/r3bdata/frssciData/R3BFrsSciPosCalData.cxx
+++ b/r3bdata/frssciData/R3BFrsSciPosCalData.cxx
@@ -1,0 +1,18 @@
+#include "R3BFrsSciPosCalData.h"
+
+R3BFrsSciPosCalData::R3BFrsSciPosCalData()
+    : fDetector(0)
+    , fRawTimeNs(0)
+    , fRawPosNs(0)
+    , fCalPosMm(0)
+{
+}
+
+R3BFrsSciPosCalData::R3BFrsSciPosCalData(UShort_t det, Double_t rawT, Float_t rawPos, Float_t calPos)
+    : fDetector(det)
+    , fRawTimeNs(rawT)
+    , fRawPosNs(rawPos)
+    , fCalPosMm(calPos)
+{
+}
+ClassImp(R3BFrsSciPosCalData)

--- a/r3bdata/frssciData/R3BFrsSciPosCalData.h
+++ b/r3bdata/frssciData/R3BFrsSciPosCalData.h
@@ -1,0 +1,34 @@
+#ifndef R3BFRSSCIPOSCALITEM_H
+#define R3BFRSSCIPOSCALITEM_H
+
+#include "TObject.h"
+
+class R3BFrsSciPosCalData : public TObject
+{
+  public:
+    // Default Constructor
+    R3BFrsSciPosCalData();
+
+    // Standard Constructor
+    R3BFrsSciPosCalData(UShort_t, Double_t, Float_t, Float_t);
+
+    // Destructor
+    virtual ~R3BFrsSciPosCalData() {}
+
+    // Getters
+    inline const UShort_t& GetDetector() const { return fDetector; }
+    inline const Double_t& GetRawTimeNs() const { return fRawTimeNs; }
+    inline const Float_t& GetRawPosNs() const { return fRawPosNs; }
+    inline const Float_t& GetCalPosMm() const { return fCalPosMm; }
+
+  private:
+    UShort_t fDetector;
+    Double_t fRawTimeNs; // 0.5 * (Tright + Tleft) after selection of the multiplicity
+    Float_t fRawPosNs;   // Tright - Tleft: x increasing for right to left
+    Float_t fCalPosMm;   // calibrated position in Mm
+
+  public:
+    ClassDef(R3BFrsSciPosCalData, 2)
+};
+
+#endif

--- a/r3bdata/frssciData/R3BFrsSciTofCalData.cxx
+++ b/r3bdata/frssciData/R3BFrsSciTofCalData.cxx
@@ -1,0 +1,33 @@
+#include "R3BFrsSciTofCalData.h"
+
+R3BFrsSciTofCalData::R3BFrsSciTofCalData()
+    : fRank(1)
+    , fDetIdSta(1)
+    , fDetIdSto(2)
+    , fCalPosStaMm(-1000)
+    , fCalPosStoMm(-1000)
+    , fRawTofNs(0)
+    , fCalTofNs(0)
+    , fBeta(0)
+{
+}
+
+R3BFrsSciTofCalData::R3BFrsSciTofCalData(UShort_t rank,
+                                         UShort_t detIdSta,
+                                         UShort_t detIdSto,
+                                         Float_t calPosSta,
+                                         Float_t calPosSto,
+                                         Double_t rawTof,
+                                         Double_t calTof,
+                                         Double_t beta)
+    : fRank(rank)
+    , fDetIdSta(detIdSta)
+    , fDetIdSto(detIdSto)
+    , fCalPosStaMm(calPosSta)
+    , fCalPosStoMm(calPosSto)
+    , fRawTofNs(rawTof)
+    , fCalTofNs(calTof)
+    , fBeta(beta)
+{
+}
+ClassImp(R3BFrsSciTofCalData)

--- a/r3bdata/frssciData/R3BFrsSciTofCalData.h
+++ b/r3bdata/frssciData/R3BFrsSciTofCalData.h
@@ -1,0 +1,41 @@
+#ifndef R3BFRSSCICALITEM_H
+#define R3BFRSSCICALITEM_H
+
+#include "TObject.h"
+
+class R3BFrsSciTofCalData : public TObject
+{
+  public:
+    // Default Constructor
+    R3BFrsSciTofCalData();
+
+    // Standard Constructor
+    R3BFrsSciTofCalData(UShort_t, UShort_t, UShort_t, Float_t, Float_t, Double_t, Double_t, Double_t);
+
+    // Destructor
+    virtual ~R3BFrsSciTofCalData() {}
+
+    // Getters
+    inline const UShort_t& GetDetIdSta() const { return fDetIdSta; }
+    inline const UShort_t& GetDetIdSto() const { return fDetIdSto; }
+    inline const Float_t& GetCalPosStaMm() const { return fCalPosStaMm; }
+    inline const Float_t& GetCalPosStoMm() const { return fCalPosStoMm; }
+    inline const Double_t& GetRawTofNs() const { return fRawTofNs; }
+    inline const Double_t& GetCalTofNs() const { return fCalTofNs; }
+    inline const Double_t& GetBeta() const { return fBeta; }
+
+  private:
+    UShort_t fRank;
+    UShort_t fDetIdSta;
+    UShort_t fDetIdSto;
+    Float_t fCalPosStaMm;
+    Float_t fCalPosStoMm;
+    Double_t fRawTofNs;
+    Double_t fCalTofNs;
+    Double_t fBeta;
+
+  public:
+    ClassDef(R3BFrsSciTofCalData, 2)
+};
+
+#endif


### PR DESCRIPTION
on-going prepare FrsSciCalPar for all calibrations (hit select, pos, tof)

R3BFrsSciCalPar class

update CMakeLists and LinkDef

declare R3BFrsScoTcal2Cal class

on-going detail the task Tcal 2 Cal

complete Tcal2Cal to select hit if nDets=1

on-going: select hit, calibrate pos and tof for nDets>1

on-going R3BFrsSciTcal2Cal

task Tcal to PosCal and TofCal for FrsSci

Describe your proposal.

Mention any issue this PR is resolved or is related to.

---

Checklist:

* [X] Rebased against `202402_fast` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [ ] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
