### PR TITLE
[FIX] Fix CMake configuration when GoogleTest doesn't exist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,7 +294,7 @@ if(CONAN_ENABLED)
         CACHE BOOL "disable implicit conversion of JSON" FORCE)
 endif()
 
-find_package(GTest REQUIRED)
+find_package2(PRIVATE GTest)
 find_package2(PUBLIC Pythia6)
 find_package2(PUBLIC Pythia8)
 find_package2(PUBLIC Protobuf)

--- a/cmake/CI_CD/configure_options.cmake
+++ b/cmake/CI_CD/configure_options.cmake
@@ -1,3 +1,6 @@
+# set required packages for CI test
+set(CMAKE_REQUIRE_FIND_PACKAGE_GTest TRUE)
+
 find_program(CCACHE "ccache")
 if(CCACHE)
     message("enable ccache for cmake build")


### PR DESCRIPTION
Remove `REQUIRED` from `find_package` of GTest.

Fix #1080

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
