### PR TITLE
Add particle whitelist to R3BPhaseSpaceGen

### DIFF
--- a/config/clang_tidy/default.yml
+++ b/config/clang_tidy/default.yml
@@ -6,6 +6,3 @@ HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
 User:            land
-CheckOptions:
-...
-

--- a/neuland/executables/CMakeLists.txt
+++ b/neuland/executables/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(neulandSim neulandSim.cxx)
-target_link_libraries(neulandSim PRIVATE R3BNeulandSimulation ${Geant4_LIBRARIES}
+target_link_libraries(neulandSim PRIVATE R3BNeulandSimulation R3BGen ${Geant4_LIBRARIES}
                                          ${Geant4VMC_LIBRARIES})
 
 add_executable(neulandAna neulandAna.cxx)

--- a/r3bgen/CMakeLists.txt
+++ b/r3bgen/CMakeLists.txt
@@ -92,6 +92,8 @@ add_library_with_dictionary(
     R3BData
     PRIVATE_DEPENDENCIES
     Geant4::G4materials
+    Boost::iostreams
+    Boost::filesystem
 )
 
 add_subdirectory(test)

--- a/r3bgen/R3BGenLinkDef.h
+++ b/r3bgen/R3BGenLinkDef.h
@@ -42,5 +42,7 @@
 #pragma link C++ class  R3BParticleSelector+;
 #pragma link C++ class  R3BBeamProperties+;
 #pragma link C++ class  R3BINCLRootGenerator+;
+#pragma link C++ class  R3BPhaseSpaceGenParticleInfo+;
+#pragma link C++ class  vector<R3BPhaseSpaceGenParticleInfo>+;
 
 #endif

--- a/r3bgen/test/testR3BPhaseSpaceGeneratorIntegration.C
+++ b/r3bgen/test/testR3BPhaseSpaceGeneratorIntegration.C
@@ -54,7 +54,7 @@ void testR3BPhaseSpaceGeneratorIntegration()
     // Primaries
     auto primGen = new FairPrimaryGenerator();
     auto gen = new R3BPhaseSpaceGenerator();
-    gen->Beam.SetEnergyDistribution(R3BDistribution1D::Delta(600));
+    gen->GetBeam().SetEnergyDistribution(R3BDistribution1D::Delta(600));
     gen->SetErelDistribution(R3BDistribution1D::Delta(100));
     gen->AddParticle(5, 17);
     gen->AddNeutron();


### PR DESCRIPTION
### Feature

1. Add particle whitelist functionality to R3BPhaseSpaceGenerator. Added particles that are not in the whitelist are not generated during the simulation.
2. write the particle info into the sink file. (After fixing [this issue](https://github.com/FairRootGroup/FairRoot/issues/1567)  in FairRoot.)
3. Fix the value for `totalEnergy`

Default is all particles are in the whitelist and no data written.

### Breaking change:

* Variable `Beam` cannot be directly obtained from the class. Use `GetBeam()` instead.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
