### PR TITLE
R3BTttxCal2Hit and others

### DIFF
--- a/r3bdata/tttxData/R3BTttxCalData.cxx
+++ b/r3bdata/tttxData/R3BTttxCalData.cxx
@@ -28,11 +28,27 @@ R3BTttxCalData::R3BTttxCalData(uint8_t DetID, uint8_t StripID, double time, doub
 
 std::string R3BTttxCalData::toString() const
 {
-    return fmt::format(
-        "DetID: {}, StripID: {}, Time: {}, Energy: {}", GetDetID(), GetStripID(), GetTime(), GetEnergy());
+    return fmt::format("DetID: {}, StripID: {}, Time: {:.2f} ns, Energy: {:.2f} keV",
+                       GetDetID(),
+                       GetStripID(),
+                       GetTime(),
+                       GetEnergy());
 }
 
 void R3BTttxCalData::Print(const Option_t*) const { std::cout << *this << std::endl; }
+
+// Sort in energy with descending order
+Int_t R3BTttxCalData::Compare(const TObject* obj) const
+{
+    const R3BTttxCalData* other = dynamic_cast<const R3BTttxCalData*>(obj);
+    if (!other)
+        return 0;
+    if (fEnergy > other->GetEnergy())
+        return -1;
+    if (fEnergy < other->GetEnergy())
+        return 1;
+    return 0;
+}
 
 std::ostream& operator<<(std::ostream& os, const R3BTttxCalData& data)
 {

--- a/r3bdata/tttxData/R3BTttxCalData.h
+++ b/r3bdata/tttxData/R3BTttxCalData.h
@@ -52,6 +52,10 @@ class R3BTttxCalData : public TObject
     [[nodiscard]] std::string toString() const;
     void Print(const Option_t*) const override;
 
+    // Sorting with Energy (high to low) within TClonesArray
+    Int_t Compare(const TObject* obj) const override;
+    Bool_t IsSortable() const override { return true; }
+
   protected:
     uint8_t fDetID = 0;
     uint8_t fStripID = 0;

--- a/r3bdata/tttxData/R3BTttxHitData.cxx
+++ b/r3bdata/tttxData/R3BTttxHitData.cxx
@@ -18,8 +18,9 @@
 #include "R3BTttxHitData.h"
 #include <fmt/core.h>
 
-R3BTttxHitData::R3BTttxHitData(double xpos, double energy, double angle, double charge, double time)
-    : fXpos(xpos)
+R3BTttxHitData::R3BTttxHitData(int8_t idet, double xpos, double energy, double angle, double charge, double time)
+    : fDetID(idet)
+    , fXpos(xpos)
     , fEnergy(energy)
     , fAng(angle)
     , fCharge(charge)
@@ -29,12 +30,14 @@ R3BTttxHitData::R3BTttxHitData(double xpos, double energy, double angle, double 
 
 std::string R3BTttxHitData::toString() const
 {
-    return fmt::format("Xpos(mm): {:.2f}, Energy: {:.2f}, Angle: {:.3f}, ChargeZ: {:.2f}, Time: {}",
-                       GetX(),
-                       GetEnergy(),
-                       GetAngle(),
-                       GetChargeZ(),
-                       GetTime());
+    return fmt::format(
+        "Detector: {}, Xpos: {:.2f} mm, Energy: {:.2f} keV, Angle: {:.3f}, ChargeZ: {:.1f}, Time: {:.2f} ns",
+        GetDetID(),
+        GetX(),
+        GetEnergy(),
+        GetAngle(),
+        GetChargeZ(),
+        GetTime());
 }
 
 void R3BTttxHitData::Print(const Option_t*) const { std::cout << *this << std::endl; }

--- a/r3bdata/tttxData/R3BTttxHitData.h
+++ b/r3bdata/tttxData/R3BTttxHitData.h
@@ -31,12 +31,13 @@ class R3BTttxHitData : public TObject
     R3BTttxHitData() = default;
 
     // Constructor with arguments (explicit)
-    explicit R3BTttxHitData(double xpos, double energy, double ang, double charge, double time = 0);
+    explicit R3BTttxHitData(int8_t idet, double xpos, double energy, double ang, double charge, double time = 0);
 
     // Destructor virtual
     virtual ~R3BTttxHitData() = default;
 
     // Accessors with [[nodiscard]]
+    [[nodiscard]] inline const int8_t& GetDetID() const { return fDetID; }
     [[nodiscard]] inline const double& GetX() const { return fXpos; }
     [[nodiscard]] inline const double& GetEnergy() const { return fEnergy; }
     [[nodiscard]] inline const double& GetAngle() const { return fAng; }
@@ -44,6 +45,7 @@ class R3BTttxHitData : public TObject
     [[nodiscard]] inline const double& GetTime() const { return fTime; }
 
     // Modifiers
+    inline void SetDetID(int8_t idet) { fDetID = idet; }
     inline void SetXpos(double xpos) { fXpos = xpos; }
     inline void SetEnergy(double energy) { fEnergy = energy; }
     inline void SetAngle(double angle) { fAng = angle; }
@@ -55,6 +57,7 @@ class R3BTttxHitData : public TObject
     void Print(const Option_t*) const override;
 
   protected:
+    int8_t fDetID = -1; // 0: Reconstructed with all detectors, 1-: ID
     double fXpos = std::nan("");
     double fEnergy = std::nan("");
     double fAng = std::nan("");

--- a/tttx/calibration/R3BTttxCal2Hit.cxx
+++ b/tttx/calibration/R3BTttxCal2Hit.cxx
@@ -50,9 +50,24 @@ R3BTttxCal2Hit::R3BTttxCal2Hit(const TString& name, int iVerbose)
 // Virtual R3BTttxCal2Hit: Destructor
 R3BTttxCal2Hit::~R3BTttxCal2Hit()
 {
+    Reset();
     if (fTttxHitData)
         delete fTttxHitData;
 }
+
+// Constructor and destructor for HitDetector
+R3BTttxCal2Hit::HitDetector::HitDetector(R3BTttxCalData* hit)
+    : fX(StripID2X(hit->GetStripID()))
+    , fE(static_cast<double>(hit->GetEnergy()))
+    , fE2(static_cast<double>(hit->GetEnergy() * hit->GetEnergy()))
+    , fT(static_cast<double>(hit->GetTime()))
+    , fDetID(hit->GetDetID())
+    , fTrefIncluded(false)
+{
+    R3BLOG(debug, "A hit constructed.");
+}
+
+R3BTttxCal2Hit::HitDetector::~HitDetector() { R3BLOG(debug, "Destructor is called."); }
 
 void R3BTttxCal2Hit::SetParContainers()
 {
@@ -74,9 +89,18 @@ void R3BTttxCal2Hit::SetParContainers()
 void R3BTttxCal2Hit::SetParameter()
 {
     //--- Parameter Container ---
-    NumDets = fHit_Par->GetNumDets(); // Number of Detectors
+    NumDets = fHit_Par->GetNumDets();     // Number of Detectors
+    NumPars = fHit_Par->GetNumParsZfit(); // Number of Parameters per each detector
+    R3BLOG(info, "Nb detectors: " << NumDets << ", Nb of Parameters per det: " << NumPars);
 
-    R3BLOG(info, "Nb detectors: " << NumDets);
+    HitParams = new TArrayF();
+    HitParams->Set(NumDets * NumPars);
+    HitParams = const_cast<TArrayF*>(fHit_Par->GetZfitParams());
+
+    vHitsDet.clear();
+    vHitsDet.resize(NumDets);
+
+    ResetVHitsDetector();
 }
 
 // -----   Public method Init   --------------------------------------------
@@ -99,12 +123,50 @@ InitStatus R3BTttxCal2Hit::Init()
     return kSUCCESS;
 }
 
+void R3BTttxCal2Hit::HitsDetector::Init()
+{
+    for (auto& fhit : fHits)
+    {
+        if (fhit)
+            delete fhit;
+    }
+    fHits.clear();
+    fDetID = 0;
+}
+
+void R3BTttxCal2Hit::InitVHitsDetector()
+{
+    for (auto& fhitdet : vHitsDet)
+    {
+        fhitdet->Init();
+    }
+}
+
 // -----   Public method ReInit   ----------------------------------------------
 InitStatus R3BTttxCal2Hit::ReInit()
 {
     SetParContainers();
     SetParameter();
     return kSUCCESS;
+}
+
+// -----   Public method Reset   ------------------------------------------------
+void R3BTttxCal2Hit::Reset()
+{
+    R3BLOG(debug, "Clearing tttxHitData structure");
+    if (fTttxHitData)
+        fTttxHitData->Clear();
+    InitVHitsDetector();
+    vUsed.clear();
+}
+
+void R3BTttxCal2Hit::ResetVHitsDetector()
+{
+    for (auto& fhits : vHitsDet)
+    {
+        fhits = new HitsDetector();
+    }
+    InitVHitsDetector();
 }
 
 // -----   Public method Execution   --------------------------------------------
@@ -120,30 +182,213 @@ void R3BTttxCal2Hit::Exec(Option_t* /*option*/)
 
     // Reading the Input -- Cal Data --
     auto nHits = fTttxCalData->GetEntriesFast();
+    R3BLOG(debug, "Number of Cal Data = " << nHits);
     if (!nHits)
         return;
+    vUsed.resize(nHits, false);
 
-    // Your code
-    // AddHitData(double xpos, double energy, double ang, double charge, double time)
+    // Sort with energy in descending order
+    fTttxCalData->Sort();
 
+    // Clustering the hits
+    for (int ihit = 0; ihit < nHits; ihit++)
+    {
+        auto* fhit = dynamic_cast<R3BTttxCalData*>(fTttxCalData->At(ihit));
+        R3BLOG(debug, "Parent hit of the cluster: " << *fhit); // toString() is formatted for TttxCalData
+        auto idet = fhit->GetDetID() - 1;
+        vHitsDet.at(idet)->NewCluster(fhit);
+        vUsed.at(ihit) = true;
+        for (int jhit = ihit + 1; jhit < nHits; jhit++)
+        {
+            if (vUsed.at(jhit))
+                continue;
+            auto* ghit = dynamic_cast<R3BTttxCalData*>(fTttxCalData->At(jhit));
+            if ((idet != ghit->GetDetID() - 1) || !IsInWindow(fhit, ghit))
+                continue;
+            R3BLOG(debug, "Child hit: " << *ghit);
+            vHitsDet.at(idet)->AddHitToLast(ghit);
+            vUsed.at(jhit) = true;
+        }
+    }
+
+    // Merge hits of detectors
+    // Calculate product of multiplicities
+    int product_mult = 1;
+    for (auto& fDet : vHitsDet)
+    {
+        product_mult *= fDet->GetMult();
+    }
+
+    // Following code assumes the number of detectors is up to two
+    if (fStoreOnlyTwoDetHitEvent && product_mult == 0)
+    {
+        return;
+    }
+
+    if (product_mult == 0 || NumDets < 2)
+    { // If at least one detector has 0 multiplicity, then use the available detector
+        for (auto& fDet : vHitsDet)
+        {
+            if (fDet->GetMult() == 0)
+                continue;
+            for (int imult = 0; imult < fDet->GetMult(); imult++)
+            {
+                if (fRequireTref && !fDet->GetHit(imult)->IsTrefIn())
+                {
+                    continue;
+                }
+                AddHitData(fDet->GetHit(imult));
+            }
+        }
+        //    }else if(product_mult == 1){
+    }
+    else
+    {
+        auto* fDet1 = vHitsDet.at(0);
+        auto* fDet2 = vHitsDet.at(1);
+        for (int imult1 = 0; imult1 < fDet1->GetMult(); imult1++)
+        {
+            if (fRequireTref && !fDet1->GetHit(imult1)->IsTrefIn())
+            {
+                continue;
+            }
+            for (int imult2 = 0; imult2 < fDet2->GetMult(); imult2++)
+            {
+                if (fRequireTref && !fDet2->GetHit(imult2)->IsTrefIn())
+                {
+                    continue;
+                }
+                if (TMath::Abs(fDet1->GetHit(imult1)->GetT() - fDet2->GetHit(imult2)->GetT()) > ftimewindow)
+                {
+                    continue;
+                }
+                // Maybe better to discard the used hits in the later analysis. Here, just filling HitData for any
+                // combinations which satisfy the time window.
+                AddHitData(fDet1->GetHit(imult1), fDet2->GetHit(imult2));
+            }
+        }
+    }
+    // For later update
+    // RecalculateZ();
     return;
 }
 
-// -----   Public method Reset   ------------------------------------------------
-void R3BTttxCal2Hit::Reset()
+// -----   Miscellaneous public/private methods  --------------------------------------------
+/*
+void R3BTttxCal2Hit::RecalculateZ(double fbeta)
+{ // Reconstruct Z based on the updated velocity.
+    if (fbeta <= 0)
+        fbeta = ffixedbeta;
+    R3BLOG(warning, "Nothing will occur with the current code.");
+    //
+    // To be filled later
+    //
+    return;
+}
+*/
+// Compare two hits whether they are within the windows
+bool R3BTttxCal2Hit::IsInWindow(R3BTttxCalData* hit1, R3BTttxCalData* hit2)
 {
-    R3BLOG(debug, "Clearing tttxHitData structure");
-    if (fTttxHitData)
-        fTttxHitData->Clear();
+    // Geometrical (Strip) Window
+    // Include tref (E=0) anyway if it satisfys the criteria
+    if ((hit2->GetStripID() < NStrips) && (TMath::Abs(hit1->GetStripID() - hit2->GetStripID()) > fneighbours))
+        return false;
+    // Time Window
+    if (TMath::Abs(hit1->GetTime() - hit2->GetTime()) > ftimewindow)
+        return false;
+    return true;
+}
+
+double R3BTttxCal2Hit::CalculateZ(R3BTttxCal2Hit::HitDetector* hit, double fbeta)
+{
+    if (fbeta <= 0)
+        fbeta = ffixedbeta;
+    auto Zet = 0.;
+    auto SqEBeta = sqrt(hit->GetE()) * fbeta;
+    for (int ipar = 0; ipar < NumPars; ipar++)
+    {
+        Zet += HitParams->GetAt((hit->GetDetID() - 1) * NumPars + ipar) * TMath::Power(SqEBeta, ipar);
+    }
+    return Zet;
+}
+
+void R3BTttxCal2Hit::HitDetector::AddHit(R3BTttxCalData* hit)
+{
+    if (hit->GetStripID() >= NStrips)
+    {
+        fTrefIncluded = true;
+        return;
+    }
+    auto E2this = hit->GetEnergy() * hit->GetEnergy();
+    auto E2tmp = fE2 + E2this;
+    // Calculate X with arithmetic average with w_i = E_i^2
+    fX = (fE2 * fX + E2this * StripID2X(hit->GetStripID())) / E2tmp;
+    fE += hit->GetEnergy();
+    fE2 = E2tmp;
+    // fT will not be updated. Take the time from the highest E hit.
+    return;
+}
+
+void R3BTttxCal2Hit::HitsDetector::NewCluster(R3BTttxCalData* hit)
+{
+    fDetID = hit->GetDetID();
+    fHits.push_back(new HitDetector(hit));
+}
+
+// Add hit to the existing cluster (last entry)
+// Assume the CalData has been sorted in Energy in descending order, and window condition is satisfied.
+void R3BTttxCal2Hit::HitsDetector::AddHitToLast(R3BTttxCalData* hit)
+{
+    R3BLOG_IF(error, fDetID == 0, "fDetID is not set in the cluster");
+    fHits.back()->AddHit(hit);
 }
 
 // -----   Private method AddHitData  --------------------------------------------
-R3BTttxHitData* R3BTttxCal2Hit::AddHitData(double xpos, double energy, double ang, double charge, double time)
+R3BTttxHitData* R3BTttxCal2Hit::AddHitData(int8_t idet, // idet0: reconstructed with two dets, idet%: hit with only det%
+                                           double xpos,
+                                           double energy,
+                                           double ang,
+                                           double charge,
+                                           double time)
 {
     // It fills the R3BTttxHitData
     TClonesArray& clref = *fTttxHitData;
     int size = clref.GetEntriesFast();
-    return new (clref[size]) R3BTttxHitData(xpos, energy, ang, charge, time);
+    return new (clref[size]) R3BTttxHitData(idet, xpos, energy, ang, charge, time);
+}
+
+R3BTttxHitData* R3BTttxCal2Hit::AddHitData(HitDetector* hit1)
+{
+    if (!fStoreOnlyTwoDetHitEvent)
+    {
+        return AddHitData(hit1->GetDetID(), hit1->GetX(), hit1->GetE(), NAN, CalculateZ(hit1), hit1->GetT());
+    }
+    return nullptr;
+}
+
+R3BTttxHitData* R3BTttxCal2Hit::AddHitData(HitDetector* hit1, HitDetector* hit2)
+{
+
+    // For the later development, the angle should be updated with Z positions derived from GeoPar.
+    auto angle = -hit1->GetX() + hit2->GetX();
+
+    // Just taking average, but maybe it needs modification to weigh detectors if thicknesses are different.
+    auto* hitdata0 = AddHitData(0,
+                                0.5 * (hit1->GetX() + hit2->GetX()),
+                                0.5 * (hit1->GetE() + hit2->GetE()),
+                                angle,
+                                0.5 * (CalculateZ(hit1) + CalculateZ(hit2)),
+                                0.5 * (hit1->GetT() + hit2->GetT()));
+    // First entry will be combined hit.
+
+    // If necessary include them, then you can add data detector by detector. This will be useful for later analysis
+    // with ReconstructZ();
+    if (!fStoreOnlyTwoDetHitEvent)
+    {
+        AddHitData(hit1->GetDetID(), hit1->GetX(), hit1->GetE(), NAN, CalculateZ(hit1), hit1->GetT());
+        AddHitData(hit2->GetDetID(), hit2->GetX(), hit2->GetE(), NAN, CalculateZ(hit2), hit2->GetT());
+    }
+    return hitdata0;
 }
 
 ClassImp(R3BTttxCal2Hit)

--- a/tttx/calibration/R3BTttxCal2Hit.h
+++ b/tttx/calibration/R3BTttxCal2Hit.h
@@ -24,7 +24,11 @@
 #include <TArrayF.h>
 #include <TRandom.h>
 
+#include "R3BLogger.h"
+#include "R3BTttxCalData.h"
 #include "R3BTttxHitData.h"
+constexpr double WStrip = 95.97 / 32.; // mm
+constexpr int NStrips = 32;
 
 class TClonesArray;
 class R3BTttxHitPar;
@@ -55,20 +59,106 @@ class R3BTttxCal2Hit : public FairTask
 
     inline void SetOnline(Bool_t option) { fOnline = option; }
 
+  public:
+    class HitDetector
+    {
+      public:
+        HitDetector() = default;
+        HitDetector(R3BTttxCalData* hit);
+        ~HitDetector();
+        void AddHit(R3BTttxCalData* hit);
+
+        [[nodiscard]] inline const auto& GetX() { return fX; };
+        [[nodiscard]] inline const auto& GetE() { return fE; };
+        [[nodiscard]] inline const auto& GetT() { return fT; };
+        [[nodiscard]] inline const auto& GetDetID() { return fDetID; };
+        [[nodiscard]] inline const auto& IsTrefIn() { return fTrefIncluded; };
+
+      private:
+        double StripID2X(int ID)
+        { // 1-oriented
+            return (static_cast<double>(ID) - static_cast<double>(NStrips) / 2. - 0.5) * WStrip;
+        }
+
+        double fX{ NAN };
+        double fE{ NAN };
+        double fE2{ NAN }; // Squared energy used in AddHit()
+        double fT{ NAN };
+        int fDetID{ -1 };
+        bool fTrefIncluded{ false };
+    };
+
+    class HitsDetector
+    {
+      public:
+        HitsDetector() = default;
+
+        void Init();
+        void NewCluster(R3BTttxCalData* hit);
+        void AddHitToLast(R3BTttxCalData* hit);
+        auto GetMult() { return fHits.size(); };
+        auto& GetHit(int mult) { return fHits.at(mult); }
+        /*
+        [[nodiscard]] inline const auto& GetMult() { return fHits.size(); };
+        auto GetX(int mult) { return fHits.at(mult).fX; };
+        auto GetE(int mult) { return fHits.at(mult).fE; };
+        auto GetT(int mult) { return fHits.at(mult).fT; };
+        */
+      private:
+        std::vector<HitDetector*> fHits;
+        int fDetID;
+    };
+
+    [[nodiscard]] inline const bool& GetRequireTref() { return fRequireTref; }
+    [[nodiscard]] inline const bool& GetStoreOnlyTwoDetHitEvent() { return fStoreOnlyTwoDetHitEvent; }
+    [[nodiscard]] inline const double& GetFixedBeta() { return ffixedbeta; }
+    [[nodiscard]] inline const double& GetTimeWindow() { return ftimewindow; }
+    [[nodiscard]] inline const uint& GetNumNeighbours() { return fneighbours; }
+    void SetRequireTref(bool val) { fRequireTref = val; }
+    void SetStoreOnlyTwoDetHitEvent(bool val) { fStoreOnlyTwoDetHitEvent = val; }
+    void SetFixedBeta(double val) { ffixedbeta = val; }
+    void SetTimeWindow(double val) { ftimewindow = val; }
+    void SetNumNeighbours(uint val) { fneighbours = val; }
+
+    // For the later update
+    // Method to access from external process for the event-by-event reconstruction.
+    // void RecalculateZ(double fbeta = -1.);
+
+    // Return calculated atomic number Z with the given velocity
+    double CalculateZ(HitDetector* hit, double fbeta = -1.);
+
   private:
+    bool IsInWindow(R3BTttxCalData* hit1, R3BTttxCalData* hit2);
+
     void Reset();
+    void InitVHitsDetector();
+    void ResetVHitsDetector();
     void SetParameter();
 
-    int NumDets = 0;
+    int NumDets = 2;
+    int NumPars = 2;
 
-    bool fOnline = false; // Don't store data for online
+    bool fOnline = false;                  // Don't store data for online
+    bool fRequireTref = false;             // Requires Tref in the cluster
+    bool fStoreOnlyTwoDetHitEvent = false; // Store only events with two detectors have hits
+    double ffixedbeta = 0.7;               // Velocity for the fixed analysis
+    double ftimewindow = 10.;              // in micro seconds
+    uint fneighbours = 2;                  // Num of neighbouring strips, if 0, no clustering
 
     R3BTttxHitPar* fHit_Par = nullptr;
+    TArrayF* HitParams = nullptr;
     TClonesArray* fTttxCalData = nullptr;
     TClonesArray* fTttxHitData = nullptr;
 
+    // For clustering
+    std::vector<HitsDetector*> vHitsDet;
+    std::vector<bool> vUsed;
+
+  private:
     // Private method AddHitData
-    R3BTttxHitData* AddHitData(double xpos, double energy, double ang, double charge, double time);
+    R3BTttxHitData* AddHitData(int8_t idet, double xpos, double energy, double ang, double charge, double time);
+    R3BTttxHitData* AddHitData(HitDetector* hit1);
+    R3BTttxHitData* AddHitData(HitDetector* hit1, HitDetector* hit2);
 
   public:
     ClassDefOverride(R3BTttxCal2Hit, 1)

--- a/tttx/calibration/R3BTttxMapped2Cal.cxx
+++ b/tttx/calibration/R3BTttxMapped2Cal.cxx
@@ -172,8 +172,8 @@ void R3BTttxMapped2Cal::Exec(Option_t* /*option*/)
     for (int idet = 0; idet < NumDets; idet++)
     {
         auto fTrig = fTttx.at(idet).GetTrig();
-        R3BLOG(debug, "Multiplicity of Trigger: " << fTrig.GetMult());
-        R3BLOG_IF(error, fTrig.GetMult() > 1, "Multiple Trigger hits: " << fTrig.GetMult());
+        R3BLOG(debug, "Detector" << idet + 1 << "Multiplicity of Trigger: " << fTrig.GetMult());
+        R3BLOG_IF(warning, fTrig.GetMult() > 1, "Multiple Trigger hits: " << fTrig.GetMult());
         for (int istrip = 0; istrip < NumStrips; istrip++)
         {
             if (fCal_Par->GetInUse(idet + 1, istrip + 1) != 1)
@@ -201,12 +201,12 @@ void R3BTttxMapped2Cal::CalculateStrip(int idet, int istrip, CalStrip& fStrip, C
 {
     for (int imult = 0; imult < fStrip.GetMult(); imult++)
     {
-        auto dtime = fStrip.GetT(imult);
+        auto itime = fStrip.GetT(imult);
         if (fTrig.GetMult() == 1)
         {
-            dtime -= fStrip.GetT(0);
+            itime -= fStrip.GetT(0);
         }
-        R3BLOG(debug, "idet=" << idet << ", istrip=" << istrip << ", time =" << dtime);
+        auto dtime = fTimeResolution * static_cast<double>(itime);
         if (dtime < fTimeMin || dtime > fTimeMax)
             return;
         auto rawE = static_cast<int>(fStrip.GetE(imult));
@@ -227,6 +227,9 @@ void R3BTttxMapped2Cal::CalculateStrip(int idet, int istrip, CalStrip& fStrip, C
                           TMath::Power(static_cast<double>(rawE), power);
             }
         }
+        R3BLOG(debug,
+               "idet = " << idet << ", istrip = " << istrip << ", time = " << dtime << " ns, energy = " << energy
+                         << " keV");
         AddCalData(idet + 1, istrip + 1, dtime, energy);
     }
 }

--- a/tttx/calibration/R3BTttxMapped2Cal.h
+++ b/tttx/calibration/R3BTttxMapped2Cal.h
@@ -57,17 +57,18 @@ class R3BTttxMapped2Cal : public FairTask
 
     inline void SetOnline(Bool_t option) { fOnline = option; }
 
-    [[nodiscard]] inline const uint8_t& GetTrefCh(uint8_t val) { return fch_tref; }
-    [[nodiscard]] inline const uint8_t& GetTrigCh(uint8_t val) { return fch_trig; }
+    [[nodiscard]] inline const uint8_t& GetTrefCh() { return fch_tref; }
+    [[nodiscard]] inline const uint8_t& GetTrigCh() { return fch_trig; }
+    [[nodiscard]] inline const double& GetTimeResolution() { return fTimeResolution; }
 
-    inline void SetTimeWindow(int min, int max)
+    inline void SetTimeWindow(double min, double max)
     {
         fTimeMin = min;
         fTimeMax = max;
     }
-    inline void SetTrefCh(int val) { fch_tref = val; }
-    inline void SetTrigCh(int val) { fch_trig = val; }
-    // inline void UseTrigTime(bool val) {fuse_trig = val};
+    inline void SetTrefCh(uint8_t val) { fch_tref = val; }
+    inline void SetTrigCh(uint8_t val) { fch_trig = val; }
+    inline void SetTimeResolution(double val) { fTimeResolution = val; }
 
   private:
     void Reset();
@@ -78,8 +79,9 @@ class R3BTttxMapped2Cal : public FairTask
     int NumParams = 0;
     uint8_t fch_tref = 33; //(1-base)
     uint8_t fch_trig = 34; // (1-base)
-    int fTimeMin = -65536;
-    int fTimeMax = 65536; // Maximum time for 2^16
+    double fTimeMin = -1e5;
+    double fTimeMax = 1e5;               // Maximum time of +/-100us
+    double fTimeResolution = 25. / 128.; // For setting 3. in pico-second
     TArrayF* CalParams;
 
     bool fOnline = false; // Don't store data for online
@@ -157,6 +159,7 @@ class R3BTttxMapped2Cal : public FairTask
   private:
     std::vector<CalDetector> fTttx;
     void CalculateStrip(int idet, int istrip, CalStrip& fStrip, CalStrip& fTrig);
+
     // Private method AddCalData
     R3BTttxCalData* AddCalData(uint8_t detid, uint8_t stripid, double time, double energy);
 

--- a/tttx/pars/R3BTttxHitPar.cxx
+++ b/tttx/pars/R3BTttxHitPar.cxx
@@ -59,6 +59,7 @@ void R3BTttxHitPar::putParams(FairParamList* list)
     }
 
     list->add("tttxDetNumberPar", fNumDets);
+    list->add("tttxNumberParsZFit", fNumParsZfit);
 
     auto array_size = fNumDets * fNumParsZfit;
     LOG(info) << "Size for array fZfitpar: " << array_size;
@@ -82,6 +83,12 @@ Bool_t R3BTttxHitPar::getParams(FairParamList* list)
         return kFALSE;
     }
 
+    if (!list->fill("tttxNumberParsZFit", &fNumParsZfit))
+    {
+        R3BLOG(fatal, "Could not initialize tttxNumberParsZFit");
+        return kFALSE;
+    }
+
     auto array_size = fNumDets * fNumParsZfit;
     R3BLOG(info, "Total number of Z-fit parameters: " << array_size);
 
@@ -91,17 +98,18 @@ Bool_t R3BTttxHitPar::getParams(FairParamList* list)
         R3BLOG(fatal, "Could not initialize tttxZfitPar");
         return kFALSE;
     }
-
     return kTRUE;
 }
 
 // ----  Method print ----------------------------------------------------------
 void R3BTttxHitPar::print()
 {
+    R3BLOG(info, "Number of detectors: " << fNumDets);
+    R3BLOG(info, "Number of Z-fit parameters: " << fNumParsZfit);
     R3BLOG(info, "TTTX Hit Parameters");
     for (int d = 0; d < fNumDets; d++)
     {
-        R3BLOG(info, "Tttx detector: " << d + 1);
+        R3BLOG(info, "Detector: " << d + 1);
         for (Int_t j = 0; j < fNumParsZfit; j++)
         {
             LOG(info) << "FitParam(" << j + 1 << ") = " << fZfitpar->GetAt(d * fNumParsZfit + j);


### PR DESCRIPTION
Now CalData will be sorted with a descending order of energy first, then it will be clustered through the Cal2Hit process based on the time and geometrical distances between the hits. The clustered hits for each detector will be again checked with the time-correlations to the other detector, then reconstruct the Z. The hit parameters are defined detector-by-detector to accommodate different thicknesses. The weights to average the values are half and half. The HitData will include the DetectorID to indicate how reconstruction is made. If two detectors are used, DetID=0 will be assigned, otherwise, if only one detector is used, the actual DetID will be recorded.

Describe your proposal.

Mention any issue this PR is resolved or is related to.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [X] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
