### PR TITLE
Change to boost::process::v2 in UcesbLauncher

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,4 @@
+Diagnostics:
+  UnusedIncludes: Strict
+  MissingIncludes: Strict
+  AnalyzeAngledIncludes: Yes

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# R3BRoot Software [![license](https://alfa-ci.gsi.de/shields/badge/license-GPL--3.0-orange.svg)](COPYRIGHT) 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5549469.svg)](https://doi.org/10.5281/zenodo.5549469) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9851/badge)](https://www.bestpractices.dev/projects/9851) [![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B%20%20%E2%97%8F%20%20%E2%97%8B-yellow)](https://fair-software.eu)
-
-[![CI-CD](https://github.com/R3BRootGroup/R3BRoot/actions/workflows/main.yml/badge.svg)](https://github.com/R3BRootGroup/R3BRoot/actions/workflows/main.yml) [![Static Analysis](https://github.com/R3BRootGroup/R3BRoot/actions/workflows/static_analysis.yml/badge.svg)](https://github.com/R3BRootGroup/R3BRoot/actions/workflows/static_analysis.yml) [![Validate Codemeta](https://github.com/R3BRootGroup/R3BRoot/actions/workflows/codemeta_validate.yaml/badge.svg)](https://github.com/R3BRootGroup/R3BRoot/actions/workflows/codemeta_validate.yaml) [![Cleanup Caches on PR Close](https://github.com/R3BRootGroup/R3BRoot/actions/workflows/cleanup_cache.yml/badge.svg)](https://github.com/R3BRootGroup/R3BRoot/actions/workflows/cleanup_cache.yml)
+# R3BRoot Software [![license](https://img.shields.io/badge/License-GPLv3-blue.svg)](COPYRIGHT) 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5549469.svg)](https://doi.org/10.5281/zenodo.5549469)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9851/badge)](https://www.bestpractices.dev/projects/9851)
+[![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B%20%20%E2%97%8F%20%20%E2%97%8B-yellow)](https://fair-software.eu)
+[![CI-CD](https://github.com/R3BRootGroup/R3BRoot/actions/workflows/main.yml/badge.svg)](https://github.com/R3BRootGroup/R3BRoot/actions/workflows/main.yml)
+[![Static Analysis](https://github.com/R3BRootGroup/R3BRoot/actions/workflows/static_analysis.yml/badge.svg)](https://github.com/R3BRootGroup/R3BRoot/actions/workflows/static_analysis.yml)
+[![Validate Codemeta](https://github.com/R3BRootGroup/R3BRoot/actions/workflows/codemeta_validate.yaml/badge.svg)](https://github.com/R3BRootGroup/R3BRoot/actions/workflows/codemeta_validate.yaml)
+[![dashboard](https://img.shields.io/badge/dashboard-r3broot-blue?labelColor=gray&style=flat)](https://cdash.gsi.de/index.php?project=R3BRoot)
 
 ## The R3BRoot Framework
 

--- a/califa/CMakeLists.txt
+++ b/califa/CMakeLists.txt
@@ -39,7 +39,7 @@ add_library_with_dictionary(
     calibration
     ana
     DEPENDENCIES
-    Spectrum
+    ROOT::Spectrum
     R3BPassive)
 
 if(BUILD_GEOMETRY)

--- a/r3bsource/CMakeLists.txt
+++ b/r3bsource/CMakeLists.txt
@@ -190,6 +190,7 @@ set(STRUCT_HEADERS
 
 set(HEADERS
     base/R3BUcesbSource.h
+    base/R3BUcesbSource2.h
     base/R3BReader.h
     base/R3BUnpackReader.h
     base/utils/R3BUcesbDecl.h

--- a/r3bsource/SourceLinkDef.h
+++ b/r3bsource/SourceLinkDef.h
@@ -20,6 +20,7 @@
 #pragma link off all functions;
 
 #pragma link C++ class R3BUcesbSource+;
+#pragma link C++ class R3B::UcesbSource+;
 #pragma link C++ class R3BReader+;
 #pragma link C++ class R3BUnpackReader+;
 #pragma link C++ class R3BWhiterabbitNeulandReader+;

--- a/r3bsource/base/R3BUcesbSource2.cxx
+++ b/r3bsource/base/R3BUcesbSource2.cxx
@@ -12,18 +12,46 @@
  ******************************************************************************/
 
 #include "R3BUcesbSource2.h"
+#include "R3BUcesbLauncher.h"
 #include <FairRootManager.h>
 #include <FairRun.h>
 #include <R3BEventHeader.h>
 #include <R3BException.h>
-#include <R3BLogger.h>
 #include <R3BUcesbDecl.h>
+#include <array>
 #include <boost/core/span.hpp>
+#include <cstddef>
+#include <cstdint>
 #include <ext_data_client.h>
+#include <fairlogger/Logger.h>
+#include <fmt/core.h>
 #include <fmt/format.h>
+#include <string_view>
+#include <sys/types.h>
+#include <utility>
 
 namespace R3B
 {
+    namespace
+    {
+        void print_uint32_with_size(const uint32_t* data, ssize_t size)
+        {
+            // TODO: use ranges library instead of reinterpret_cast
+            constexpr auto column_size = 8;
+            using SubDataType = const std::array<uint32_t, column_size>;
+
+            auto data_span = boost::span<SubDataType>(reinterpret_cast<SubDataType*>(data), size / column_size);
+            LOGP(info, "Raw data:");
+            auto index = uint32_t{};
+            for (const auto& row_data : data_span)
+            {
+                fmt::print("RAW{0:04x}: {1:08x}\n", index, fmt::join(row_data, " "));
+                index += column_size;
+            }
+        }
+
+    } // namespace
+
     UcesbSource::UcesbSource(std::string_view lmdfile_name,
                              std::string_view ntuple_options,
                              std::string_view ucesb_path,
@@ -53,7 +81,7 @@ namespace R3B
         {
             command_string = fmt::format("{} --max-events={}", command_string, max_event_num_);
         }
-        R3BLOG(info, fmt::format("Calling ucesb with command: {}", command_string));
+        LOGP(info, "Calling ucesb with command: {}", command_string);
 
         ucesb_server_launcher_.Launch(std::move(command_string));
     }
@@ -62,13 +90,13 @@ namespace R3B
     {
         if (auto* frm = FairRootManager::Instance(); frm != nullptr)
         {
-            R3BLOG(debug, "Checking the register of R3BEventHeader");
+            LOGP(debug, "Checking the register of R3BEventHeader");
             if (event_header_ = dynamic_cast<R3BEventHeader*>(frm->GetObject("EventHeader.")); event_header_ == nullptr)
             {
                 throw R3B::runtime_error("EventHeader. was not defined properly!");
             }
         }
-        R3BLOG(debug, "EventHeader. was defined properly");
+        LOGP(debug, "EventHeader. was defined properly");
 
         init_readers();
         setup_ucesb();
@@ -89,7 +117,7 @@ namespace R3B
         }
         else
         {
-            R3BLOG(error, "ext_data_clnt::setup() failed");
+            LOGP(error, "ext_data_clnt::setup() failed");
             const auto* msg = (ucesb_client_.last_error() == nullptr) ? UCESB_NULL_STR_MSG : ucesb_client_.last_error();
             throw R3B::runtime_error(fmt::format("UCESB error: {}", msg));
         }
@@ -104,34 +132,18 @@ namespace R3B
         }
         else if (ret_val == 0)
         {
-            R3BLOG(info, "Reached the maximal event num on the ucesb server.");
+            LOGP(info, "Reached the maximal event num on the ucesb server.");
             // ending event loop here
             return 1;
         }
         else
         {
-            R3BLOG(error, "ext_data_clnt::fetch_event() failed");
+            LOGP(error, "ext_data_clnt::fetch_event() failed");
             const auto* msg = (ucesb_client_.last_error() == nullptr) ? UCESB_NULL_STR_MSG : ucesb_client_.last_error();
             throw R3B::runtime_error(fmt::format("UCESB error: {}", msg));
         }
 
         return 0;
-    }
-
-    void print_uint32_with_size(const uint32_t* data, ssize_t size)
-    {
-        // TODO: use ranges library instead of reinterpret_cast
-        constexpr auto column_size = 8;
-        using SubDataType = const std::array<uint32_t, column_size>;
-
-        auto data_span = std::span<SubDataType>(reinterpret_cast<SubDataType*>(data), size / column_size);
-        R3BLOG(info, "Raw data:");
-        auto index = uint32_t{};
-        for (const auto& row_data : data_span)
-        {
-            fmt::print("RAW{0:04x}: {1:08x}\n", index, fmt::join(row_data, " "));
-            index += column_size;
-        }
     }
 
     void UcesbSource::print_raw_data()
@@ -151,7 +163,7 @@ namespace R3B
         }
         else
         {
-            R3BLOG(error, "ext_data_clnt::get_raw_data()");
+            LOGP(error, "ext_data_clnt::get_raw_data()");
             throw R3B::runtime_error("Failed to get raw data.");
         }
     }
@@ -166,17 +178,17 @@ namespace R3B
 
         if (run_id_ != 0)
         {
-            R3BLOG(info, fmt::format("Setting the run ID of the FairRun to be {} from FairSource", run_id_));
+            LOGP(info, "Setting the run ID of the FairRun to be {} from FairSource", run_id_);
             run->SetRunId(run_id_);
         }
         else if (auto run_id = run->GetRunId(); run_id != 0)
         {
-            R3BLOG(info, fmt::format("Setting the run ID of the FairSource to be {} from FairRun", run_id));
+            LOGP(info, "Setting the run ID of the FairSource to be {} from FairRun", run_id);
             run_id_ = run_id;
         }
         else
         {
-            R3BLOG(warn, "Run ID of neither FairRun nor FairSource is set!");
+            LOGP(warn, "Run ID of neither FairRun nor FairSource is set!");
         }
     }
 

--- a/r3bsource/base/R3BUcesbSource2.h
+++ b/r3bsource/base/R3BUcesbSource2.h
@@ -18,7 +18,13 @@
 #include <R3BUcesbLauncher.h>
 #include <R3BUcesbMappingFlag.h>
 #include <R3BUcesbStructInfo.h>
+#include <Rtypes.h>
+#include <cstddef>
 #include <ext_data_clnt.hh>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
 
 struct EXT_STR_h101_t;
 using EventStructType = EXT_STR_h101_t;
@@ -59,10 +65,10 @@ namespace R3B
         auto AddReader(Args&&... args) -> ReaderType*;
         // TODO: C++20 concepts
         template <typename UnaryOp>
-        void ForEachReader(UnaryOp&& opt);
+        void ForEachReader(UnaryOp opt);
 
         template <typename Predicate>
-        auto FindReaderIf(Predicate&& pred) -> R3BReader*;
+        auto FindReaderIf(Predicate pred) -> R3BReader*;
 
         // deprecate the old API because of bad memory managerment
         [[deprecated("Please use smart pointer method to add a reader")]] auto* AddReader(R3BReader* a_reader)
@@ -115,7 +121,7 @@ namespace R3B
         Source_Type GetSourceType() override { return kONLINE; }
 
       public:
-        ClassDefInlineOverride(R3B::UcesbSource, 1);
+        ClassDefOverride(R3B::UcesbSource, 1);
     };
 
     template <typename ReaderType>
@@ -133,7 +139,7 @@ namespace R3B
     }
 
     template <typename UnaryOp>
-    void UcesbSource::ForEachReader(UnaryOp&& opt)
+    void UcesbSource::ForEachReader(UnaryOp opt)
     {
         for (auto& reader : readers_)
         {
@@ -142,7 +148,7 @@ namespace R3B
     }
 
     template <typename Predicate>
-    auto UcesbSource::FindReaderIf(Predicate&& pred) -> R3BReader*
+    auto UcesbSource::FindReaderIf(Predicate pred) -> R3BReader*
     {
         auto res = std::find_if(readers_.begin(), readers_.end(), [&pred](auto& reader) { return pred(reader.get()); });
         return (res == readers_.end()) ? nullptr : res->get();

--- a/r3bsource/base/utils/R3BUcesbLauncher.cxx
+++ b/r3bsource/base/utils/R3BUcesbLauncher.cxx
@@ -14,12 +14,30 @@
 #include "R3BUcesbLauncher.h"
 #include <R3BException.h>
 #include <R3BLogger.h>
+#include <algorithm>
 #include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/constants.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/process/v2/process.hpp>
+#include <boost/process/v2/stdio.hpp>
+#include <chrono>
+#include <cstddef>
+#include <fairlogger/Logger.h>
 #include <filesystem>
+#include <fmt/core.h>
+#include <fmt/format.h>
 #include <fmt/os.h>
+#include <memory>
 #include <regex>
 
 #include <ext_data_clnt.hh>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
 
 constexpr auto CHILD_CLOSE_WAITING_TIME = std::chrono::seconds(5);
 
@@ -162,9 +180,12 @@ namespace R3B
                            launch_strings.executable,
                            fmt::join(launch_args, " ")));
 
-        ucesb_server_ = std::make_unique<boost::process::child>(
-            launch_strings.executable, boost::process::args(launch_args), boost::process::std_out > server_pipe_);
-        if (auto is_status_ok = client_->connect(server_pipe_.native_source()); not is_status_ok)
+        ucesb_server_ =
+            std::make_unique<bpv2::process>(ios_,
+                                            launch_strings.executable,
+                                            launch_args,
+                                            bpv2::process_stdio{ .in = nullptr, .out = server_pipe_, .err = stdout });
+        if (auto is_status_ok = client_->connect(server_pipe_.native_handle()); not is_status_ok)
         {
             R3BLOG(error, "ext_data_clnt::connect() failed");
             const auto* msg = (client_->last_error() == nullptr) ? UCESB_NULL_STR_MSG : client_->last_error();
@@ -181,15 +202,15 @@ namespace R3B
             throw R3B::runtime_error("ext_data_clnt::close() failed");
         }
         auto err_code = std::error_code{};
-        if (not ucesb_server_->wait_for(CHILD_CLOSE_WAITING_TIME, err_code))
-        {
-            R3BLOG(warn, fmt::format("Failed to close Ucesb server! Error code: {}", err_code.value()));
-            ucesb_server_->terminate(err_code);
-            R3BLOG(warn, "Killing Ucesb server");
-        }
-        else
-        {
-            R3BLOG(info, "Ucesb server is closed successfully");
-        }
+        ucesb_server_->async_wait(
+            [](const std::error_code& err, int ret)
+            {
+                if (err)
+                {
+                    LOGP(error, "Error occured from ucesb server. Error message: {}", err.message());
+                }
+                LOGP(info, "Ucesb server is closed successfully with the return value: {}", ret);
+            });
+        ios_.run_for(CHILD_CLOSE_WAITING_TIME);
     }
 } // namespace R3B

--- a/r3bsource/base/utils/R3BUcesbLauncher.h
+++ b/r3bsource/base/utils/R3BUcesbLauncher.h
@@ -13,10 +13,17 @@
  * or submit itself to any jurisdiction.                                      *
  ******************************************************************************/
 #include <boost/asio.hpp>
-#include <boost/process.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/readable_pipe.hpp>
+#include <boost/process/v2/process.hpp>
+#include <cstddef>
 #include <ext_data_clnt.hh>
+#include <memory>
+#include <string>
 
 constexpr auto UCESB_NULL_STR_MSG = "Can't retrieve error message as last_error returns nullptr!";
+
+namespace bpv2 = boost::process::v2;
 
 namespace R3B
 {
@@ -33,9 +40,9 @@ namespace R3B
 
       private:
         ext_data_clnt* client_ = nullptr;
-        std::unique_ptr<boost::process::child> ucesb_server_;
+        std::unique_ptr<bpv2::process> ucesb_server_;
         boost::asio::io_service ios_;
-        boost::process::async_pipe server_pipe_{ ios_ };
+        boost::asio::readable_pipe server_pipe_{ ios_ };
     };
 
 } // namespace R3B


### PR DESCRIPTION
Use boost process v2 instead in UcesbLauncher class. This removes the deprecation of `wait_for` method of `Boost::process::child`.

Boost process v2 utilizes the asynchronous execution from Boost::asio, which is really nice for closing a subprocess. `async_pipe` is also changed to `readable_pipe` in `Boost::process::v2`.

UPDATE:

Add a new badge for cdash link and remove/fix the broken badges.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
