### PR TITLE
R3BDataMonitor, R3BValueError and Update on FileSource2

### DIFF
--- a/r3bbase/BaseLinkDef.h
+++ b/r3bbase/BaseLinkDef.h
@@ -31,4 +31,8 @@
 #pragma link C++ class R3BTcutPar+;
 #pragma link C++ class R3BTsplinePar+;
 #pragma link C++ class R3BCoarseTimeStitch+;
+#pragma link C++ class R3B::ValueError<double>+;
+#pragma link C++ class pair<R3B::ValueError<double>, R3B::ValueError<double>>+;
+#pragma link C++ class R3B::LRPair<R3B::ValueError<double>>+;
+#pragma link C++ class R3B::LRPair<int>+;
 #endif

--- a/r3bbase/CMakeLists.txt
+++ b/r3bbase/CMakeLists.txt
@@ -12,6 +12,9 @@
 ##############################################################################
 
 set(SRCS
+    # cmake-format: sortable
+    data_monitor/R3BDataMonitor.cxx
+    data_monitor/R3BDataMonitorCanvas.cxx
     R3BCoarseTimeStitch.cxx
     R3BDataPropagator.cxx
     R3BDetector.cxx
@@ -27,6 +30,9 @@ set(SRCS
     R3BWhiterabbitPropagator.cxx)
 
 set(HEADERS
+    # cmake-format: sortable
+    data_monitor/R3BDataMonitor.h
+    data_monitor/R3BDataMonitorCanvas.h
     R3BCoarseTimeStitch.h
     R3BDataPropagator.h
     R3BDetector.h
@@ -55,6 +61,7 @@ add_library_with_dictionary(
     SRCS
     ${SRCS}
     INCLUDEDIRS
+    data_monitor
     ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDENCIES
     ${DEPENDENCIES})

--- a/r3bbase/R3BEventHeaderPropagator.cxx
+++ b/r3bbase/R3BEventHeaderPropagator.cxx
@@ -11,7 +11,6 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 
-#include "FairLogger.h"
 #include <FairRootManager.h>
 
 #include "R3BEventHeaderPropagator.h"
@@ -23,20 +22,10 @@ R3BEventHeaderPropagator::R3BEventHeaderPropagator()
 {
 }
 
-R3BEventHeaderPropagator::R3BEventHeaderPropagator(const TString& name, Int_t iVerbose, const TString& nameheader)
+R3BEventHeaderPropagator::R3BEventHeaderPropagator(const TString& name, Int_t iVerbose, std::string_view nameheader)
     : FairTask(name, iVerbose)
     , fNameHeader(nameheader)
-    , fHeader(nullptr)
-    , fSource(nullptr)
 {
-}
-
-R3BEventHeaderPropagator::~R3BEventHeaderPropagator()
-{
-    if (fHeader)
-    {
-        delete fHeader;
-    }
 }
 
 InitStatus R3BEventHeaderPropagator::Init()
@@ -47,21 +36,20 @@ InitStatus R3BEventHeaderPropagator::Init()
     R3BLOG_IF(fatal, !fHeader, "EventHeader. not found.");
     R3BLOG_IF(info, fHeader, "EventHeader. found.");
 
-    frm->Register(fNameHeader, "EventHeader", fHeader, kTRUE);
+    frm->Register(fNameHeader.data(), "EventHeader", fHeader, kTRUE);
 
-    fSource = R3BFileSource::Instance();
+    fSource = frm->GetSource();
     R3BLOG_IF(fatal, !fSource, "R3BFileSource not found.");
 
     return kSUCCESS;
 }
 
-void R3BEventHeaderPropagator::Exec(Option_t*)
+void R3BEventHeaderPropagator::Exec(Option_t* /*option*/)
 {
-    if (fSource)
+    if (fSource != nullptr)
     {
         fHeader->SetRunId(fSource->GetRunId());
     }
-    return;
 }
 
 ClassImp(R3BEventHeaderPropagator);

--- a/r3bbase/R3BEventHeaderPropagator.h
+++ b/r3bbase/R3BEventHeaderPropagator.h
@@ -18,7 +18,7 @@
 #include <Rtypes.h>
 
 #include "R3BEventHeader.h"
-class R3BFileSource;
+class FairSource;
 
 class R3BEventHeaderPropagator : public FairTask
 {
@@ -35,13 +35,9 @@ class R3BEventHeaderPropagator : public FairTask
      * @param name a name of the task.
      * @param iVerbose a verbosity level.
      */
-    R3BEventHeaderPropagator(const TString& name, Int_t iVerbose = 1, const TString& nameheader = "EventHeader.");
-
-    /**
-     * Destructor.
-     * Frees the memory used by the object.
-     */
-    ~R3BEventHeaderPropagator() override;
+    explicit R3BEventHeaderPropagator(const TString& name,
+                                      Int_t iVerbose = 1,
+                                      std::string_view nameheader = "EventHeader.");
 
     /**
      * Method for task initialization.
@@ -56,15 +52,15 @@ class R3BEventHeaderPropagator : public FairTask
      * Is called by the framework every time a new event is read.
      * @param option an execution option.
      */
-    void Exec(Option_t*) override;
+    void Exec(Option_t* /*option*/) override;
 
   private:
-    TString fNameHeader;
-    R3BEventHeader* fHeader;
-    R3BFileSource* fSource;
+    std::string fNameHeader;
+    R3BEventHeader* fHeader = nullptr;
+    FairSource* fSource = nullptr;
 
   public:
-    ClassDefOverride(R3BEventHeaderPropagator, 0)
+    ClassDefOverride(R3BEventHeaderPropagator, 1)
 };
 
 #endif // R3BEVENTHEADERPROPAGATOR_H

--- a/r3bbase/R3BFileSource2.h
+++ b/r3bbase/R3BFileSource2.h
@@ -13,14 +13,35 @@
 
 #pragma once
 
-#include "FairSource.h"
 #include "R3BShared.h"
+#include <FairFileSourceBase.h>
 #include <TObjString.h>
+#include <chrono>
 #include <optional>
 
 class FairRootManager;
 class TChain;
 class TFolder;
+
+class R3BEventProgressPrinter
+{
+  public:
+    R3BEventProgressPrinter() = default;
+    void SetRunID(unsigned int runID) { run_id_ = runID; }
+    void SetMaxEventNum(unsigned int max_event_num) { max_event_num_ = max_event_num; }
+    void SetRefreshRate_Hz(float rate);
+    void ShowProgress(uint64_t event_num);
+
+  private:
+    uint64_t max_event_num_ = 0;
+    float refresh_rate_ = 2.; // Hz
+    std::chrono::milliseconds refresh_period_{ static_cast<int>(1000. / refresh_rate_) };
+    unsigned int run_id_ = 0;
+    std::chrono::time_point<std::chrono::steady_clock> previous_t_ = std::chrono::steady_clock::now();
+    uint64_t previous_event_num_ = 0;
+
+    void Print(uint64_t event_num, double speed_per_ms);
+};
 
 class R3BInputRootFiles
 {
@@ -48,6 +69,8 @@ class R3BInputRootFiles
     void SetTreeName(std::string_view treeName) { treeName_ = treeName; }
     void SetTitle(std::string_view title) { title_ = title; }
     void SetFileHeaderName(std::string_view fileHeader) { fileHeader_ = fileHeader; }
+    void SetEnableTreeFile(bool is_tree_file) { is_tree_file_ = is_tree_file; }
+    void SetRunID(uint run_id) { initial_RunID_ = run_id; }
 
     // rule of five:
     ~R3BInputRootFiles() = default;
@@ -58,8 +81,9 @@ class R3BInputRootFiles
 
   private:
     bool is_friend_ = false;
+    bool is_tree_file_ = false;
     uint initial_RunID_ = 0;
-    // title of each file group seems not necessary. Consider to remove it in the future.
+    // TODO: title of each file group seems not necessary. Consider to remove it in the future.
     std::string title_;
     std::string treeName_ = "evt";
     std::string folderName_;
@@ -75,33 +99,42 @@ class R3BInputRootFiles
     auto ValidateFile(const std::string& filename) -> bool;
     static auto ExtractMainFolder(TFile*) -> std::optional<TKey*>;
     auto ExtractRunId(TFile* rootFile) -> std::optional<uint>;
+    void register_branch_name();
 };
 
-class R3BFileSource2 : public FairSource
+class R3BFileSource2 : public FairFileSourceBase
 {
   public:
-    // constructors:
     R3BFileSource2();
     explicit R3BFileSource2(std::string file, std::string_view title = "InputRootFile");
     R3BFileSource2(std::vector<std::string> fileNames, std::string_view title);
     explicit R3BFileSource2(std::vector<std::string> fileNames);
 
-    // public interface:
     void AddFile(std::string);
     void AddFriend(std::string_view);
+
+    [[nodiscard]] auto GetEventEnd() const { return event_end_; }
+
+    // setters:
     void SetFileHeaderName(std::string_view fileHeaderName) { inputDataFiles_.SetFileHeaderName(fileHeaderName); }
-    void DisablePrint() { allow_print_ = false; }
-    void EnablePrint() { allow_print_ = true; }
+    // Set event print refresh rate in Hz
+    void SetEventPrintRefreshRate(float rate) { event_progress_.SetRefreshRate_Hz(rate); }
+    void SetEnableTreeFile(bool is_tree_file) { inputDataFiles_.SetEnableTreeFile(is_tree_file); }
+    void SetInitRunID(int run_id)
+    {
+        inputDataFiles_.SetRunID(run_id);
+        SetRunId(run_id);
+    }
 
   private:
-    bool allow_print_ = false;
+    int event_end_ = 0;
     R3BInputRootFiles inputDataFiles_;
+    R3BEventProgressPrinter event_progress_;
     FairEventHeader* evtHeader_ = nullptr;
     std::vector<R3BInputRootFiles> inputFriendFiles_;
     std::vector<std::string> dataFileNames_;
     std::vector<std::string> friendFileNames_;
 
-    // virtual functions should be private!
     Bool_t Init() override;
     Int_t ReadEvent(UInt_t eventID = 0) override;
     void Close() override {}
@@ -115,9 +148,9 @@ class R3BFileSource2 : public FairSource
     void ReadBranchEvent(const char* BrName, Int_t Entry) override;
     void FillEventHeader(FairEventHeader* evtHeader) override;
     Bool_t ActivateObject(TObject** obj, const char* BrName) override;
-
+    Bool_t ActivateObjectAny(void** obj, const std::type_info& info, const char* BrName) override;
     // WTF is this?
-    Bool_t SpecifyRunId() override { return ReadEvent(0) == 0; }
+    Bool_t SpecifyRunId() override { return true; }
 
   public:
     ClassDefOverride(R3BFileSource2, 0) // NOLINT

--- a/r3bbase/R3BFormatters.h
+++ b/r3bbase/R3BFormatters.h
@@ -1,0 +1,43 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include "R3BShared.h"
+#include <TVector3.h>
+#include <fmt/format.h>
+
+template <>
+class fmt::formatter<TVector3>
+{
+  public:
+    static constexpr auto parse(format_parse_context& ctx) { return ctx.end(); }
+    template <typename FmtContent>
+    constexpr auto format(const TVector3& vec, FmtContent& ctn) const
+    {
+        return format_to(ctn.out(), "[x: {}, y: {}, z: {}]", vec.X(), vec.Y(), vec.Z());
+    }
+};
+
+template <typename DataType>
+class fmt::formatter<R3B::ValueError<DataType>>
+{
+  public:
+    // TODO: add more options
+    static constexpr auto parse(format_parse_context& ctx) { return ctx.end(); }
+    template <typename FmtContent>
+    constexpr auto format(const R3B::ValueError<DataType>& value_error, FmtContent& ctn) const
+    {
+        return format_to(ctn.out(), "{}+/-{}", value_error.value, value_error.error);
+    }
+};

--- a/r3bbase/R3BIOConnector.h
+++ b/r3bbase/R3BIOConnector.h
@@ -123,9 +123,8 @@ namespace R3B
     {
       public:
         using RawDataType = std::remove_const_t<std::remove_cv_t<OutputType>>;
-        explicit OutputConnector(std::string_view branchName, bool persistance = true)
-            : persistance_{ persistance }
-            , branch_name_{ branchName }
+        explicit OutputConnector(std::string_view branchName)
+            : branch_name_{ branchName }
         {
         }
 
@@ -136,11 +135,11 @@ namespace R3B
         OutputConnector& operator=(const OutputConnector& other) = delete;
         OutputConnector& operator=(OutputConnector&&) = delete;
 
-        void init(const boost::source_location& loc = BOOST_CURRENT_LOCATION)
+        void init(bool persistance = true, const boost::source_location& loc = BOOST_CURRENT_LOCATION)
         {
             if (auto* ioman = FairRootManager::Instance(); ioman != nullptr)
             {
-                ioman->RegisterAny(branch_name_.c_str(), data_ptr_, true);
+                ioman->RegisterAny(branch_name_.c_str(), data_ptr_, persistance);
             }
             else
             {
@@ -162,7 +161,6 @@ namespace R3B
         }
 
       private:
-        bool persistance_ = true;
         std::string branch_name_;
         RawDataType data_;
         RawDataType* data_ptr_ = &data_;

--- a/r3bbase/R3BShared.h
+++ b/r3bbase/R3BShared.h
@@ -12,8 +12,14 @@
  ******************************************************************************/
 
 #pragma once
+
+#include "R3BLogger.h"
 #include <FairLogger.h>
+#include <R3BValueError.h>
 #include <TFile.h>
+#include <filesystem>
+#include <fmt/std.h>
+#include <regex>
 #include <type_traits>
 #include <utility>
 
@@ -23,6 +29,8 @@ class TTree;
 
 namespace R3B
 {
+    // -------------------------------------------------------------------------
+    // root_owned:
     // ROOT types owned by ROOT: TH1, TF1;
     template <typename... Types>
     struct TypeCollection
@@ -40,16 +48,6 @@ namespace R3B
     template <typename Type>
     inline constexpr bool is_root_owned = is_based_on<Type, RootTypes>;
 
-    struct TFileDeleter
-    {
-        void operator()(TFile* rootfile)
-        {
-
-            LOG(debug2) << "Closing file " << rootfile->GetName();
-            rootfile->Close();
-        }
-    };
-
     template <typename RootType, typename... Args>
     inline auto root_owned(Args&&... args)
     {
@@ -57,11 +55,160 @@ namespace R3B
         return new RootType(std::forward<Args>(args)...); // NOLINT
     }
 
+    // -------------------------------------------------------------------------
+    // make owned historgam
+
+    template <typename Hist, typename... Args>
+    inline auto make_hist(Args&&... args)
+    {
+        static_assert(std::is_base_of_v<TH1, Hist>, "make_hist: not a histogram type!");
+        auto hist = std::make_unique<Hist>(std::forward<Args>(args)...);
+        hist->SetDirectory(nullptr);
+        return hist;
+    }
+
+    // -------------------------------------------------------------------------
+    // make_rootfile:
+    struct TFileDeleter
+    {
+        void operator()(TFile* rootfile)
+        {
+            LOG(debug2) << "Closing file " << rootfile->GetName();
+            rootfile->Close();
+            delete rootfile; // NOLINT
+        }
+    };
+
     using unique_rootfile = std::unique_ptr<TFile, TFileDeleter>;
 
+    // make a root file that closes automatically
     template <typename... Args>
     inline auto make_rootfile(Args&&... args)
     {
         return unique_rootfile{ new TFile(std::forward<Args>(args)...) };
+    }
+
+    // -------------------------------------------------------------------------
+    // Get the length of a C array:
+    // clang-format off
+    template <typename DataType, std::size_t size>
+    constexpr std::size_t GetSize(const DataType (&/*unused*/)[size]) // NOLINT
+    {
+        return size;
+    }
+    // clang-format on
+
+    // -------------------------------------------------------------------------
+    // side enums:
+    enum class Side : bool
+    {
+        left,
+        right
+    };
+
+    // convert sides to indices: left -> 0, right -> 1
+    constexpr auto toIndex(Side side) -> size_t
+    {
+        if (side == Side::left)
+        {
+            return 0;
+        }
+        return 1;
+    }
+
+    // convert indices to sides: 0 -> left, 1 -> right
+    constexpr auto IndexToSide(size_t index) -> Side
+    {
+        if (index == 0)
+        {
+            return Side::left;
+        }
+        return Side::right;
+    }
+    // -------------------------------------------------------------------------
+    // left and right pair
+    template <typename DataType>
+    class LRPair
+    {
+      public:
+        LRPair() = default;
+        LRPair(const DataType& left, const DataType& right)
+            : data_{ std::make_pair(left, right) }
+            , is_valid(true)
+        {
+        }
+
+        auto& left() { return data_.first; }
+        auto& right() { return data_.second; }
+        auto& left() const { return data_.first; }
+        auto& right() const { return data_.second; }
+        auto get(Side side) const -> const auto& { return (side == Side::left) ? data_.first : data_.second; }
+        auto get(Side side) -> auto& { return (side == Side::left) ? data_.first : data_.second; }
+
+      private:
+        std::pair<DataType, DataType> data_;
+        bool is_valid = false;
+
+      public:
+        ClassDefNV(LRPair, 1);
+    };
+
+    // -------------------------------------------------------------------------
+    // fast exponential function:
+    static const uint8_t DEFAULT_ITERATION = 8U;
+    template <uint8_t iterations = DEFAULT_ITERATION>
+    auto FastExp(const float val) -> float
+    {
+        auto exp = 1.F + val / (1U << iterations);
+        for (auto i = 0; i < iterations; ++i)
+        {
+            exp *= exp;
+        }
+        return exp;
+    }
+
+    // -------------------------------------------------------------------------
+    // File handling
+    namespace fs = std::filesystem;
+    inline auto GetParentDir(std::string_view filename) -> fs::path
+    {
+        auto path = fs::path{ filename };
+        auto parent_folder = path.parent_path();
+        if (parent_folder.empty())
+        {
+            return ".";
+        }
+
+        if (not fs::exists(parent_folder))
+        {
+            R3BLOG(
+                error,
+                fmt::format(R"(Cannot get the parent folder of the regex path "{}"! Setting it to the current folder)",
+                            filename));
+            return ".";
+        }
+
+        return parent_folder;
+    }
+
+    inline auto GetFilesFromRegex(std::string_view filename_regex) -> std::vector<std::string>
+    {
+        auto regex_path = fs::path{ filename_regex };
+        auto parent_folder = GetParentDir(filename_regex);
+        const auto regex_string = regex_path.filename().string();
+        auto filelist = std::vector<std::string>{};
+        for (const auto& dir_entry : fs::directory_iterator(parent_folder))
+        {
+            if (std::regex_match(dir_entry.path().filename().string(), std::regex{ regex_string }))
+            {
+                filelist.emplace_back(fs::absolute(dir_entry.path()));
+            }
+        }
+        if (filelist.empty())
+        {
+            R3BLOG(error, fmt::format(R"(Cannot find any files with regex "{}")", regex_string));
+        }
+        std::sort(filelist.begin(), filelist.end());
+        return filelist;
     }
 } // namespace R3B

--- a/r3bbase/R3BValueError.h
+++ b/r3bbase/R3BValueError.h
@@ -1,0 +1,129 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#pragma once
+#include <TObject.h>
+#include <cmath>
+#include <type_traits>
+
+namespace R3B
+{
+    template <typename DataType>
+    struct ValueError
+    {
+        bool valid = true;
+        DataType value{};
+        DataType error{};
+
+        ValueError(const DataType& val, const DataType& err)
+            : value{ val }
+            , error{ err }
+        {
+        }
+
+        ValueError()
+            : valid{ false }
+        {
+        }
+
+        auto operator-() const -> ValueError<DataType> { return { -value, error }; }
+
+        template <typename OtherType, typename = std::enable_if_t<std::is_arithmetic_v<OtherType>>>
+        auto operator+(OtherType other) const -> ValueError<DataType>
+        {
+            return { value + other, error };
+        }
+
+        template <typename OtherType, typename = std::enable_if_t<std::is_arithmetic_v<OtherType>>>
+        auto operator*(OtherType other) const -> ValueError<DataType>
+        {
+            return { value * other, error * other };
+        }
+
+        template <typename OtherType, typename = std::enable_if_t<std::is_arithmetic_v<OtherType>>>
+        auto operator/(OtherType other) const -> ValueError<DataType>
+        {
+            return { value / other, error / other };
+        }
+
+        template <typename OtherType, typename = std::enable_if_t<std::is_arithmetic_v<OtherType>>>
+        auto operator-(OtherType val) const -> ValueError<DataType>
+        {
+            return { value - val, error };
+        }
+
+        template <typename OtherType, typename = std::enable_if_t<std::is_arithmetic_v<OtherType>>>
+        void operator-=(OtherType other)
+        {
+            value -= other;
+        }
+
+      public:
+        ClassDefNV(ValueError, 1);
+    };
+
+    using ValueErrorD = ValueError<double>;
+    using ValueErrorF = ValueError<float>;
+    using ValueErrorI = ValueError<int>;
+
+    template <typename DataType>
+    auto operator*(ValueError<DataType> left, ValueError<DataType> right) -> ValueError<DataType>
+    {
+        auto new_value = left.value * right.value;
+        auto new_error = std::sqrt(right.value * right.value * left.error * left.error +
+                                   left.value * left.value * right.error * right.error);
+        return { new_value, new_error };
+    }
+
+    template <typename DataType>
+    auto operator/(ValueError<DataType> numerator, ValueError<DataType> denominator) -> ValueError<DataType>
+    {
+        auto new_value = numerator.value / denominator.value;
+        auto new_error = std::sqrt(numerator.error * numerator.error +
+                                   denominator.error * denominator.error * new_value * new_value) /
+                         denominator.value;
+        return { new_value, std::abs(new_error) };
+    }
+
+    template <typename DataType>
+    auto operator+(ValueError<DataType> left, ValueError<DataType> right) -> ValueError<DataType>
+    {
+        auto new_value = left.value + right.value;
+        // TODO: not the fastest way
+        auto new_err = std::sqrt(left.error * left.error + right.error * right.error);
+        return { new_value, new_err };
+    }
+
+    template <typename DataType>
+    auto operator-(ValueError<DataType> left, ValueError<DataType> right) -> ValueError<DataType>
+    {
+        auto new_value = left.value - right.value;
+        // TODO: not the fastest way
+        auto new_err = std::sqrt(left.error * left.error + right.error * right.error);
+        return { new_value, new_err };
+    }
+
+    template <typename DataType>
+    auto operator-=(ValueError<DataType>& left, const ValueError<DataType>& right) -> ValueError<DataType>&
+    {
+        left = left - right;
+        return left;
+    }
+
+    template <typename DataType>
+    auto operator+=(ValueError<DataType>& left, const ValueError<DataType>& right) -> ValueError<DataType>&
+    {
+        left = left + right;
+        return left;
+    }
+} // namespace R3B

--- a/r3bbase/README.md
+++ b/r3bbase/README.md
@@ -1,0 +1,214 @@
+# Class interfaces
+
+## `R3BIOConnector`
+
+The class `R3BIOConnector` is used to declare the input and output data structure in the tasks based on `FairTask`. It's highly recommended to use `R3BIOConnector` instead of `TClonesArray`.
+
+Usage:
+
+```c++
+class MyTask : public FairTask
+{
+  public:
+    MyTask() = default;
+    auto Init() -> InitStatus override
+    {
+        points_.init();
+        hits_.init();
+    }
+
+    void Exec(Option_t* /*option*/) override {
+        const auto& points = points_.get();
+        // do something about points
+        // ...
+
+        // fill the hits
+        auto& hits = hits_.get();
+        auto& hit = hits.emplace_oback();
+    }
+
+  private:
+    R3B::InputVectorConnector<R3BNeulandPoint> points_{ "NeulandPoints" };
+    R3B::OutputVectorConnector<R3BNeulandPoint> hits_{ "NeulandHits" };
+}
+```
+
+Additionally there are three built-in types to support data IO with STL containers:
+
+- `InputVectorConnector` and `OutputVectorConnector`: data IO with `std::vector`
+- `InputMapConnector` and `OutputMapConnector`: data IO with `std::map`
+- `InputHashConnector` and `OutputHashConnector`: data IO with `std::unordered_map`
+
+The `get()` API provides the access to the internal STL data container from `R3BIOConnector`. For `R3BInputConnector`, the return value is a const reference `const T&`. And for `R3BOutputConnector`, the return value is a simple reference `T&`.
+
+Additionally, the `R3BInputConnector` provides iterators to loop through every element in the internal STL container:
+```c++
+// iterate through points using range-based for loop
+for(const auto& point : points_)
+{
+    std::cout << point.energy << std::endl;
+}
+```
+
+**Attention:**
+
+To successfully read and write STL container from/to the root file, the corresponding types must be also declared in the `LinkDef.h` file. For example:
+
+```c++
+#pragma link C++ class R3BNeulandPoint+;
+#pragma link C++ class vector<R3BNeulandPoint>+;
+```
+
+
+## `R3BValueError`
+
+`R3BValueError` is a data structure which contains a value and an error to represent any measurement value with an uncertainty. 
+
+Usage:
+```c++
+const auto distance = R3B::ValueError{1., 0.2}; // represents 1 +/- 0.2
+```
+
+Some basic arithmetic operations are implemented, such as `+`, `*`, `/`, `-`, `-=` and `+=`. For example:
+
+```c++
+const auto v1 = R3B::ValueError{1., 0.2};
+const auto v2 = R3B::ValueError{3., 0.2};
+
+const auto v3 = v1 * v2;
+const auto v4 = v1 / v2;
+const auto v5 = v1 + v2;
+const auto v6 = v1 - v2;
+```
+Error values from the above mentioned operations are calculated using Gaussian error propagation. Therefore, it could be expensive in terms of computations.
+
+## `R3BFileSource2`
+
+`R3BFileSource2` is an improved version of `R3BFileSource` with a much cleaner design using the same interfaces. It also supports reading root files containing just a single root tree.
+
+Usage:
+```c++
+// To add multiple files
+auto file_source = std::make_unique<R3BFileSource2>();
+
+for(auto filename : filenames)
+{
+    file_source->AddFile(std::move(filename));
+}
+run->SetSource(file_source.release()); // if FairRoot version < 19.0.1
+run->SetSource(std::move(file_source)); // if FairRoot version >= 19.0.1
+```
+To add the source files which only contain root trees:
+```c++
+auto file_source = std::make_unique<R3BFileSource2>();
+
+file_source->SetInitRunID(999); // set the run iD
+file_source->SetEnableTreeFile(true);
+
+file_source->AddFile("filename.root");
+```
+Please make sure that the run ID set to file_source is consistent with the run ID from the parameter file.
+
+### Event processing rate printing
+
+`R3BFileSource2` also has a Event processing rate printer, to the set refresh rate of the printer, use
+
+```c++
+file_source->SetEventPrintRefreshRate(2); // 2 Hz
+```
+
+## `R3BDataMonitor`
+
+`R3BDataMonitor` is a histogram/graph manager for tasks based on `FairTask`.
+
+Usage:
+```c++
+class MyTask : public FairTask
+{
+  public:
+    MyTask() = default;
+    auto Init() -> InitStatus override
+    {
+        hist_1d = data_monitor_.add_hist<TH1D>(
+            "module_num", "Counts with module ids", total_bar_num, -0.5, total_bar_num + 0.5);
+
+        hist_2d = data_monitor_.add_hist<TH2D>("TimeLVsBar",
+                                               "Time_vs_bar_left",
+                                               total_bar_num,
+                                               0.5,
+                                               0.5 + total_bar_num,
+                                               BINSIZE_TIME,
+                                               HIST_MIN_TIME,
+                                               HIST_MAX_TIME);
+    }
+
+    void Exec(Option_t* /*option*/) override
+    {
+        hist_1d->Fill(val1);
+        hist_2d->Fill(val2, val3);
+    }
+
+    void FinishTask() override
+    {
+        // Save to the sink file in "DataMonitor/foler_name" folder
+        histograms_.save_to_sink(folder_name);
+    }
+
+  private:
+    R3BDataMonitor data_monitor_;
+    TH1D* hist_1d = nullptr;
+    TH2D* hist_2d = nullptr;
+}
+```
+With `R3BDataMonitor`, all histograms/graphs will be automatically saved and written to the file in the end of the task.
+
+### Output file location
+
+There are two APIs from `R3BDataMonitor` to save histograms/graphs to a local root file:
+
+- `save_to_sink(foldername)`
+  saves all the histograms and graphs to the sink file (obtained from `FairRun::Instance()->GetSink()`). The folder where histograms are located is "DataMonitor/foldername". If the `foldername` is empty or not provided, the location would just be "DataMonitor" folder.
+
+- `save_to_file(filename)`
+  saves all histograms and graphs to an independent root file with the file name `filename`. If the `filename` is empty or not provided, the file would be named with the current data and time.
+
+### Canvases for online monitoring
+
+Histograms and graphs can also be grouped into different canvases (ROOT `TCavnas`). This could happen quite often for the online monitoring using the ROOT `THttp` server.
+
+To create a new canvas and add histograms to it:
+
+```c++
+auto Init() -> InitStatus override
+{
+        auto& canvas = data_monitor_.creat_canvas("canvas name", "canvas title", x, y, a, b);
+        canva.divide(1, 2);
+        hHitEvsBarCosmics_ = canvas.add<1, TH2D>("hHitEvsBarCosmics",
+                                                 "HitLevel: Energy vs Bars cosmics",
+                                                 bar_numbers,
+                                                 -0.5,
+                                                 bar_numbers + 0.5,
+                                                 ENERGY_BIN_SIZE,
+                                                 0,
+                                                 ENERGY_MAX);
+
+        hTdiffvsBarCosmics_ = canvas.add<2, TH2D>("hTdiffvsBarCosmics",
+                                                  "Tdiff vs Bars cosmics",
+                                                  bar_numbers,
+                                                  -0.5,
+                                                  bar_numbers + 0.5,
+                                                  TIME_BIN_SIZE,
+                                                  -ENERGY_MAX,
+                                                  ENERGY_MAX);
+}
+```
+Again, all the histograms and graphs inside each canvas will be automatically saved into the specified folder.
+
+### Canvas interaction with Root `THttp` server class
+
+If the online analysis is based on Root `THttp` server class, `DataMonitor` provides an additional API to register all owning canvases:
+
+```c++
+auto* run = FairRun::Instance();
+data_monitor_.register_canvases(run);
+```

--- a/r3bbase/data_monitor/R3BDataMonitor.cxx
+++ b/r3bbase/data_monitor/R3BDataMonitor.cxx
@@ -1,0 +1,122 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#include "R3BDataMonitor.h"
+#include <FairRootFileSink.h>
+#include <FairRunOnline.h>
+#include <FairRuntimeDb.h>
+#include <fmt/chrono.h>
+#include <fmt/format.h>
+
+namespace
+{
+    auto create_datatime_rootfile(std::string_view base_filename) -> std::unique_ptr<TFile>
+    {
+        auto time = std::chrono::system_clock::now();
+        const auto file_name = fmt::format("{}-{:%Y-%m-%d-%Hh-%Mm-%Ss}.root", base_filename, time);
+        auto* root_file = TFile::Open(file_name.data(), "RECREATE");
+        return std::unique_ptr<TFile>{ root_file };
+    }
+
+} // namespace
+
+namespace R3B
+{
+    void DataMonitor::save_to_sink(std::string_view folderName, FairSink* sinkFile)
+    {
+        auto* hist_dir = get_hist_dir(sinkFile);
+        auto* new_dir = folderName.empty() ? hist_dir : hist_dir->mkdir(folderName.data(), "", true);
+        if (new_dir == nullptr)
+        {
+            throw R3B::runtime_error(
+                fmt::format("Failed to create a sub directory {} for the histrogams!", folderName));
+        }
+        R3BLOG(info,
+               fmt::format("Saving figures to the directory {:?} in the root file {:?}",
+                           folderName,
+                           new_dir->GetFile()->GetName()));
+
+        write_all(new_dir);
+        // old_dir->cd();
+    }
+
+    auto DataMonitor::get_hist_dir(FairSink* sinkFile) -> TDirectory*
+    {
+        auto* rootSinkFile = dynamic_cast<FairRootFileSink*>(sinkFile);
+        if (rootSinkFile == nullptr)
+        {
+            throw R3B::logic_error("Cannot save the histograms as the output file is not a root file!");
+        }
+        auto* rootFile = rootSinkFile->GetRootFile();
+        auto* hist_dir = rootFile->mkdir(DEFAULT_HIST_MONITOR_DIR, "", true);
+        if (hist_dir == nullptr)
+        {
+            throw R3B::runtime_error("Cannot create a directory for the histrogams!");
+        }
+        return hist_dir;
+    }
+
+    void DataMonitor::draw_canvases()
+    {
+        for (auto& [canvas_name, canvas] : canvases_)
+        {
+            canvas.draw();
+        }
+    }
+
+    void DataMonitor::register_canvases(FairRun* run)
+    {
+        if (auto* run_online = dynamic_cast<FairRunOnline*>(run); run_online != nullptr)
+        {
+            for (auto& [name, canvas] : canvases_)
+            {
+                run_online->AddObject(canvas.get_canvas());
+            }
+        }
+    }
+
+    void DataMonitor::reset_all_hists()
+    {
+        for (auto& [name, hist] : histograms_)
+        {
+            hist->Reset();
+        }
+    }
+
+    void DataMonitor::save_to_file(std::string_view filename)
+    {
+        if (filename.empty())
+        {
+            filename = save_filename_;
+        }
+        auto rootfile = create_datatime_rootfile(filename);
+        R3BLOG(info, fmt::format("Saving histograms to {}", rootfile->GetName()));
+        write_all(rootfile.get());
+    }
+
+    void DataMonitor::write_all(TDirectory* dir)
+    {
+        for (auto& [name, hist] : histograms_)
+        {
+            if (hist->GetEntries() == 0)
+            {
+                R3BLOG(warn, fmt::format("Histogram {} is empty while written to the file!", hist->GetName()));
+            }
+            dir->WriteObject(hist.get(), hist->GetName());
+        }
+        for (auto& [name, graph] : graphs_)
+        {
+            dir->WriteObject(graph.get(), graph->GetName(), "overwrite");
+        }
+    }
+} // namespace R3B

--- a/r3bbase/data_monitor/R3BDataMonitor.h
+++ b/r3bbase/data_monitor/R3BDataMonitor.h
@@ -1,0 +1,167 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#pragma once
+
+#include "R3BDataMonitorCanvas.h"
+#include "R3BShared.h"
+#include <FairRun.h>
+#include <R3BException.h>
+#include <map>
+#include <string>
+
+class FairRun;
+
+namespace R3B
+{
+    constexpr auto DEFAULT_HIST_MONITOR_DIR = "DataMonitor";
+    class DataMonitor
+    {
+      public:
+        DataMonitor() = default;
+
+        template <typename... Args>
+        [[nodiscard]] auto create_canvas(std::string_view canvas_name, std::string_view canvas_title, Args&&... args)
+            -> DataMonitorCanvas&;
+
+        // Use R3B::make_hist to create unique_ptr<TH1>
+        [[nodiscard]] auto add_hist(std::unique_ptr<TH1> hist) -> TH1*
+        {
+            return add_to_map(std::move(hist), histograms_);
+        }
+
+        template <typename Hist, typename... Args>
+        [[nodiscard]] auto add_hist(std::string_view histName, std::string_view histTitle, Args&&... args) -> Hist*;
+
+        template <typename GraphType>
+        [[nodiscard]] auto add_graph(std::string_view graph_name, std::unique_ptr<GraphType> graph) -> GraphType*
+        {
+            graph->SetName(graph_name.data());
+            return add_to_map(std::move(graph), graphs_);
+        }
+
+        template <typename... Args>
+        [[nodiscard]] auto add_graph(std::string_view graph_name, Args&&... args) -> TGraph*
+        {
+            return add_graph(graph_name, std::make_unique<TGraph>(std::forward<Args>(args)...));
+        }
+
+        // Save plots to FairSink
+        void save_to_sink(std::string_view folderName = "", FairSink* sinkFile = FairRun::Instance()->GetSink());
+        // Save plots to any root file
+        void save_to_file(std::string_view filename = "");
+
+        // Used for online monitoring
+        void draw_canvases();
+        void register_canvases(FairRun* run);
+        void reset_all_hists();
+
+      private:
+        std::string save_filename_{ "histograms_save" };
+        std::map<std::string, std::unique_ptr<TH1>> histograms_;
+        std::map<std::string, std::unique_ptr<TGraph>> graphs_;
+        std::map<std::string, DataMonitorCanvas> canvases_;
+        static auto get_hist_dir(FairSink* sinkFile) -> TDirectory*;
+        void write_all(TDirectory* dir);
+
+        template <typename ElementType, typename ContainerType>
+        static auto add_to_map(std::unique_ptr<ElementType> element, ContainerType& container) -> ElementType*;
+        template <typename ElementType, typename ContainerType>
+        static auto add_to_vector(std::unique_ptr<ElementType> element, ContainerType& container) -> ElementType*
+        {
+            auto* ptr = element.get();
+            container.emplace_back(std::move(element));
+            return ptr;
+        }
+    };
+
+    template <typename ElementType, typename ContainerType>
+    auto DataMonitor::add_to_map(std::unique_ptr<ElementType> element, ContainerType& container) -> ElementType*
+    {
+        const auto* element_name = element->GetName();
+        auto* element_ptr = element.get();
+        const auto [it, is_success] = container.emplace(std::string{ element_name }, std::move(element));
+        if (not is_success)
+        {
+            throw R3B::logic_error(fmt::format(
+                "Element with the name {} has been already added. Please use different name!", element_name));
+        }
+        return element_ptr;
+    }
+
+    template <typename Hist, typename... Args>
+    auto DataMonitor::add_hist(std::string_view histName, std::string_view histTitle, Args&&... args) -> Hist*
+    {
+        auto hist = R3B::make_hist<Hist>(histName.data(), histTitle.data(), std::forward<Args>(args)...);
+        return static_cast<Hist*>(add_hist(std::move(hist)));
+    }
+
+    template <typename... Args>
+    auto DataMonitor::create_canvas(std::string_view canvas_name, std::string_view canvas_title, Args&&... args)
+        -> DataMonitorCanvas&
+    {
+        if (canvases_.find(std::string{ canvas_name }) != canvases_.end())
+        {
+            throw R3B::logic_error(fmt::format(
+                "A canvas with the name {} has been already added. Please use different name!", canvas_name));
+        }
+        const auto [it, is_success] = canvases_.insert(
+            { std::string{ canvas_name }, DataMonitorCanvas(this, canvas_name.data(), canvas_title.data(), args...) });
+        return it->second;
+    }
+
+    template <typename... Args>
+    DataMonitorCanvas::DataMonitorCanvas(DataMonitor* monitor, Args&&... args)
+        : monitor_{ monitor }
+        , canvas_(std::make_unique<TCanvas>(std::forward<Args>(args)...))
+    {
+    }
+
+    template <int div_num, typename ElementType, typename... Args>
+    constexpr auto DataMonitorCanvas::add(Args&&... args) -> CanvasElement<ElementType>
+    {
+        static_assert(div_num > 0, "Division number of the histogram must be larger than 0!");
+        return add<ElementType>(div_num, std::forward<Args>(args)...);
+    }
+
+    template <typename ElementType, typename... Args>
+    constexpr auto DataMonitorCanvas::add(int div_num, Args&&... args) -> CanvasElement<ElementType>
+    {
+        ElementType* figure = nullptr;
+        if constexpr (std::is_same_v<TGraph, ElementType>)
+        {
+            figure = monitor_->add_graph<ElementType>(std::forward<Args>(args)...);
+        }
+        else
+        {
+            figure = monitor_->add_hist<ElementType>(std::forward<Args>(args)...);
+        }
+
+        if (figures_.find(div_num) != figures_.end())
+        {
+            figures_[div_num].emplace_back(figure);
+        }
+        else
+        {
+            figures_.emplace(div_num, std::vector<DrawableElementPtr>{ figure });
+        }
+        if constexpr (std::is_base_of_v<TH2, ElementType>)
+        {
+            const auto* option = figure->GetOption();
+            figure->SetOption(fmt::format("{} COLZ", option).c_str());
+        }
+        auto* pad = canvas_->GetPad(div_num);
+        return CanvasElement{ figure, pad };
+    }
+
+} // namespace R3B

--- a/r3bbase/data_monitor/R3BDataMonitorCanvas.cxx
+++ b/r3bbase/data_monitor/R3BDataMonitorCanvas.cxx
@@ -1,0 +1,62 @@
+#include "R3BDataMonitorCanvas.h"
+
+template <typename T>
+using remove_const_ref = std::remove_const_t<std::remove_reference_t<T>>;
+
+namespace R3B
+{
+    DataMonitorCanvas::DataMonitorCanvas(DataMonitor* monitor)
+        : monitor_{ monitor }
+    {
+    }
+
+    void DataMonitorCanvas::draw()
+    {
+        for (auto& [div_num, figures] : figures_)
+        {
+            canvas_->cd(div_num);
+            for (auto iter = figures.begin(); iter != figures.end(); ++iter)
+            {
+                auto is_first = (iter == figures.begin());
+                std::visit(
+                    [is_first](auto& figure)
+                    {
+                        const auto* option = figure->GetOption();
+                        if (is_first)
+                        {
+
+                            figure->Draw(option);
+                        }
+                        else
+                        {
+                            figure->Draw(fmt::format("same {}", option).c_str());
+                        }
+                    },
+                    *iter);
+            }
+        }
+    }
+
+    void DataMonitorCanvas::reset()
+    {
+        for (auto& [div_num, hists] : figures_)
+        {
+            for (auto& hist : hists)
+            {
+                std::visit(
+                    [](auto& figure)
+                    {
+                        if constexpr (std::is_same_v<TGraph*, remove_const_ref<decltype(figure)>>)
+                        {
+                            figure->Set(0);
+                        }
+                        else if constexpr (std::is_same_v<TH1*, remove_const_ref<decltype(figure)>>)
+                        {
+                            figure->Reset();
+                        }
+                    },
+                    hist);
+            }
+        }
+    }
+} // namespace R3B

--- a/r3bbase/data_monitor/R3BDataMonitorCanvas.h
+++ b/r3bbase/data_monitor/R3BDataMonitorCanvas.h
@@ -1,0 +1,77 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2023 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+#pragma once
+#include <TCanvas.h>
+#include <TGraph.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <fmt/core.h>
+#include <variant>
+
+namespace R3B
+{
+    class DataMonitor;
+
+    template <typename ElementType>
+    class CanvasElement
+    {
+
+      public:
+        CanvasElement() = default;
+        CanvasElement(ElementType* element, TVirtualPad* pad)
+            : element_{ element }
+            , pad_{ pad }
+        {
+        }
+        auto* get() { return element_; }
+        auto* operator->() { return element_; }
+        auto* pad() { return pad_; }
+
+      private:
+        ElementType* element_ = nullptr;
+        TVirtualPad* pad_ = nullptr;
+    };
+
+    class DataMonitorCanvas
+    {
+      public:
+        using DrawableElementPtr = std::variant<TH1*, TGraph*>;
+        explicit DataMonitorCanvas(DataMonitor* monitor);
+
+        template <typename... Args>
+        explicit DataMonitorCanvas(DataMonitor* monitor, Args&&... args);
+
+        template <int div_num = 1, typename ElementType, typename... Args>
+        [[nodiscard]] constexpr auto add(Args&&... args) -> CanvasElement<ElementType>;
+
+        template <typename ElementType, typename... Args>
+        [[nodiscard]] constexpr auto add(int div_num, Args&&... args) -> CanvasElement<ElementType>;
+
+        template <typename... Args>
+        void divide(Args&&... args)
+        {
+            canvas_->Divide(args...);
+        }
+
+        auto get_canvas() -> TCanvas* { return canvas_.get(); }
+
+        void draw();
+        void reset();
+
+      private:
+        DataMonitor* monitor_ = nullptr;
+        std::unique_ptr<TCanvas> canvas_;
+        std::map<int, std::vector<DrawableElementPtr>> figures_;
+    };
+} // namespace R3B


### PR DESCRIPTION
### Features

* Adding a new class `R3BDataMonitor`, a histogram manager, that could be used inside a task class.
* Adding a new class `R3BValueError`, a numeric data structure to represent physical values with errors. Popular operations, such as `+`, `-`, `/`, `*` are implemented.
* Update on `R3BFileSource2` such that it can read a root file just containing a root tree. (_todo: need a test_)

This pull request is second part of the PR #890 .

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
