### PR TITLE
Fix a compilation error when old version of libfmt is used

### DIFF
--- a/r3bsource/base/utils/R3BUcesbLauncher.cxx
+++ b/r3bsource/base/utils/R3BUcesbLauncher.cxx
@@ -183,7 +183,7 @@ namespace R3B
         auto err_code = std::error_code{};
         if (not ucesb_server_->wait_for(CHILD_CLOSE_WAITING_TIME, err_code))
         {
-            R3BLOG(warn, fmt::format("Failed to close Ucesb server! Error code: {}", err_code));
+            R3BLOG(warn, fmt::format("Failed to close Ucesb server! Error code: {}", err_code.value()));
             ucesb_server_->terminate(err_code);
             R3BLOG(warn, "Killing Ucesb server");
         }


### PR DESCRIPTION
Print the value of std::error_code instead since the formatter of std::error_code may not be supported in old versions of libfmt.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
