### PR TITLE
Updated IncomingBeta reconstruction for s091 experiment.

### DIFF
--- a/analysis/CMakeLists.txt
+++ b/analysis/CMakeLists.txt
@@ -66,6 +66,7 @@ ${R3BROOT_SOURCE_DIR}/r3bdata/tofiData
 ${R3BROOT_SOURCE_DIR}/r3bdata/pdcData
 ${R3BROOT_SOURCE_DIR}/r3bdata/pspData
 ${R3BROOT_SOURCE_DIR}/r3bdata/fibData
+${R3BROOT_SOURCE_DIR}/r3bdata/frssciData
 ${R3BROOT_SOURCE_DIR}/r3bdata/ptofData
 ${R3BROOT_SOURCE_DIR}/r3bdata/sampData
 ${R3BROOT_SOURCE_DIR}/r3bdata/sfibData

--- a/analysis/offline/R3BAnalysisIncomingID.h
+++ b/analysis/offline/R3BAnalysisIncomingID.h
@@ -101,6 +101,8 @@ class R3BAnalysisIncomingID : public FairTask
     // Acsessor to set use of trigger corrected times
     void SetUseTref() { fUseTref = kTRUE; }
 
+    void SetNumDet(int val) { fNumDet = val; }
+
   protected:
     R3BEventHeader* fHeader{}; // Event header
 

--- a/analysis/offline/R3BIncomingBeta.cxx
+++ b/analysis/offline/R3BIncomingBeta.cxx
@@ -28,6 +28,7 @@
 #include "R3BIncomingBeta.h"
 #include "R3BIncomingIDPar.h"
 #include "R3BLogger.h"
+#include "R3BLosCalData.h"
 #include "R3BLosHitData.h"
 #include "R3BSci2HitData.h"
 #include "R3BSci2TcalData.h"
@@ -42,22 +43,22 @@ R3BIncomingBeta::R3BIncomingBeta()
 
 R3BIncomingBeta::R3BIncomingBeta(const char* name, Int_t iVerbose)
     : FairTask(name, iVerbose)
-    , fHitSci2(NULL)
-    , fTcalSci2(NULL)
-    , fFrsDataCA(NULL)
-    , fPos_p0(-11)
-    , fPos_p1(54.7)
-    , fP0(-2.12371e7)
-    , fP1(4.9473e7)
-    , fP2(-2.87635e7)
-    , fZprimary(50.)
-    , fZoffset(-1.3)
-    , fOnline(kFALSE)
     , fTimeStitch(nullptr)
     , fIncomingID_Par(NULL)
+    , fFrsDataCA(NULL)
+    , fHitSci2(NULL)
+    , fPosCalFrsSci(NULL)
+    , fTcalSci2(NULL)
+    , fOnline(kFALSE)
+    , fStaId(1)
+    , fStoId(2)
+    , fLosRefCh(0)
+    , fLosCalTrig_Low(3160.)
+    , fLosCalTrig_High(3220.)
     , fNumDet(1)
     , fUseTref(kFALSE)
     , fUseMultHit(kFALSE)
+    , fUseFrsSci(kFALSE)
 {
     fToFoffset = new TArrayF(fNumDet);
     fPosS2Left = new TArrayF(fNumDet);
@@ -112,19 +113,37 @@ InitStatus R3BIncomingBeta::Init()
 
     fHeader = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
 
-    // Get access to Sci2 data at hit level
-    fHitSci2 = dynamic_cast<TClonesArray*>(mgr->GetObject("Sci2Hit"));
-    R3BLOG_IF(warn, !fHitSci2, "Could not find Sci2Hit");
+    if (!fUseFrsSci)
+    {
+        // Get access to Sci2 data at hit level
+        fHitSci2 = dynamic_cast<TClonesArray*>(mgr->GetObject("Sci2Hit"));
+        R3BLOG_IF(fatal, !fHitSci2, "Could not find Sci2Hit");
+    }
+    else
+    {
+        // Get access to Sci2 data at hit level
+        fPosCalFrsSci = dynamic_cast<TClonesArray*>(mgr->GetObject("FrsSciPosCalData"));
+        R3BLOG_IF(fatal, !fPosCalFrsSci, "Could not find FrsSciPosCalData");
+    }
 
     // Get access to hit data of the LOS
     fHitLos = dynamic_cast<TClonesArray*>(mgr->GetObject("LosHit"));
-    R3BLOG_IF(warn, !fHitLos, "LosHit not found");
+    R3BLOG_IF(fatal, !fHitLos, "LosHit not found");
+
+    if (fHeader->GetExpId() == 91 || fHeader->GetExpId() == 118)
+    {
+        fCalLos = dynamic_cast<TClonesArray*>(mgr->GetObject("LosCal"));
+        R3BLOG_IF(fatal, !fCalLos, "LosCal not found");
+
+        fCalLosTrig = dynamic_cast<TClonesArray*>(mgr->GetObject("LosTriggerCal"));
+        R3BLOG_IF(fatal, !fCalLosTrig, "LosTriggerCal not found");
+    }
 
     // Get access to Sci2 data at Tcal level
     if (fHeader->GetExpId() == 509)
     {
         fTcalSci2 = dynamic_cast<TClonesArray*>(mgr->GetObject("Sci2Tcal"));
-        R3BLOG_IF(warn, !fTcalSci2, "Could not find Sci2Tcal");
+        R3BLOG_IF(fatal, !fTcalSci2, "Could not find Sci2Tcal");
     }
 
     // Output data
@@ -209,7 +228,6 @@ void R3BIncomingBeta::Exec(Option_t* option)
             multSci2Tcal[(numDet - 1) * 3 + ch]++;
         } // --- end of loop over Sci2 Tcal data --- //
     }
-
     // --- read hit from Sci2 data --- //
     if (fHitSci2 && fHitSci2->GetEntriesFast() > 0)
     {
@@ -233,43 +251,97 @@ void R3BIncomingBeta::Exec(Option_t* option)
         } // --- end of loop over hit data --- //
     }
 
-    // --- read hit from LOS data --- //
-    if (fHitLos && fHitLos->GetEntriesFast() > 0)
+    // --- read hit from Sci2 data --- //
+    if (fPosCalFrsSci && fPosCalFrsSci->GetEntriesFast() > 0)
     {
-        Int_t numDet = 1;
-
-        nHits = fHitLos->GetEntriesFast();
-
+        Int_t numDet = -1;
+        nHits = fPosCalFrsSci->GetEntriesFast();
         for (Int_t ihit = 0; ihit < nHits; ihit++)
         {
-            R3BLosHitData* hittcal = dynamic_cast<R3BLosHitData*>(fHitLos->At(ihit));
+            R3BFrsSciPosCalData* hittcal = dynamic_cast<R3BFrsSciPosCalData*>(fPosCalFrsSci->At(ihit));
             numDet = hittcal->GetDetector();
-
-            if (multLos[numDet - 1] >= MAXMULT)
-                break;
-            timeLosV[numDet - 1][multLos[numDet - 1]] = hittcal->GetTime();
-            posLosX_cm[numDet - 1][multLos[numDet - 1]] = hittcal->GetX_cm();
-            multLos[numDet - 1]++;
+            if (numDet > fNumDet)
+            {
+                R3BLOG(warn, "FrsSci detector id:" << numDet << " is out of range!");
+                continue;
+            }
+            if (multSci2[numDet - 1] >= MAXMULT)
+                continue;
+            PosSci2_m1[numDet - 1][multSci2[numDet - 1]] = hittcal->GetCalPosMm();
+            TimeSci2_m1[numDet - 1][multSci2[numDet - 1]] = hittcal->GetRawTimeNs();
+            TimeSci2wTref_m1[numDet - 1][multSci2[numDet - 1]] = hittcal->GetRawTimeNsWithTref();
+            multSci2[numDet - 1]++;
         } // --- end of loop over hit data --- //
     }
 
-    // Note 1: fNumDet doesn't really make sense to me in this task
-    // since the number of detectors of LOS and FRS can be
-    // different but they are for some reason treated as the
-    // same here. Doesn't really affect my analysis hence I
-    // leave it as it is.
-    // Note 2: If the objective is to use only Los Z, FRSdata can
+    if (fHeader->GetExpId() == 91 || fHeader->GetExpId() == 118)
+    {
+        // --- read hit from LOSCal data --- //
+        if (fCalLos && fCalLos->GetEntriesFast() > 0)
+        {
+            nHits = fCalLos->GetEntriesFast();
+            if (nHits == 1 || (fCalLosTrig && fCalLosTrig->GetEntriesFast() == 1))
+            {
+                for (Int_t ihit = 0; ihit < nHits; ihit++)
+                {
+                    auto* hittcal = dynamic_cast<R3BLosCalData*>(fCalLos->At(ihit));
+                    auto* hittcaltrig = dynamic_cast<R3BLosCalData*>(fCalLosTrig->At(0));
+                    auto numDet = hittcal->GetDetector();
+                    if (multLos[numDet - 1] >= MAXMULT)
+                        break;
+                    auto los_tdiff = fTimeStitch->GetTime(
+                        hittcaltrig->GetTimeV_ns(0) - hittcal->GetTimeV_ns(fLosRefCh), "vftx", "vftx");
+                    if (los_tdiff < fLosCalTrig_Low || los_tdiff > fLosCalTrig_High)
+                    {
+                        continue;
+                    }
+                    timeLosV[numDet - 1][multLos[numDet - 1]] =
+                        hittcal->GetMeanTimeVFTX() - hittcal->GetTimeV_ns(fLosRefCh);
+                    // posLosX_cm[numDet - 1][multLos[numDet - 1]] = hittcal->GetX_cm();
+                    multLos[numDet - 1]++;
+                } // --- end of loop over hit data --- //
+            }
+        }
+    }
+    else
+    {
+        // --- read hit from LOS data --- //
+        if (fHitLos && fHitLos->GetEntriesFast() > 0)
+        {
+            Int_t numDet = -1;
+
+            nHits = fHitLos->GetEntriesFast();
+
+            for (Int_t ihit = 0; ihit < nHits; ihit++)
+            {
+                R3BLosHitData* hittcal = dynamic_cast<R3BLosHitData*>(fHitLos->At(ihit));
+                numDet = hittcal->GetDetector();
+
+                if (multLos[numDet - 1] >= MAXMULT)
+                    break;
+                timeLosV[numDet - 1][multLos[numDet - 1]] = hittcal->GetTime();
+                posLosX_cm[numDet - 1][multLos[numDet - 1]] = hittcal->GetX_cm();
+                multLos[numDet - 1]++;
+            } // --- end of loop over hit data --- //
+        }
+    }
+
+    // Note: If the objective is to use only Los Z, FRSdata can
     // now easily be made multihit capable from this code itself,
     // just save the Los Z and calculate the Brho and A/Q value here
     // no need to run the separate R3BAnalysisIncomingID task which
     // can currently take only single hits because the Z information
     // is generally taken from other detectors
     // -Nikhil
-    Double_t good_beta = 0., good_pos_s2 = 0., good_pos_los = 0., good_tof = 0.;
+    Double_t good_beta = NAN, good_pos_s2 = NAN, good_pos_los = NAN, good_tof = NAN;
 
     for (int i = 0; i < fNumDet; i++)
     {
-        for (Int_t i_L = 0; i_L < multLos[i]; i_L++)
+        if (fUseFrsSci && (fStoId != 0 || fStaId != i + 1))
+        {
+            continue;
+        }
+        for (Int_t i_L = 0; i_L < multLos[0]; i_L++) // Here we assume there is only one LOS detector
         {
             Int_t num_tof_candidates = 0;
             for (Int_t i_2 = 0; i_2 < multSci2[i]; i_2++)
@@ -278,34 +350,46 @@ void R3BIncomingBeta::Exec(Option_t* option)
                 {
                     ToFraw_m1 = fTimeStitch->GetTime(fHeader->GetTStart() - TimeSci2wTref_m1[i][i_2], "vftx", "vftx");
                 }
+                else if (fHeader->GetExpId() == 91 || fHeader->GetExpId() == 118)
+                {
+                    ToFraw_m1 =
+                        fTimeStitch->GetTime(timeLosV[0][i_L] - TimeSci2wTref_m1[i][i_2],
+                                             "vftx",
+                                             "vftx"); // Ref time is subtracted already on timeLosV for this case
+                }
                 else
                 {
-                    ToFraw_m1 = fTimeStitch->GetTime(timeLosV[i][i_L] - TimeSci2_m1[i][i_2], "vftx", "vftx");
+                    ToFraw_m1 = fTimeStitch->GetTime(timeLosV[0][i_L] - TimeSci2_m1[i][i_2], "vftx", "vftx");
                     if (ToFraw_m1 > 0. && fHeader->GetExpId() == 515)
                         ToFraw_m1 = ToFraw_m1 - 40960.;
                 }
                 Velo_m1 = 1. / (fTof2InvV_p0->GetAt(i) +
                                 fTof2InvV_p1->GetAt(i) * (fToFoffset->GetAt(i) + ToFraw_m1)); // [m/ns]
                 Beta_m1 = Velo_m1 / (TMath::C() / pow(10, 9));
-
                 // Select good ToF hit with gating beta
                 if (Beta_m1 < fBeta_max && Beta_m1 > fBeta_min)
                 {
                     good_beta = Beta_m1;
                     good_tof = ToFraw_m1;
                     good_pos_s2 = PosSci2_m1[i][i_2];
-                    good_pos_los = posLosX_cm[i][i_L];
+                    good_pos_los = posLosX_cm[0][i_L];
                     num_tof_candidates++;
                 }
             }
-
             if (num_tof_candidates == 1)
             {
-                AddData(1, 2, 0., 0., good_beta, 0., good_pos_s2, good_pos_los, good_tof);
+                AddData(fStaId,
+                        fStoId,
+                        0.,
+                        0.,
+                        good_beta,
+                        0.,
+                        good_pos_s2,
+                        good_pos_los,
+                        good_tof); // NaN indicator of only one
                 if (!fUseMultHit)
                     break;
             }
-
             if (num_tof_candidates == 0 && fHeader->GetExpId() == 509)
             {
                 Int_t num_tof_ch = 0;
@@ -344,38 +428,88 @@ void R3BIncomingBeta::Exec(Option_t* option)
                 }
                 if (num_tof_ch == 1)
                 {
-                    AddData(1, 2, 0., 0., good_beta, 0., 0. / 0., good_pos_los, good_tof); // NaN indicator of only one
-                                                                                           // S2 pmt present
+                    AddData(1, 2, 0., 0., good_beta, 0., NAN, good_pos_los,
+                            good_tof); // NaN indicator of only one
+                    // S2 pmt present
+                    if (!fUseMultHit)
+                        break;
+                }
+            }             // end: if (num_tof_candidates == 0 && fHeader->GetExpId() == 509)
+            if (fUseTref) // Tref defines when the trigger time is. And only one hit is recorded.
+                break;
+        } // End of loop with LOS mult
+    }
+
+    // This part can be done by FrsSciTCal2Cal and resulting as FrsSciTofCalData.
+    /*
+    if (fUseFrsSci && fStoId > 0 && fStaId > 0)
+    { // Use FrsSci for both Start and Stop
+        for (Int_t i_stop = 0; i_stop < multSci2[fStoId - 1]; i_stop++)
+        {
+            for (Int_t i_2 = 0; i_2 < multSci2[fStaId - 1]; i_2++)
+            {
+                if (fUseTref)
+                {
+                    ToFraw_m1 =
+                        fTimeStitch->GetTime(fHeader->GetTStart() - TimeSci2wTref_m1[fStaId - 1][i_2], "vftx", "vftx");
+                } // Enable only when the FrsSciProvideTStart is ready
+                else
+                {
+                    ToFraw_m1 = fTimeStitch->GetTime(
+                        TimeSci2_m1[fStoId - 1][i_stop] - TimeSci2_m1[fStaId - 1][i_2], "vftx", "vftx");
+                }
+                Velo_m1 =
+                    1. / (fTof2InvV_p0->GetAt(fStaId - 1) +
+                          fTof2InvV_p1->GetAt(fStaId - 1) * (fToFoffset->GetAt(fStaId - 1) + ToFraw_m1)); // [m/ns]
+                Beta_m1 = Velo_m1 / (TMath::C() / pow(10, 9));
+
+                // Select good ToF hit with gating beta
+                if (Beta_m1 < fBeta_max && Beta_m1 > fBeta_min)
+                {
+                    good_beta = Beta_m1;
+                    good_tof = ToFraw_m1;
+                    good_pos_s2 = PosSci2_m1[fStaId - 1][i_2];
+                    good_pos_los = PosSci2_m1[fStoId - 1][i_2]; // Let's keep calling stop det as los
+                    num_tof_candidates++;
+                    AddData(fStaId, fStoId, 0., 0., good_beta, 0., good_pos_s2, good_pos_los, good_tof);
                     if (!fUseMultHit)
                         break;
                 }
             }
-            if (fUseTref)
-                break;
         }
     }
+    */
 }
 
 void R3BIncomingBeta::FinishEvent()
 {
+    R3BLOG(debug1, "Clearing Loaded Structures");
     if (fHitSci2)
     {
         fHitSci2->Clear();
+    }
+    if (fHeader->GetExpId() == 91 || fHeader->GetExpId() == 118)
+    {
+        if (fCalLos)
+        {
+            fCalLos->Clear();
+        }
+        if (fCalLosTrig)
+        {
+            fCalLosTrig->Clear();
+        }
     }
     if (fHitLos)
     {
         fHitLos->Clear();
     }
-}
-
-void R3BIncomingBeta::Reset()
-{
-    R3BLOG(debug1, "Clearing FrsData Structure");
     if (fFrsDataCA)
     {
         fFrsDataCA->Clear();
     }
 }
+
+void R3BIncomingBeta::Reset() {}
 
 // -----   Private method AddData  --------------------------------------------
 R3BFrsData* R3BIncomingBeta::AddData(Int_t StaId,

--- a/analysis/offline/R3BIncomingBeta.h
+++ b/analysis/offline/R3BIncomingBeta.h
@@ -23,6 +23,7 @@
 // R3B headers
 #include "R3BEventHeader.h"
 #include "R3BFrsData.h"
+#include "R3BFrsSciPosCalData.h"
 #include "R3BMusicHitData.h"
 
 // FAIR headers
@@ -87,19 +88,20 @@ class R3BIncomingBeta : public FairTask
 
     virtual void Reset();
 
-    void SetBetaCorrectionForZ(Double_t p0, Double_t p1, Double_t p2, Double_t Zprimary, Double_t Zoffset)
-    {
-        fP0 = p0;
-        fP1 = p1;
-        fP2 = p2;
-        fZprimary = Zprimary;
-        fZoffset = Zoffset;
-    }
-
     // Accessor to select online mode
     void SetOnline(Bool_t option) { fOnline = option; }
     void SetUseTref() { fUseTref = kTRUE; }
     void SetUseMultHit() { fUseMultHit = kTRUE; }
+    void SetNumDets(int val) { fNumDet = val; }
+    void SetStaId(int val) { fStaId = val; }
+    void SetStoId(int val) { fStoId = val; } // if id == 0 and bFrsSci = true, then LOS will be used
+    void SetLosRefCh(int val) { fLosRefCh = val; }
+    void UseFrsSci(bool val) { fUseFrsSci = val; } // If false, sci2 will be used
+    void SetLosCalRange(Double_t low, Double_t high)
+    {
+        fLosCalTrig_Low = low;
+        fLosCalTrig_High = high;
+    } // Only for S118/S091
 
   protected:
     R3BEventHeader* fHeader{}; // Event header
@@ -111,14 +113,18 @@ class R3BIncomingBeta : public FairTask
     TClonesArray* fFrsDataCA;          /**< Array with FRS-output data. >*/
 
     TClonesArray* fHitSci2;
+    TClonesArray* fPosCalFrsSci;
     TClonesArray* fHitLos;
+    TClonesArray* fCalLos;
+    TClonesArray* fCalLosTrig;
     TClonesArray* fTcalSci2; /**< Array with Tcal items. */
 
-    Bool_t fOnline; // Don't store data for online
-    Double_t fP0, fP1, fP2, fZprimary, fZoffset;
+    int fStaId;
+    int fStoId;
+    int fLosRefCh;
+    Double_t fLosCalTrig_Low, fLosCalTrig_High;
 
-    Double_t fPos_p0;
-    Double_t fPos_p1;
+    Bool_t fOnline; // Don't store data for online
 
     UInt_t fNumDet;
     TArrayF* fToFoffset;
@@ -127,6 +133,7 @@ class R3BIncomingBeta : public FairTask
     Float_t fBeta_max, fBeta_min;
     Bool_t fUseTref;
     Bool_t fUseMultHit;
+    bool fUseFrsSci;
 
     /** Private method FrsData **/
     //** Adds a FrsData to the analysis

--- a/analysis/online/R3BIncomingIDOnlineSpectra.cxx
+++ b/analysis/online/R3BIncomingIDOnlineSpectra.cxx
@@ -50,6 +50,7 @@ R3BIncomingIDOnlineSpectra::R3BIncomingIDOnlineSpectra(const TString& name, Int_
     , fHitLos(NULL)
     , fMwpc0HitDataCA(NULL)
     , fMwpc1HitDataCA(NULL)
+    , header(nullptr)
     , fNEvents(0)
     , fTpat(-1)
     , fStaId(1)
@@ -57,11 +58,16 @@ R3BIncomingIDOnlineSpectra::R3BIncomingIDOnlineSpectra(const TString& name, Int_
     , fMax_Z(20.)
     , fMin_Aq(1.6)
     , fMax_Aq(3.9)
+    , fMin_Brho(6)
+    , fMax_Brho(10)
+    , fMin_RawTof(-50000)
+    , fMax_RawTof(50000)
+    , fMin_Beta(0.)
+    , fMax_Beta(1.)
     , fMin_Z_gate(0.)
     , fMax_Z_gate(20.)
     , fMin_Aq_gate(1.6)
     , fMax_Aq_gate(3.9)
-    , header(nullptr)
 {
 }
 
@@ -124,7 +130,7 @@ InitStatus R3BIncomingIDOnlineSpectra::Init()
     // Hit data, beta
     Name1 = "fh1_beta_frs";
     Name2 = "FRS: Beta";
-    fh1_beta = new TH1F(Name1, Name2, 1000, 0.45, 0.99);
+    fh1_beta = new TH1F(Name1, Name2, 1000, fMin_Beta, fMax_Beta);
     fh1_beta->GetXaxis()->SetTitle("Beta");
     fh1_beta->GetYaxis()->SetTitle("Counts");
     fh1_beta->GetYaxis()->SetTitleOffset(1.15);
@@ -142,7 +148,7 @@ InitStatus R3BIncomingIDOnlineSpectra::Init()
 
     Name1 = "fh1_tofraw_frs";
     Name2 = "FRS: Raw Tof";
-    fh1_tof = new TH1F(Name1, Name2, 20000, -50000, 50000);
+    fh1_tof = new TH1F(Name1, Name2, 20000, fMin_RawTof, fMax_RawTof);
     fh1_tof->GetXaxis()->SetTitle("ToF [ns]");
     fh1_tof->GetYaxis()->SetTitle("Counts");
     fh1_tof->GetYaxis()->SetTitleOffset(1.15);
@@ -161,7 +167,7 @@ InitStatus R3BIncomingIDOnlineSpectra::Init()
 
     Name1 = "fh1_brho_frs";
     Name2 = "FRS: Brho S2-Cave";
-    fh1_brho = new TH1F(Name1, Name2, 1500, 8., 19.);
+    fh1_brho = new TH1F(Name1, Name2, 1500, fMin_Brho, fMax_Brho);
     fh1_brho->GetXaxis()->SetTitle("Brho [Tm]");
     fh1_brho->GetYaxis()->SetTitle("Counts");
     fh1_brho->GetYaxis()->SetTitleOffset(1.15);

--- a/analysis/online/R3BIncomingIDOnlineSpectra.h
+++ b/analysis/online/R3BIncomingIDOnlineSpectra.h
@@ -94,6 +94,18 @@ class R3BIncomingIDOnlineSpectra : public FairTask
 
     // Setting parameters
     void SetStartPlaId(Int_t id) { fStaId = id; };
+    void SetRangeRawTof(Double_t min, Double_t max)
+    {
+        fMin_RawTof = min;
+        fMax_RawTof = max;
+    }
+
+    void SetRangeBeta(Double_t min, Double_t max)
+    {
+        fMin_Beta = min;
+        fMax_Beta = max;
+    }
+
     void SetRangeZ(Double_t min, Double_t max)
     {
         fMin_Z = min;
@@ -104,6 +116,12 @@ class R3BIncomingIDOnlineSpectra : public FairTask
     {
         fMin_Aq = min;
         fMax_Aq = max;
+    }
+
+    void SetRangeBrho(Double_t min, Double_t max)
+    {
+        fMin_Brho = min;
+        fMax_Brho = max;
     }
 
     void SetIsoGate(Double_t minz, Double_t maxz, Double_t minaq, Double_t maxaq)
@@ -120,13 +138,6 @@ class R3BIncomingIDOnlineSpectra : public FairTask
     TClonesArray* fMwpc0HitDataCA;
     TClonesArray* fMwpc1HitDataCA;
 
-    // Start Plastic ID
-    Int_t fStaId;
-
-    // Ranges for the histograms;
-    Double_t fMin_Z, fMax_Z, fMin_Aq, fMax_Aq;
-    Double_t fMin_Z_gate, fMax_Z_gate, fMin_Aq_gate, fMax_Aq_gate;
-
     // Parameters
     R3BTGeoPar* fMw0GeoPar;
     R3BTGeoPar* fMw1GeoPar;
@@ -135,6 +146,13 @@ class R3BIncomingIDOnlineSpectra : public FairTask
     R3BEventHeader* header; /**< Event header.      */
     Int_t fNEvents;         /**< Event counter.     */
     Int_t fTpat;
+
+    // Start Plastic ID
+    Int_t fStaId;
+
+    // Ranges for the histograms;
+    Double_t fMin_Z, fMax_Z, fMin_Aq, fMax_Aq, fMin_Brho, fMax_Brho, fMin_RawTof, fMax_RawTof, fMin_Beta, fMax_Beta;
+    Double_t fMin_Z_gate, fMax_Z_gate, fMin_Aq_gate, fMax_Aq_gate;
 
     // Canvas
     TCanvas* cBeta;

--- a/frssci/calibration/R3BFrsSciTcal2Cal.h
+++ b/frssci/calibration/R3BFrsSciTcal2Cal.h
@@ -66,7 +66,11 @@ class R3BFrsSciTcal2Cal : public FairTask
 
     TRandom3 rand;
 
-    R3BFrsSciPosCalData* AddPosCalData(UShort_t det, Double_t traw, Float_t rawpos, Float_t calpos);
+    R3BFrsSciPosCalData* AddPosCalData(UShort_t det,
+                                       Double_t traw,
+                                       Double_t traw_wtref,
+                                       Float_t rawpos,
+                                       Float_t calpos);
     R3BFrsSciTofCalData* AddTofCalData(UShort_t rank,
                                        UShort_t detsta,
                                        UShort_t detsto,

--- a/frssci/online/R3BOnlineSpectraFrsSci.cxx
+++ b/frssci/online/R3BOnlineSpectraFrsSci.cxx
@@ -45,6 +45,10 @@ R3BOnlineSpectraFrsSci::R3BOnlineSpectraFrsSci(const char* name, Int_t iVerbose)
     , fNbDets(3)
     , fNbPmts(3)
     , fNbTofs(3)
+    , fpos_range_min(-5.)
+    , fpos_range_max(5.)
+    , ftof_range_min(0.)
+    , ftof_range_max(2500)
 {
 }
 
@@ -207,8 +211,12 @@ InitStatus R3BOnlineSpectraFrsSci::Init()
         {
             // === TH1F: Raw Position in Ns if mult1 RIGHT and LEFT === //
             sprintf(Name1, "FrsSci%i_PosRaw_MULT1", i + 1);
-            fh1_Tcal1Hit_PosRaw[i] = new TH1D(Name1, Name1, 10000, -5, 5);
-            fh1_Tcal1Hit_PosRaw[i]->GetXaxis()->SetTitle("Raw Positon [ns] if mult1 at L and R");
+            fh1_Tcal1Hit_PosRaw[i] = new TH1D(Name1,
+                                              Name1,
+                                              static_cast<int>(20. * (fpos_range_max - fpos_range_min)),
+                                              fpos_range_min,
+                                              fpos_range_max);
+            fh1_Tcal1Hit_PosRaw[i]->GetXaxis()->SetTitle("Raw Positon [ns] if mult1 at L and R. 50 ps per bin");
             fh1_Tcal1Hit_PosRaw[i]->GetYaxis()->SetTitle("number of counts with mult1");
             fh1_Tcal1Hit_PosRaw[i]->GetXaxis()->CenterTitle(true);
             fh1_Tcal1Hit_PosRaw[i]->GetYaxis()->CenterTitle(true);
@@ -228,8 +236,13 @@ InitStatus R3BOnlineSpectraFrsSci::Init()
                 for (UShort_t sto = sta + 1; sto <= fNbDets; sto++)
                 {
                     sprintf(Name1, "TofRaw_FrsSci%i_to_FrsSci%i_MULT1", sta, sto);
-                    fh1_Tcal1Hit_TofRaw[cpt] = new TH1D(Name1, Name1, 150000, 200, 2500);
-                    fh1_Tcal1Hit_TofRaw[cpt]->GetXaxis()->SetTitle("Raw Tof [ns] if mult1 at L, R and Tref");
+                    fh1_Tcal1Hit_TofRaw[cpt] = new TH1D(Name1,
+                                                        Name1,
+                                                        static_cast<int>(10. * (ftof_range_max - ftof_range_min)),
+                                                        ftof_range_min,
+                                                        fpos_range_max);
+                    fh1_Tcal1Hit_TofRaw[cpt]->GetXaxis()->SetTitle(
+                        "Raw Tof [ns] if mult1 at L, R and Tref. 100 ps per bin.");
                     fh1_Tcal1Hit_TofRaw[cpt]->GetYaxis()->SetTitle("number of counts with mult1");
                     fh1_Tcal1Hit_TofRaw[cpt]->GetXaxis()->CenterTitle(true);
                     fh1_Tcal1Hit_TofRaw[cpt]->GetYaxis()->CenterTitle(true);
@@ -284,7 +297,11 @@ InitStatus R3BOnlineSpectraFrsSci::Init()
                              fh1_Tcal1Hit_PosRaw[i]->GetBinLowEdge(nbins) + fh1_Tcal1Hit_PosRaw[i]->GetBinWidth(nbins));
             }
             else
-                fh1_Cal_PosRaw[i] = new TH1D(Name1, Name1, 1000, -250, 250);
+                fh1_Cal_PosRaw[i] = new TH1D(Name1,
+                                             Name1,
+                                             static_cast<int>(2. * (fpos_range_max - fpos_range_min)),
+                                             fpos_range_min,
+                                             fpos_range_max);
             fh1_Cal_PosRaw[i]->GetXaxis()->SetTitle("Raw Positon [ns] in red CAL level, in blue TCAL-MULT1");
             fh1_Cal_PosRaw[i]->GetYaxis()->SetTitle("number of counts with mult1");
             fh1_Cal_PosRaw[i]->GetXaxis()->CenterTitle(true);

--- a/frssci/online/R3BOnlineSpectraFrsSci.h
+++ b/frssci/online/R3BOnlineSpectraFrsSci.h
@@ -106,6 +106,17 @@ class R3BOnlineSpectraFrsSci : public FairTask
         }
     }
 
+    void SetPosRange(float min, float max)
+    {
+        fpos_range_min = min;
+        fpos_range_max = max;
+    }
+    void SetTofRange(float min, float max)
+    {
+        ftof_range_min = min;
+        ftof_range_max = max;
+    }
+
   private:
     R3BEventHeader* fEventHeader; /**< Event header.      */
 
@@ -159,6 +170,12 @@ class R3BOnlineSpectraFrsSci : public FairTask
     TH2D** fh2_Cal_BRhoVsPosSto; // [fNbTofs]
     TH2D** fh2_Cal_AoQVsPosSta;  // [fNbTofs]
     TH2D** fh2_Cal_AoQVsPosSto;  // [fNbTofs]
+
+    // Define ranges
+    float fpos_range_min;
+    float fpos_range_max;
+    float ftof_range_min;
+    float ftof_range_max;
 
   public:
     ClassDef(R3BOnlineSpectraFrsSci, 1)

--- a/los/R3BLosProvideTStart.cxx
+++ b/los/R3BLosProvideTStart.cxx
@@ -90,12 +90,6 @@ Double_t R3BLosProvideTStart::GetTStart() const
     const auto losCalData = fLosCalData.Retrieve();
     const auto losTriggerCalData = fLosTriggerCalData.Retrieve();
     Float_t diff;
-    auto T1 = 10240; // TAMEX, range is 2048*5ns
-    auto T2 = 40960; // VFTX, range is 40960*5ns
-
-    const int c1 = std::min(T1, T2);
-    const int c2 = std::max(T1, T2);
-
     if (losCalData.empty())
     {
         return std::numeric_limits<Double_t>::quiet_NaN();
@@ -110,6 +104,7 @@ Double_t R3BLosProvideTStart::GetTStart() const
         if (losTriggerCalData.back()->GetTimeV_ns(0) > 0.)
         {
             R3BLOG(debug1, "CalData with VFTX trigger info for LOS");
+
             return fTimeStitch->GetTime(
                 losCalData.back()->GetMeanTimeVFTX() - losTriggerCalData.back()->GetTimeV_ns(0), "vftx", "vftx");
         }
@@ -140,6 +135,7 @@ Double_t R3BLosProvideTStart::GetTStartTrigHit() const
         {
             Double_t tref_t =
                 fTimeStitch->GetTime((*it)->GetTime() - losTriggerData.front()->GetRawTimeNs(), "vftx", "vftx");
+
             if (tref_t > edgeL && tref_t < edgeR)
                 return tref_t;
         }

--- a/los/calib/R3BLosCal2Hit.cxx
+++ b/los/calib/R3BLosCal2Hit.cxx
@@ -434,7 +434,6 @@ void R3BLosCal2Hit::Exec(Option_t* option)
     }
 
     Int_t nHits = fCalItems->GetEntries();
-
     if (nHits == 0)
         return;
 
@@ -547,7 +546,6 @@ void R3BLosCal2Hit::Exec(Option_t* option)
                    return (lhs[0] < rhs[0]) ? -1 : ((rhs[0] < lhs[0]) ? 1 : 0);
                });
     // End sorting
-
     for (Int_t ihit = 0; ihit < nHits; ihit++)
     {
         Bool_t iLOSTypeMCFD = false;
@@ -628,11 +626,11 @@ void R3BLosCal2Hit::Exec(Option_t* option)
                 }
             }
 
-            timeLosM[ihit] = timeLosM[ihit] / nPMV;
-            timeLosT[ihit] = timeLosT[ihit] / nPMT;
+            timeLosM[ihit] = timeLosM[ihit] / static_cast<double>(nPMV);
+            timeLosT[ihit] = timeLosT[ihit] / static_cast<double>(nPMT);
 
-            totsum[ihit] = totsum[ihit] / nPMT;
-            totsum_corr[ihit] = totsum_corr[ihit] / nPMT;
+            totsum[ihit] = totsum[ihit] / static_cast<double>(nPMT);
+            totsum_corr[ihit] = totsum_corr[ihit] / static_cast<double>(nPMT);
 
             // Time resolution TAMEX
             LosTresT[ihit] = ((time_L[ihit][0] + time_L[ihit][2] + time_L[ihit][4] + time_L[ihit][6]) -
@@ -683,13 +681,13 @@ void R3BLosCal2Hit::Exec(Option_t* option)
                 ((time_L_corr[ihit][0] + time_L_corr[ihit][2] + time_L_corr[ihit][4] + time_L_corr[ihit][6]) -
                  (time_L_corr[ihit][1] + time_L_corr[ihit][3] + time_L_corr[ihit][5] + time_L_corr[ihit][7])) /
                 4.;
-            timeLosT_corr[ihit] = timeLosT_corr[ihit] / nPMT;
+            timeLosT_corr[ihit] = timeLosT_corr[ihit] / static_cast<double>(nPMT);
 
             // MCFD
             LosTresM_corr[ihit] = ((time_V_corr[ihit][0] + time_V[ihit][2] + time_V[ihit][4] + time_V[ihit][6]) -
                                    (time_V_corr[ihit][1] + time_V[ihit][3] + time_V[ihit][5] + time_V[ihit][7])) /
                                   4.;
-            timeLosM_corr[ihit] = timeLosM_corr[ihit] / nPMV;
+            timeLosM_corr[ihit] = timeLosM_corr[ihit] / static_cast<double>(nPMV);
 
             // Position from ToT:
             xToT_cm[ihit] = (((tot[ihit][5] + tot[ihit][6]) / 2. - (tot[ihit][1] + tot[ihit][2]) / 2.) /
@@ -809,7 +807,6 @@ void R3BLosCal2Hit::Exec(Option_t* option)
             }
 
         } // end of LOSTYPE = true
-
         new ((*fHitItems)[fHitItems->GetEntriesFast()])
             R3BLosHitData(nDet, t_hit[ihit], x_cm[ihit], y_cm[ihit], Z[ihit]);
 

--- a/r3bdata/frssciData/R3BFrsSciPosCalData.cxx
+++ b/r3bdata/frssciData/R3BFrsSciPosCalData.cxx
@@ -3,14 +3,20 @@
 R3BFrsSciPosCalData::R3BFrsSciPosCalData()
     : fDetector(0)
     , fRawTimeNs(0)
+    , fRawTimeNs_wTref(0)
     , fRawPosNs(0)
     , fCalPosMm(0)
 {
 }
 
-R3BFrsSciPosCalData::R3BFrsSciPosCalData(UShort_t det, Double_t rawT, Float_t rawPos, Float_t calPos)
+R3BFrsSciPosCalData::R3BFrsSciPosCalData(UShort_t det,
+                                         Double_t rawT,
+                                         Double_t rawT_wTref,
+                                         Float_t rawPos,
+                                         Float_t calPos)
     : fDetector(det)
     , fRawTimeNs(rawT)
+    , fRawTimeNs_wTref(rawT_wTref)
     , fRawPosNs(rawPos)
     , fCalPosMm(calPos)
 {

--- a/r3bdata/frssciData/R3BFrsSciPosCalData.h
+++ b/r3bdata/frssciData/R3BFrsSciPosCalData.h
@@ -21,7 +21,7 @@ class R3BFrsSciPosCalData : public TObject
     R3BFrsSciPosCalData();
 
     // Standard Constructor
-    R3BFrsSciPosCalData(UShort_t, Double_t, Float_t, Float_t);
+    R3BFrsSciPosCalData(UShort_t, Double_t, Double_t, Float_t, Float_t);
 
     // Destructor
     virtual ~R3BFrsSciPosCalData() {}
@@ -29,15 +29,17 @@ class R3BFrsSciPosCalData : public TObject
     // Getters
     inline const UShort_t& GetDetector() const { return fDetector; }
     inline const Double_t& GetRawTimeNs() const { return fRawTimeNs; }
+    inline const Double_t& GetRawTimeNsWithTref() const { return fRawTimeNs_wTref; }
     inline const Float_t& GetRawPosNs() const { return fRawPosNs; }
     inline const Float_t& GetCalPosMm() const { return fCalPosMm; }
 
   private:
     UShort_t fDetector;
-    Double_t fRawTimeNs; // 0.5 * (Tright + Tleft) after selection of the multiplicity
-    Float_t fRawPosNs;   // Tright - Tleft: x increasing for right to left
-    Float_t fCalPosMm;   // calibrated position in Mm
+    Double_t fRawTimeNs;       // 0.5 * (Tright + Tleft) after selection of the multiplicity
+    Double_t fRawTimeNs_wTref; // 0.5 * (Tright + Tleft) - Ttrig
+    Float_t fRawPosNs;         // Tright - Tleft: x increasing for right to left
+    Float_t fCalPosMm;         // calibrated position in Mm
 
   public:
-    ClassDef(R3BFrsSciPosCalData, 2)
+    ClassDef(R3BFrsSciPosCalData, 3)
 };


### PR DESCRIPTION
Clean-up and minor improvements in los classes.

Include the timing of the S2 hit after subtraction of the reference time in FrsSciPosCalData.

Bug fix in R3BFrsSciTcal2Cal when obtaining good pairs of hits of left and right PMTs.

Update IncomingData to reconstruct S2(FrsSci) to LosCal for the s091 experiment. Los CFD out was used for the Tref signal for S2, so LosCal is used for reconstructing ToF specific to the experiment. When multiple hits in Los are seen, only good hits wrt the trigger timing are chosen.

Describe your proposal.

Mention any issue this PR is resolved or is related to.

---

Checklist:

* [X] Rebased against `dev` branch
* [X] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [X] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [X] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
