### PR TITLE
LOS: Added trailing trigger times to the reader

### DIFF
--- a/r3bsource/los/R3BLosReader.cxx
+++ b/r3bsource/los/R3BLosReader.cxx
@@ -16,11 +16,11 @@
 #include "R3BLogger.h"
 #include "R3BLosMappedData.h"
 
-#include "FairLogger.h"
-#include "FairRootManager.h"
+#include <FairLogger.h>
+#include <FairRootManager.h>
 
-#include "TClonesArray.h"
-#include "TMath.h"
+#include <TClonesArray.h>
+#include <TMath.h>
 
 /**
  ** ext_h101_los.h was created by running
@@ -407,15 +407,28 @@ Bool_t R3BLosReader::R3BRead()
             trigChannels = data->LOS[d].TTRIGFL;
             for (uint32_t i = 0; i < trigChannels; i++)
             {
-                uint32_t channelf = data->LOS[d].TTRIGFLI[i]; // = 1..2
-                uint32_t channelc = data->LOS[d].TTRIGCLI[i]; // = 1..2
-                if (channelf == channelc)
+                // Leading times
+                uint32_t channelfl = data->LOS[d].TTRIGFLI[i]; // = 1..2
+                uint32_t channelcl = data->LOS[d].TTRIGCLI[i]; // = 1..2
+                if (channelfl == channelcl)
                     new ((*fArrayTrigger)[fArrayTrigger->GetEntriesFast()])
                         R3BLosMappedData(d + 1,                    // detector number
-                                         channelf,                 // channel number: 1
+                                         channelfl,                // channel number: 1
                                          1,                        // VFTX (0),TAMEX leading (1), TAMEX trailing (2)
-                                         data->LOS[d].TTRIGFLv[i], // VFTX fine time
-                                         data->LOS[d].TTRIGCLv[i]  // VFTX coarse time
+                                         data->LOS[d].TTRIGFLv[i], // TAMEX3 fine time
+                                         data->LOS[d].TTRIGCLv[i]  // TAMEX3 coarse time
+                        );
+
+                // Trailing times
+                uint32_t channelft = data->LOS[d].TTRIGFTI[i]; // = 1..2
+                uint32_t channelct = data->LOS[d].TTRIGCTI[i]; // = 1..2
+                if (channelft == channelct)
+                    new ((*fArrayTrigger)[fArrayTrigger->GetEntriesFast()])
+                        R3BLosMappedData(d + 1,                    // detector number
+                                         channelft,                // channel number: 1
+                                         2,                        // VFTX (0),TAMEX leading (1), TAMEX trailing (2)
+                                         data->LOS[d].TTRIGFTv[i], // TAMEX3 fine time
+                                         data->LOS[d].TTRIGCTv[i]  // TAMEX3 coarse time
                         );
             }
         }
@@ -433,4 +446,4 @@ void R3BLosReader::Reset()
         fArrayTrigger->Clear();
 }
 
-ClassImp(R3BLosReader);
+ClassImp(R3BLosReader)

--- a/r3bsource/los/R3BLosReader.h
+++ b/r3bsource/los/R3BLosReader.h
@@ -11,8 +11,7 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 
-#ifndef R3BLOSREADER_H
-#define R3BLOSREADER_H 1
+#pragma once
 
 #include "R3BReader.h"
 #include <Rtypes.h>
@@ -42,10 +41,10 @@ class R3BLosReader : public R3BReader
     virtual void Reset() override;
 
     // Accessor to select online mode
-    void SetOnline(Bool_t option) { fOnline = option; }
+    inline void SetOnline(Bool_t option) { fOnline = option; }
 
     // Accessor to skip trigger times
-    void SetSkipTriggerTimes() { fSkiptriggertimes = kTRUE; }
+    inline void SetSkipTriggerTimes() { fSkiptriggertimes = kTRUE; }
 
   private:
     // An event counter
@@ -67,5 +66,3 @@ class R3BLosReader : public R3BReader
   public:
     ClassDefOverride(R3BLosReader, 0);
 };
-
-#endif /* R3BLOSREADER_H */

--- a/r3bsource/los/ext_h101_los.h
+++ b/r3bsource/los/ext_h101_los.h
@@ -18,8 +18,7 @@
  * Do not edit - automatically generated.
  */
 
-#ifndef __GUARD_H101_LOS_EXT_H101_LOS_H__
-#define __GUARD_H101_LOS_EXT_H101_LOS_H__
+#pragma once
 
 #ifndef __CINT__
 #include <stdint.h>
@@ -84,6 +83,12 @@ typedef struct EXT_STR_h101_LOS_t
     uint32_t LOS1TTRIGCL /* [0,1] */;
     uint32_t LOS1TTRIGCLI[1 EXT_STRUCT_CTRL(LOS1TTRIGCL)] /* [1,1] */;
     uint32_t LOS1TTRIGCLv[1 EXT_STRUCT_CTRL(LOS1TTRIGCL)] /* [0,65535] */;
+    uint32_t LOS1TTRIGFT /* [0,1] */;
+    uint32_t LOS1TTRIGFTI[1 EXT_STRUCT_CTRL(LOS1TTRIGFT)] /* [1,1] */;
+    uint32_t LOS1TTRIGFTv[1 EXT_STRUCT_CTRL(LOS1TTRIGFT)] /* [0,65535] */;
+    uint32_t LOS1TTRIGCT /* [0,1] */;
+    uint32_t LOS1TTRIGCTI[1 EXT_STRUCT_CTRL(LOS1TTRIGCT)] /* [1,1] */;
+    uint32_t LOS1TTRIGCTv[1 EXT_STRUCT_CTRL(LOS1TTRIGCT)] /* [0,65535] */;
 
 } EXT_STR_h101_LOS;
 
@@ -140,66 +145,106 @@ typedef struct EXT_STR_h101_LOS_onion_t
         uint32_t TTRIGCL;
         uint32_t TTRIGCLI[1 /* TTRIGCL */];
         uint32_t TTRIGCLv[1 /* TTRIGCL */];
+        uint32_t TTRIGFT;
+        uint32_t TTRIGFTI[1 /* TTRIGFT */];
+        uint32_t TTRIGFTv[1 /* TTRIGFT */];
+        uint32_t TTRIGCT;
+        uint32_t TTRIGCTI[1 /* TTRIGCT */];
+        uint32_t TTRIGCTv[1 /* TTRIGCT */];
     } LOS[1];
 
 } EXT_STR_h101_LOS_onion;
 
 /*******************************************************/
 
-#define EXT_STR_h101_LOS_ITEMS_INFO(ok, si, offset, struct_t, printerr)                                              \
-    do                                                                                                               \
-    {                                                                                                                \
-        ok = 1;                                                                                                      \
-        /* RAW */                                                                                                    \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1VTFM, UINT32, "LOS1VTFM", 8);                  \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1VTFMI, UINT32, "LOS1VTFMI", "LOS1VTFM");       \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1VTFME, UINT32, "LOS1VTFME", "LOS1VTFM");       \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1VTF, UINT32, "LOS1VTF", 256);                  \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1VTFv, UINT32, "LOS1VTFv", "LOS1VTF");          \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1VTCM, UINT32, "LOS1VTCM", 8);                  \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1VTCMI, UINT32, "LOS1VTCMI", "LOS1VTCM");       \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1VTCME, UINT32, "LOS1VTCME", "LOS1VTCM");       \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1VTC, UINT32, "LOS1VTC", 256);                  \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1VTCv, UINT32, "LOS1VTCv", "LOS1VTC");          \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1VTRIGF, UINT32, "LOS1VTRIGF", 1);              \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1VTRIGFI, UINT32, "LOS1VTRIGFI", "LOS1VTRIGF"); \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1VTRIGFv, UINT32, "LOS1VTRIGFv", "LOS1VTRIGF"); \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1VTRIGC, UINT32, "LOS1VTRIGC", 1);              \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1VTRIGCI, UINT32, "LOS1VTRIGCI", "LOS1VTRIGC"); \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1VTRIGCv, UINT32, "LOS1VTRIGCv", "LOS1VTRIGC"); \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1TTFLM, UINT32, "LOS1TTFLM", 8);                \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1TTFLMI, UINT32, "LOS1TTFLMI", "LOS1TTFLM");    \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1TTFLME, UINT32, "LOS1TTFLME", "LOS1TTFLM");    \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1TTFL, UINT32, "LOS1TTFL", 256);                \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1TTFLv, UINT32, "LOS1TTFLv", "LOS1TTFL");       \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1TTFTM, UINT32, "LOS1TTFTM", 8);                \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1TTFTMI, UINT32, "LOS1TTFTMI", "LOS1TTFTM");    \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1TTFTME, UINT32, "LOS1TTFTME", "LOS1TTFTM");    \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1TTFT, UINT32, "LOS1TTFT", 256);                \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1TTFTv, UINT32, "LOS1TTFTv", "LOS1TTFT");       \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1TTCLM, UINT32, "LOS1TTCLM", 8);                \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1TTCLMI, UINT32, "LOS1TTCLMI", "LOS1TTCLM");    \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1TTCLME, UINT32, "LOS1TTCLME", "LOS1TTCLM");    \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1TTCL, UINT32, "LOS1TTCL", 256);                \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1TTCLv, UINT32, "LOS1TTCLv", "LOS1TTCL");       \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1TTCTM, UINT32, "LOS1TTCTM", 8);                \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1TTCTMI, UINT32, "LOS1TTCTMI", "LOS1TTCTM");    \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1TTCTME, UINT32, "LOS1TTCTME", "LOS1TTCTM");    \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1TTCT, UINT32, "LOS1TTCT", 256);                \
-        EXT_STR_ITEM_INFO_ZZP(ok, si, offset, struct_t, printerr, LOS1TTCTv, UINT32, "LOS1TTCTv", "LOS1TTCT");       \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1TTRIGFL, UINT32, "LOS1TTRIGFL", 1);            \
-        EXT_STR_ITEM_INFO_ZZP(                                                                                       \
-            ok, si, offset, struct_t, printerr, LOS1TTRIGFLI, UINT32, "LOS1TTRIGFLI", "LOS1TTRIGFL");                \
-        EXT_STR_ITEM_INFO_ZZP(                                                                                       \
-            ok, si, offset, struct_t, printerr, LOS1TTRIGFLv, UINT32, "LOS1TTRIGFLv", "LOS1TTRIGFL");                \
-        EXT_STR_ITEM_INFO_LIM(ok, si, offset, struct_t, printerr, LOS1TTRIGCL, UINT32, "LOS1TTRIGCL", 1);            \
-        EXT_STR_ITEM_INFO_ZZP(                                                                                       \
-            ok, si, offset, struct_t, printerr, LOS1TTRIGCLI, UINT32, "LOS1TTRIGCLI", "LOS1TTRIGCL");                \
-        EXT_STR_ITEM_INFO_ZZP(                                                                                       \
-            ok, si, offset, struct_t, printerr, LOS1TTRIGCLv, UINT32, "LOS1TTRIGCLv", "LOS1TTRIGCL");                \
-                                                                                                                     \
+#define EXT_STR_h101_LOS_ITEMS_INFO(ok, si, offset, struct_t, printerr)                                               \
+    do                                                                                                                \
+    {                                                                                                                 \
+        ok = 1;                                                                                                       \
+        /* RAW */                                                                                                     \
+        EXT_STR_ITEM_INFO2_LIM(ok, si, offset, struct_t, printerr, LOS1VTFM, UINT32, "LOS1VTFM", 8, 0 /*flags*/);     \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1VTFMI, UINT32, "LOS1VTFMI", "LOS1VTFM", 0 /*flags*/);             \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1VTFME, UINT32, "LOS1VTFME", "LOS1VTFM", 0 /*flags*/);             \
+        EXT_STR_ITEM_INFO2_LIM(ok, si, offset, struct_t, printerr, LOS1VTF, UINT32, "LOS1VTF", 256, 0 /*flags*/);     \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1VTFv, UINT32, "LOS1VTFv", "LOS1VTF", 0 /*flags*/);                \
+        EXT_STR_ITEM_INFO2_LIM(ok, si, offset, struct_t, printerr, LOS1VTCM, UINT32, "LOS1VTCM", 8, 0 /*flags*/);     \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1VTCMI, UINT32, "LOS1VTCMI", "LOS1VTCM", 0 /*flags*/);             \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1VTCME, UINT32, "LOS1VTCME", "LOS1VTCM", 0 /*flags*/);             \
+        EXT_STR_ITEM_INFO2_LIM(ok, si, offset, struct_t, printerr, LOS1VTC, UINT32, "LOS1VTC", 256, 0 /*flags*/);     \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1VTCv, UINT32, "LOS1VTCv", "LOS1VTC", 0 /*flags*/);                \
+        EXT_STR_ITEM_INFO2_LIM(ok, si, offset, struct_t, printerr, LOS1VTRIGF, UINT32, "LOS1VTRIGF", 1, 0 /*flags*/); \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1VTRIGFI, UINT32, "LOS1VTRIGFI", "LOS1VTRIGF", 0 /*flags*/);       \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1VTRIGFv, UINT32, "LOS1VTRIGFv", "LOS1VTRIGF", 0 /*flags*/);       \
+        EXT_STR_ITEM_INFO2_LIM(ok, si, offset, struct_t, printerr, LOS1VTRIGC, UINT32, "LOS1VTRIGC", 1, 0 /*flags*/); \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1VTRIGCI, UINT32, "LOS1VTRIGCI", "LOS1VTRIGC", 0 /*flags*/);       \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1VTRIGCv, UINT32, "LOS1VTRIGCv", "LOS1VTRIGC", 0 /*flags*/);       \
+        EXT_STR_ITEM_INFO2_LIM(ok, si, offset, struct_t, printerr, LOS1TTFLM, UINT32, "LOS1TTFLM", 8, 0 /*flags*/);   \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTFLMI, UINT32, "LOS1TTFLMI", "LOS1TTFLM", 0 /*flags*/);          \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTFLME, UINT32, "LOS1TTFLME", "LOS1TTFLM", 0 /*flags*/);          \
+        EXT_STR_ITEM_INFO2_LIM(ok, si, offset, struct_t, printerr, LOS1TTFL, UINT32, "LOS1TTFL", 256, 0 /*flags*/);   \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTFLv, UINT32, "LOS1TTFLv", "LOS1TTFL", 0 /*flags*/);             \
+        EXT_STR_ITEM_INFO2_LIM(ok, si, offset, struct_t, printerr, LOS1TTFTM, UINT32, "LOS1TTFTM", 8, 0 /*flags*/);   \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTFTMI, UINT32, "LOS1TTFTMI", "LOS1TTFTM", 0 /*flags*/);          \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTFTME, UINT32, "LOS1TTFTME", "LOS1TTFTM", 0 /*flags*/);          \
+        EXT_STR_ITEM_INFO2_LIM(ok, si, offset, struct_t, printerr, LOS1TTFT, UINT32, "LOS1TTFT", 256, 0 /*flags*/);   \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTFTv, UINT32, "LOS1TTFTv", "LOS1TTFT", 0 /*flags*/);             \
+        EXT_STR_ITEM_INFO2_LIM(ok, si, offset, struct_t, printerr, LOS1TTCLM, UINT32, "LOS1TTCLM", 8, 0 /*flags*/);   \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTCLMI, UINT32, "LOS1TTCLMI", "LOS1TTCLM", 0 /*flags*/);          \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTCLME, UINT32, "LOS1TTCLME", "LOS1TTCLM", 0 /*flags*/);          \
+        EXT_STR_ITEM_INFO2_LIM(ok, si, offset, struct_t, printerr, LOS1TTCL, UINT32, "LOS1TTCL", 256, 0 /*flags*/);   \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTCLv, UINT32, "LOS1TTCLv", "LOS1TTCL", 0 /*flags*/);             \
+        EXT_STR_ITEM_INFO2_LIM(ok, si, offset, struct_t, printerr, LOS1TTCTM, UINT32, "LOS1TTCTM", 8, 0 /*flags*/);   \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTCTMI, UINT32, "LOS1TTCTMI", "LOS1TTCTM", 0 /*flags*/);          \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTCTME, UINT32, "LOS1TTCTME", "LOS1TTCTM", 0 /*flags*/);          \
+        EXT_STR_ITEM_INFO2_LIM(ok, si, offset, struct_t, printerr, LOS1TTCT, UINT32, "LOS1TTCT", 256, 0 /*flags*/);   \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTCTv, UINT32, "LOS1TTCTv", "LOS1TTCT", 0 /*flags*/);             \
+        EXT_STR_ITEM_INFO2_LIM(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTRIGFL, UINT32, "LOS1TTRIGFL", 1, 0 /*flags*/);                  \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTRIGFLI, UINT32, "LOS1TTRIGFLI", "LOS1TTRIGFL", 0 /*flags*/);    \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTRIGFLv, UINT32, "LOS1TTRIGFLv", "LOS1TTRIGFL", 0 /*flags*/);    \
+        EXT_STR_ITEM_INFO2_LIM(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTRIGCL, UINT32, "LOS1TTRIGCL", 1, 0 /*flags*/);                  \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTRIGCLI, UINT32, "LOS1TTRIGCLI", "LOS1TTRIGCL", 0 /*flags*/);    \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTRIGCLv, UINT32, "LOS1TTRIGCLv", "LOS1TTRIGCL", 0 /*flags*/);    \
+        EXT_STR_ITEM_INFO2_LIM(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTRIGFT, UINT32, "LOS1TTRIGFT", 1, 0 /*flags*/);                  \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTRIGFTI, UINT32, "LOS1TTRIGFTI", "LOS1TTRIGFT", 0 /*flags*/);    \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTRIGFTv, UINT32, "LOS1TTRIGFTv", "LOS1TTRIGFT", 0 /*flags*/);    \
+        EXT_STR_ITEM_INFO2_LIM(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTRIGCT, UINT32, "LOS1TTRIGCT", 1, 0 /*flags*/);                  \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTRIGCTI, UINT32, "LOS1TTRIGCTI", "LOS1TTRIGCT", 0 /*flags*/);    \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                       \
+            ok, si, offset, struct_t, printerr, LOS1TTRIGCTv, UINT32, "LOS1TTRIGCTv", "LOS1TTRIGCT", 0 /*flags*/);    \
+                                                                                                                      \
     } while (0);
-
-#endif /*__GUARD_H101_LOS_EXT_H101_LOS_H__*/
 
 /*******************************************************/


### PR DESCRIPTION
The TAMEX trigger trailing edge was added to the LOS Reader, this should cover the PR #989 by @lponnath 

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
