### PR TITLE
2D correlation plot of tpat in R3BGeneralOnlineSpectra

### DIFF
--- a/analysis/online/R3BGeneralOnlineSpectra.h
+++ b/analysis/online/R3BGeneralOnlineSpectra.h
@@ -142,6 +142,8 @@ class R3BGeneralOnlineSpectra : public FairTask
     // Unpack
     TH1F *fh1_trigger, *fh1_tpat, *fh1_wr[2];
     TH1F* fh1_wrs[5];
+    TH2F* fh2_tpat;
+    std::vector<int> tpatbin;
 
   public:
     ClassDef(R3BGeneralOnlineSpectra, 0)


### PR DESCRIPTION
A 2D plot to illustrate tpat values in each event is added. This will be useful to monitor the Trloii functions for Foot-on and Foot-bonus triggers.

Describe your proposal.

Mention any issue this PR is resolved or is related to.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [X] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
