### PR TITLE
New features for the online of FOOT and Alpide

### DIFF
--- a/alpide/online/R3BAlpideOnlineSpectra.cxx
+++ b/alpide/online/R3BAlpideOnlineSpectra.cxx
@@ -179,7 +179,8 @@ InitStatus R3BAlpideOnlineSpectra::Init()
         }
         mainfol->Add(calfol);
 
-        fh1_Calmult_total = R3B::root_owned<TH1F>("fh1_mulcal_sensor_total", "Cal_mult for all sensors", 70, 0, 70);
+        fh1_Calmult_total =
+            R3B::root_owned<TH1F>("fh1_mulcal_sensor_total", "Cal_mult for all sensors", 70, -0.5, 69.5);
         fh1_Calmult_total->GetXaxis()->SetTitle("Pixel multiplicity");
         fh1_Calmult_total->GetYaxis()->SetTitle("Counts");
         fh1_Calmult_total->GetYaxis()->SetTitleOffset(1.1);
@@ -231,7 +232,7 @@ InitStatus R3BAlpideOnlineSpectra::Init()
             cHit->Divide(2, 1);
             sprintf(Name1, "fh2_pos_hit_sensor_%d", s + 1);
             sprintf(Name2, "Hit-position for sensor: %d", s + 1);
-            fh2_PosHit[s] = R3B::root_owned<TH2F>(Name1, Name2, 200, -15.0, 15.0, 100, -7.5, 7.5);
+            fh2_PosHit[s] = R3B::root_owned<TH2F>(Name1, Name2, 200, 0, 30., 100, 0, 15.);
             fh2_PosHit[s]->GetXaxis()->SetTitle("Posl [mm]");
             fh2_PosHit[s]->GetYaxis()->SetTitle("Post [mm]");
             fh2_PosHit[s]->GetYaxis()->SetTitleOffset(1.1);
@@ -270,6 +271,34 @@ InitStatus R3BAlpideOnlineSpectra::Init()
             fh1_Clustermult[s]->Draw();
             hitfol->Add(cHitm);
         }
+
+        auto cHitmTot = new TCanvas("Cluster_multiplicity_total", "mult hit info", 10, 10, 500, 500);
+        fh1_Clustermult_total =
+            R3B::root_owned<TH1F>("Cluster_multiplicity_total", "Total cluster multiplicity", 60, 0, 60);
+        fh1_Clustermult_total->GetXaxis()->SetTitle("Cluster multiplicity");
+        fh1_Clustermult_total->GetYaxis()->SetTitle("Counts");
+        fh1_Clustermult_total->GetYaxis()->SetTitleOffset(1.1);
+        fh1_Clustermult_total->GetXaxis()->CenterTitle(true);
+        fh1_Clustermult_total->GetYaxis()->CenterTitle(true);
+        fh1_Clustermult_total->SetLineColor(1);
+        fh1_Clustermult_total->SetFillColor(31);
+        cHitmTot->cd();
+        fh1_Clustermult_total->Draw();
+        hitfol->Add(cHitmTot);
+
+        auto cSizemTot = new TCanvas("Size_multiplicity_total", "size hit info", 10, 10, 500, 500);
+        fh1_Clustersize_total = R3B::root_owned<TH1F>("Size_multiplicity_total", "Total size multiplicity", 60, 0, 60);
+        fh1_Clustersize_total->GetXaxis()->SetTitle("Size multiplicity");
+        fh1_Clustersize_total->GetYaxis()->SetTitle("Counts");
+        fh1_Clustersize_total->GetYaxis()->SetTitleOffset(1.1);
+        fh1_Clustersize_total->GetXaxis()->CenterTitle(true);
+        fh1_Clustersize_total->GetYaxis()->CenterTitle(true);
+        fh1_Clustersize_total->SetLineColor(1);
+        fh1_Clustersize_total->SetFillColor(31);
+        cSizemTot->cd();
+        fh1_Clustersize_total->Draw();
+        hitfol->Add(cSizemTot);
+
         mainfol->Add(hitfol);
 
         cHit_angcor = new TCanvas("Theta_vs_Phi", "Correlation theta vs phi", 10, 10, 500, 500);
@@ -458,8 +487,16 @@ void R3BAlpideOnlineSpectra::Reset_Histo()
         {
             hist->Reset();
         }
+
         fh2_theta_phi->Reset();
         fh2_max_clusters->Reset();
+
+        for (auto& hist : fh2_y_x)
+        {
+            hist->Reset();
+        }
+        fh1_Clustermult_total->Reset();
+        fh1_Clustersize_total->Reset();
     }
 
     return;
@@ -539,6 +576,7 @@ void R3BAlpideOnlineSpectra::Exec(Option_t* /*option*/)
         std::vector<double> y_max(2, NAN);
         std::vector<int> cls_size(2, 0);
 
+        fh1_Clustermult_total->Fill(nHits);
         for (size_t ihit = 0; ihit < nHits; ihit++)
         {
             auto hit = dynamic_cast<R3BAlpideHitData*>(fHitItems->At(ihit));
@@ -547,6 +585,7 @@ void R3BAlpideOnlineSpectra::Exec(Option_t* /*option*/)
             auto senid = hit->GetSensorId() - 1;
             fh1_Clustersize[senid]->Fill(hit->GetClusterSize());
             fh2_PosHit[senid]->Fill(hit->GetPosl(), hit->GetPost());
+            fh1_Clustersize_total->Fill(hit->GetClusterSize());
             if (fMap_Par->GetGeoVersion() == 202505)
             {
                 fh2_theta_phi->Fill(hit->GetPhi() * TMath::RadToDeg(), hit->GetTheta() * TMath::RadToDeg());
@@ -575,6 +614,7 @@ void R3BAlpideOnlineSpectra::Exec(Option_t* /*option*/)
                     }
                 }
             }
+
             mult[senid]++;
         }
         for (size_t s = 0; s < fNbSensors; s++)
@@ -585,12 +625,16 @@ void R3BAlpideOnlineSpectra::Exec(Option_t* /*option*/)
         {
             if (std::isfinite(x_max[0]) && std::isfinite(x_max[1]))
                 fh2_y_x_cor_det[0]->Fill(x_max[0], x_max[1]);
+
             if (std::isfinite(y_max[0]) && std::isfinite(y_max[1]))
                 fh2_y_x_cor_det[1]->Fill(y_max[0], y_max[1]);
+
             if (std::isfinite(x_max[0]) && std::isfinite(y_max[1]))
                 fh2_y_x_cor_det[2]->Fill(x_max[0], y_max[1]);
-            if (std::isfinite(x_max[2]) && std::isfinite(y_max[0]))
+
+            if (std::isfinite(x_max[1]) && std::isfinite(y_max[0]))
                 fh2_y_x_cor_det[3]->Fill(x_max[1], y_max[0]);
+
             if (cls_size[0] > 0 && cls_size[1] > 0)
                 fh2_max_clusters->Fill(cls_size[0], cls_size[1]);
         }
@@ -639,6 +683,7 @@ void R3BAlpideOnlineSpectra::FinishTask()
     if (fHitItems)
     {
         fh2_theta_phi->Write();
+
         fh2_max_clusters->Write();
         for (const auto& hist : fh2_y_x)
         {
@@ -648,6 +693,9 @@ void R3BAlpideOnlineSpectra::FinishTask()
         {
             hist->Write();
         }
+
+        fh1_Clustermult_total->Write();
+        fh1_Clustersize_total->Write();
     }
 }
 ClassImp(R3BAlpideOnlineSpectra)

--- a/alpide/online/R3BAlpideOnlineSpectra.h
+++ b/alpide/online/R3BAlpideOnlineSpectra.h
@@ -125,6 +125,9 @@ class R3BAlpideOnlineSpectra : public FairTask
     std::vector<TH2F*> fh2_y_x_cor_det;
     TH2F* fh2_max_clusters;
 
+    TH1F* fh1_Clustermult_total;
+    TH1F* fh1_Clustersize_total;
+
     TCanvas* cCalPixelSize = nullptr;
     TCanvas* cHit_angcor = nullptr;
 

--- a/ssd/CMakeLists.txt
+++ b/ssd/CMakeLists.txt
@@ -35,10 +35,11 @@ set(SRCS
     calibration/R3BAmsStripCal2Hit.cxx
     online/R3BAmsOnlineSpectra.cxx
     online/R3BAmsCalifaCorrelatedOnlineSpectra.cxx
+    online/R3BFootVsAlpideOnlineSpectra.cxx
     online/R3BFootOnlineSpectra.cxx
     pars/R3BFootMappingPar.cxx
     pars/R3BFootCalPar.cxx
-    pars/R3BFootHitPar.cxx
+	pars/R3BFootHitPar.cxx
     calibration/R3BFootMapped2StripCal.cxx
     calibration/R3BFootStripCal2Hit.cxx)
 
@@ -66,10 +67,11 @@ set(HEADERS
     calibration/R3BAmsStripCal2Hit.h
     online/R3BAmsOnlineSpectra.h
     online/R3BAmsCalifaCorrelatedOnlineSpectra.h
+	online/R3BFootVsAlpideOnlineSpectra.h
     online/R3BFootOnlineSpectra.h
     pars/R3BFootMappingPar.h
     pars/R3BFootCalPar.h
-    pars/R3BFootHitPar.h
+	pars/R3BFootHitPar.h
     calibration/R3BFootMapped2StripCal.h
     calibration/R3BFootStripCal2Hit.h)
 

--- a/ssd/SsdLinkDef.h
+++ b/ssd/SsdLinkDef.h
@@ -43,6 +43,7 @@
 #pragma link C++ class R3BAmsStripCal2Hit+;
 #pragma link C++ class R3BAmsOnlineSpectra+;
 #pragma link C++ class R3BAmsCalifaCorrelatedOnlineSpectra+;
+#pragma link C++ class R3BFootVsAlpideOnlineSpectra;
 #pragma link C++ class vector<R3B::DetectorMappedData>+;
 
 #pragma link C++ class R3BFootMappingPar+;

--- a/ssd/calibration/R3BFootMapped2StripCal.cxx
+++ b/ssd/calibration/R3BFootMapped2StripCal.cxx
@@ -294,6 +294,13 @@ void R3BFootMapped2StripCal::SetPedestals(Int_t thr, TString conf)
                 Float_t ped = h1_peds->GetBinContent(istrip + 1);
                 Float_t sig = h1_sigma->GetBinContent(istrip + 1);
 
+                // Do not update dead strip
+                if (sigmas[iDet][istrip] == -1)
+                {
+                    sig = -1.;
+                    ped = -1.;
+                }
+
                 sigmas[iDet][istrip] = sig;
                 pedestals[iDet][istrip] = ped;
 
@@ -312,7 +319,16 @@ void R3BFootMapped2StripCal::SetPedestals(Int_t thr, TString conf)
                 fine_sigmas[iDet][istrip] = h1_sigma->GetBinContent(istrip + 1);
                 fCal_Par->SetFineSigma(fine_sigmas[iDet][istrip], iDet * fNStrip + istrip);
                 fCal_Par->setChanged(kTRUE);
-                sigmas[iDet][istrip] = fine_sigmas[iDet][istrip];
+                Float_t sig;
+                if (sigmas[iDet][istrip] == -1)
+                {
+                    sig = -1.;
+                }
+                else
+                {
+                    sig = fine_sigmas[iDet][istrip];
+                }
+                sigmas[iDet][istrip] = sig;
             }
         }
 
@@ -423,7 +439,7 @@ void R3BFootMapped2StripCal::Exec(Option_t* /*option*/)
             h2_fine[detId]->Fill(stripId + 1, energies[detId][stripId]);
         }
 
-        if (energies[detId][stripId] > 0. && pedestals[detId][stripId] != -1)
+        if (energies[detId][stripId] > 0. && sigmas[detId][stripId] != -1)
             StripCounter[detId]++;
     }
 
@@ -432,9 +448,11 @@ void R3BFootMapped2StripCal::Exec(Option_t* /*option*/)
         detId = data->GetDetId() - 1;
         stripId = data->GetStripId() - 1;
 
-        if (pedestals[detId][stripId] != -1 &&
+        if (sigmas[detId][stripId] != -1 &&
             StripCounter[detId] < fNStrip) // allow also negative values for the energies
+        {
             AddCalData(detId + 1, stripId + 1, energies[detId][stripId], fine_sigmas[detId][stripId]);
+        }
     }
 }
 

--- a/ssd/calibration/R3BFootStripCal2Hit.cxx
+++ b/ssd/calibration/R3BFootStripCal2Hit.cxx
@@ -35,6 +35,7 @@
 // FOOT headers
 #include "R3BFootCalData.h"
 #include "R3BFootHitData.h"
+#include "R3BFootHitPar.h"
 #include "R3BFootMappingPar.h"
 #include "R3BFootStripCal2Hit.h"
 #include "R3BLogger.h"
@@ -70,6 +71,17 @@ void R3BFootStripCal2Hit::SetParContainers()
     {
         R3BLOG(info, "footMappingPar found");
     }
+
+    R3BLOG(info, "Calling SetParContainers()");
+    fHit_Par = dynamic_cast<R3BFootHitPar*>(rtdb->getContainer("footHitPar"));
+    if (!fHit_Par)
+    {
+        R3BLOG(error, "SetParContainers(): footHitPar not found");
+    }
+    else
+    {
+        R3BLOG(info, "SetParContainers(): footHitPar loaded correctly");
+    }
 }
 
 void R3BFootStripCal2Hit::SetParameter()
@@ -92,6 +104,28 @@ void R3BFootStripCal2Hit::SetParameter()
         fOffsetY.push_back(fMap_Par->GetOffsetY(i + 1));
     }
     fMap_Par->printParams();
+
+    if (!fHit_Par)
+    {
+        R3BLOG(error, "SetParameter(): fHit_Par is NULL");
+    }
+    else
+    {
+        R3BLOG(info, TString::Format("SetParameter(): fHit_Par is VALID, NumParsFit = %d", fHit_Par->GetNumParsFit()));
+    }
+
+    fNumParsFit = fHit_Par->GetNumParsFit();
+    HitCalParams = fHit_Par->GetCharCalParams();
+    Int_t array_size = fMaxNumDet * fNumParsFit;
+    HitCalParams->Set(array_size);
+
+    for (int d = 0; d < fMaxNumDet; d++)
+    {
+        for (int j = 0; j < fNumParsFit; j++)
+        {
+            fCharCalPar.push_back(HitCalParams->GetAt(d * fNumParsFit + j));
+        }
+    }
 }
 
 // -----   Public method Init   -------------------------------------------------
@@ -224,9 +258,6 @@ void R3BFootStripCal2Hit::Exec(Option_t* /*option*/)
             int k = j + 1;
             while (k < StripE[i].size())
             {
-                if (StripI[i][k] - StripI[i][k - 1] != 1)
-                    break;
-
                 if (StripE[i][k] < fTimesSigmas * StripS[i][k])
                     break;
 
@@ -333,9 +364,25 @@ void R3BFootStripCal2Hit::Exec(Option_t* /*option*/)
             TVector3 master(x, y, z);
             // TODO: Eta correction not used at the moment
 
+            // Charge calibration (charge = m * energy + n)
+            double m = 1;
+            double n = 0;
+
+            if (fCharCalPar.size() > 0)
+            {
+                if (fCharCalPar[i * fNumParsFit] != 0)
+                {
+                    m = fCharCalPar[i * fNumParsFit];
+                    n = fCharCalPar[i * fNumParsFit + 1];
+                }
+            }
+
+            double charge = m * ClusterESum[i][j] + n;
+
             if (ClusterESum[i][j] > fThSum && j < fMaxNumClusters)
             {
-                AddHitData(i + 1, ClusterNStrip[i][j], pos, master, ClusterESum[i][j], ClusterMult[i], Eta[i][j]);
+                AddHitData(
+                    i + 1, ClusterNStrip[i][j], pos, master, ClusterESum[i][j], ClusterMult[i], Eta[i][j], charge);
             }
             else
             {
@@ -375,11 +422,12 @@ R3BFootHitData* R3BFootStripCal2Hit::AddHitData(uint8_t detid,
                                                 TVector3 master,
                                                 double energy_s,
                                                 uint16_t mulS,
-                                                double eta)
+                                                double eta,
+                                                double charge)
 {
     TClonesArray& clref = *fFootHitData;
     int size = clref.GetEntriesFast();
-    return new (clref.ConstructedAt(size)) R3BFootHitData(detid, numhit, pos, master, energy_s, mulS, eta);
+    return new (clref.ConstructedAt(size)) R3BFootHitData(detid, numhit, pos, master, energy_s, mulS, eta, charge);
 }
 
 ClassImp(R3BFootStripCal2Hit)

--- a/ssd/calibration/R3BFootStripCal2Hit.h
+++ b/ssd/calibration/R3BFootStripCal2Hit.h
@@ -23,12 +23,14 @@
 #include <FairTask.h>
 
 #include <Rtypes.h>
+#include <TArrayF.h>
 #include <TVector3.h>
 #include <vector>
 
 class TClonesArray;
 class TH1F;
 class R3BFootMappingPar;
+class R3BFootHitPar;
 
 class R3BFootStripCal2Hit : public FairTask
 {
@@ -80,12 +82,15 @@ class R3BFootStripCal2Hit : public FairTask
     double fTimesSigmas = 3.;
     int fMaxNumDet = 16;
     int fMaxNumClusters = 10;
+    int fNumParsFit = 2;
     std::vector<double> fDistTarget;
     std::vector<double> fAngleTheta;
     std::vector<double> fAnglePhi;
     std::vector<double> fOffsetX;
     std::vector<double> fOffsetY;
+    std::vector<double> fCharCalPar;
     std::vector<TH1F*> hssd;
+    TArrayF* HitCalParams = nullptr;
 
     std::vector<int> ClusterMult;                 // Cluster multiplicity
     std::vector<std::vector<double>> ClusterPos;  // Position of Cluster from Weighted Average
@@ -97,8 +102,10 @@ class R3BFootStripCal2Hit : public FairTask
     std::vector<std::vector<std::vector<double>>> ClusterE; // Energy of Strip in Cluster
 
     R3BFootMappingPar* fMap_Par = nullptr; // Parameter container with mapping
-    TClonesArray* fFootCalData = nullptr;  // Array with FOOT Cal-input data
-    TClonesArray* fFootHitData = nullptr;  // Array with FOOT Hit-output data
+    R3BFootHitPar* fHit_Par = nullptr;     // Parameter container with hit params
+
+    TClonesArray* fFootCalData = nullptr; // Array with FOOT Cal-input data
+    TClonesArray* fFootHitData = nullptr; // Array with FOOT Hit-output data
 
     bool fOnline = false; // Don't store data for online
     Double_t* fChannelPeaks;
@@ -110,7 +117,8 @@ class R3BFootStripCal2Hit : public FairTask
                                TVector3 master,
                                double energy_s,
                                uint16_t mulS,
-                               double eta);
+                               double eta,
+                               double charge);
 
   public:
     // Class definition

--- a/ssd/online/R3BFootOnlineSpectra.cxx
+++ b/ssd/online/R3BFootOnlineSpectra.cxx
@@ -91,9 +91,6 @@ InitStatus R3BFootOnlineSpectra::Init()
 
     // Create histograms for all the detectors
     // Energy range for strips
-    Double_t binsE = 1000;
-    Double_t minE = -100;
-    Double_t maxE = 3000;
 
     char Name1[255];
     char Name2[255];
@@ -118,7 +115,7 @@ InitStatus R3BFootOnlineSpectra::Init()
     { // one histo per detector
         sprintf(Name1, "fh2_energy_vs_strip_det_%d", i + 1);
         sprintf(Name2, "Mapped energy vs strip number for FOOT Det: %d", i + 1);
-        fh2_EnergyVsStrip[i] = R3B::root_owned<TH2F>(Name1, Name2, 640, 1, 641, binsE, -100, 3000);
+        fh2_EnergyVsStrip[i] = R3B::root_owned<TH2F>(Name1, Name2, 640, 1, 641, fBinsE, fMinE, fMaxE);
         fh2_EnergyVsStrip[i]->GetXaxis()->SetTitle("Strip number");
         fh2_EnergyVsStrip[i]->GetYaxis()->SetTitle("Energy [channels]");
         fh2_EnergyVsStrip[i]->GetYaxis()->SetTitleOffset(1.4);
@@ -130,7 +127,7 @@ InitStatus R3BFootOnlineSpectra::Init()
             fh2_EnergyVsStrip[i]->Draw("col");
             for (int i_asic = 1; i_asic < 10; i_asic++)
             {
-                TLine* l = new TLine(64.5 * i_asic, minE, 64.5 * i_asic, maxE);
+                TLine* l = new TLine(64.5 * i_asic, fMinE, 64.5 * i_asic, fMaxE);
                 l->Draw("same");
                 l->SetLineStyle(7);
                 l->SetLineWidth(1);
@@ -154,7 +151,7 @@ InitStatus R3BFootOnlineSpectra::Init()
         {
             sprintf(Name1, "fh2_energy_vs_strip_cal_det_%d", i + 1);
             sprintf(Name2, "Cal-energy vs strip number for FOOT Det: %d", i + 1);
-            fh2_EnergyVsStrip_cal[i] = R3B::root_owned<TH2F>(Name1, Name2, 640, 1, 641, binsE, -100, 1000);
+            fh2_EnergyVsStrip_cal[i] = R3B::root_owned<TH2F>(Name1, Name2, 640, 1, 641, fBinsE, fMinE, fMaxE / 3.);
             fh2_EnergyVsStrip_cal[i]->GetXaxis()->SetTitle("Strip number");
             fh2_EnergyVsStrip_cal[i]->GetYaxis()->SetTitle("Energy [channels]");
             fh2_EnergyVsStrip_cal[i]->GetYaxis()->SetTitleOffset(1.4);
@@ -167,7 +164,7 @@ InitStatus R3BFootOnlineSpectra::Init()
                 fh2_EnergyVsStrip_cal[i]->Draw("col");
                 for (int i_asic = 1; i_asic < 10; i_asic++)
                 {
-                    TLine* l = new TLine(64.5 * i_asic, minE, 64.5 * i_asic, maxE);
+                    TLine* l = new TLine(64.5 * i_asic, fMinE, 64.5 * i_asic, fMaxE / 3.);
                     l->Draw("same");
                     l->SetLineStyle(7);
                     l->SetLineWidth(1);
@@ -225,10 +222,31 @@ InitStatus R3BFootOnlineSpectra::Init()
     auto cHit_MultSize = new TCanvas("FOOT_mulSize", "hit multiplicity and size info", 10, 10, 500, 500);
     cHit_MultSize->Divide(4, 4);
 
+    // Energy correlation
+    auto cHit_EnergyCorr = new TCanvas("FOOT_energyCorr", "Energy correlation", 10, 10, 500, 500);
+    cHit_EnergyCorr->Divide(2, 2);
+
+    // Max energy correlation
+    auto cHit_MaxEnergyCorr = new TCanvas("FOOT_maxEnergyCorr", "Max energy correlation", 10, 10, 500, 500);
+    cHit_MaxEnergyCorr->Divide(2, 2);
+
+    // Eta
+    auto cHit_Charge = new TCanvas("FOOT_charge", "charge info", 10, 10, 500, 500);
+    cHit_Charge->Divide(4, 2);
+
+    // position vs energy
+
+    auto cHit_position_charge = new TCanvas("FOOT_position_charge", "charge info", 10, 10, 500, 500);
+    cHit_position_charge->Divide(4, 2);
+
     hitfol->Add(cHit);
     hitfol->Add(cHit_PosCorr);
     hitfol->Add(cHit_Eta);
     hitfol->Add(cHit_MultSize);
+    hitfol->Add(cHit_EnergyCorr);
+    hitfol->Add(cHit_MaxEnergyCorr);
+    hitfol->Add(cHit_Charge);
+    hitfol->Add(cHit_position_charge);
 
     if (fHitItems)
     {
@@ -239,8 +257,12 @@ InitStatus R3BFootOnlineSpectra::Init()
         fh1_ene.resize(fNbDet);
         fh1_mult.resize(fNbDet);
         fh1_size.resize(fNbDet);
+        fh1_charge.resize(fNbDet);
+        fh2_pos_charge.resize(fNbDet);
         fh2_eta.resize(fNbDet);
         fh2_foot_corr.resize(fNbDet / 2);
+        fh2_energy_corr.resize(fNbDet / 2);
+        fh2_energy_corr_max.resize(fNbDet / 2);
 
         for (Int_t i = 0; i < fNbDet; i++)
         { // one histo per detector
@@ -255,7 +277,7 @@ InitStatus R3BFootOnlineSpectra::Init()
 
             sprintf(Name1, "fh1_ene_det_%d", i + 1);
             sprintf(Name2, "Cluster energy for FOOT Det: %d", i + 1);
-            fh1_ene[i] = R3B::root_owned<TH1F>(Name1, Name2, binsE, minE, maxE);
+            fh1_ene[i] = R3B::root_owned<TH1F>(Name1, Name2, fBinsE, fMinE, fMaxE);
             fh1_ene[i]->GetXaxis()->SetTitle("Energy");
             fh1_ene[i]->GetYaxis()->SetTitle("Counts");
             fh1_ene[i]->GetYaxis()->SetTitleOffset(1.4);
@@ -264,9 +286,9 @@ InitStatus R3BFootOnlineSpectra::Init()
 
             sprintf(Name1, "fh2_eta_vs_strip_det_%d", i + 1);
             sprintf(Name2, "Eta parameter for FOOT Det: %d", i + 1);
-            fh2_eta[i] = R3B::root_owned<TH2F>(Name1, Name2, 100, 0, 1, binsE, 0, maxE);
-            fh2_eta[i]->GetXaxis()->SetTitle("Strip");
-            fh2_eta[i]->GetYaxis()->SetTitle("Eta");
+            fh2_eta[i] = R3B::root_owned<TH2F>(Name1, Name2, 100, 0, 1, fBinsE, 0, fMaxE);
+            fh2_eta[i]->GetXaxis()->SetTitle("Eta");
+            fh2_eta[i]->GetYaxis()->SetTitle("Energy [channels]");
             fh2_eta[i]->GetYaxis()->SetTitleOffset(1.4);
             fh2_eta[i]->GetXaxis()->CenterTitle(true);
             fh2_eta[i]->GetYaxis()->CenterTitle(true);
@@ -289,6 +311,24 @@ InitStatus R3BFootOnlineSpectra::Init()
             fh1_size[i]->GetXaxis()->CenterTitle(true);
             fh1_size[i]->GetYaxis()->CenterTitle(true);
 
+            sprintf(Name1, "fh1_charge_det_%d", i + 1);
+            sprintf(Name2, "Charge for FOOT Det: %d", i + 1);
+            fh1_charge[i] = R3B::root_owned<TH1F>(Name1, Name2, fBinsE, fMinE, fMaxE);
+            fh1_charge[i]->GetXaxis()->SetTitle("Charge");
+            fh1_charge[i]->GetYaxis()->SetTitle("Counts");
+            fh1_charge[i]->GetYaxis()->SetTitleOffset(1.4);
+            fh1_charge[i]->GetXaxis()->CenterTitle(true);
+            fh1_charge[i]->GetYaxis()->CenterTitle(true);
+
+            sprintf(Name1, "fh2_pos_charge_det_%d", i + 1);
+            sprintf(Name2, " Position vs Energy for FOOT Det: %d", i + 1);
+            fh2_pos_charge[i] = R3B::root_owned<TH2F>(Name1, Name2, 200, -50., 50., fBinsE / 2., 0, fMaxE);
+            fh2_pos_charge[i]->GetXaxis()->SetTitle("Position [mm]");
+            fh2_pos_charge[i]->GetYaxis()->SetTitle("Charge");
+            fh2_pos_charge[i]->GetYaxis()->SetTitleOffset(1.4);
+            fh2_pos_charge[i]->GetXaxis()->CenterTitle(true);
+            fh2_pos_charge[i]->GetYaxis()->CenterTitle(true);
+
             if ((i % 2) == 0)
             {
                 sprintf(Name1, "fh2_pos_corr_dets_%d_%d", i + 1, i + 2);
@@ -299,6 +339,31 @@ InitStatus R3BFootOnlineSpectra::Init()
                 fh2_foot_corr[i / 2]->GetYaxis()->SetTitleOffset(1.4);
                 fh2_foot_corr[i / 2]->GetXaxis()->CenterTitle(true);
                 fh2_foot_corr[i / 2]->GetYaxis()->CenterTitle(true);
+
+                sprintf(Name1, "fh2_energ_corr_dets_%d_%d", i + 1, i + 2);
+                sprintf(Name2, "Cluster energy correlation for FOOTs: %d and %d", i + 1, i + 2);
+                fh2_energy_corr[i / 2] = R3B::root_owned<TH2F>(Name1, Name2, fBinsE, 0, fMaxE, fBinsE, 0, fMaxE);
+
+                sprintf(Name1, "Energy det %d [channels]", i + 1);
+                fh2_energy_corr[i / 2]->GetXaxis()->SetTitle(Name1);
+                sprintf(Name1, "Energy det %d [channels]", i + 2);
+                fh2_energy_corr[i / 2]->GetYaxis()->SetTitle(Name1);
+                fh2_energy_corr[i / 2]->GetYaxis()->SetTitleOffset(1.4);
+                fh2_energy_corr[i / 2]->GetXaxis()->CenterTitle(true);
+                fh2_energy_corr[i / 2]->GetYaxis()->CenterTitle(true);
+
+                sprintf(Name1, "fh2_max_energ_corr_dets_%d_%d", i + 1, i + 2);
+                sprintf(Name2, "Max energy correlation correlation for FOOTs: %d and %d", i + 1, i + 2);
+                fh2_energy_corr_max[i / 2] =
+                    R3B::root_owned<TH2F>(Name1, Name2, fBinsE / 2, 0, fMaxE, fBinsE / 2, 0, fMaxE);
+
+                sprintf(Name1, "Max energy det %d [channels]", i + 1);
+                fh2_energy_corr_max[i / 2]->GetXaxis()->SetTitle(Name1);
+                sprintf(Name1, "Max energy det %d [channels]", i + 2);
+                fh2_energy_corr_max[i / 2]->GetYaxis()->SetTitle(Name1);
+                fh2_energy_corr_max[i / 2]->GetYaxis()->SetTitleOffset(1.4);
+                fh2_energy_corr_max[i / 2]->GetXaxis()->CenterTitle(true);
+                fh2_energy_corr_max[i / 2]->GetYaxis()->CenterTitle(true);
             }
 
             int foot_num = i + 1;
@@ -312,10 +377,17 @@ InitStatus R3BFootOnlineSpectra::Init()
 
                 if ((foot_num % 2) == 1)
                 {
-                    if (foot_num < 12)
+                    if (foot_num < 12) // do not change!
                     {
                         cHit_PosCorr->cd(i_pad_corr);
                         fh2_foot_corr[i / 2]->Draw();
+
+                        cHit_EnergyCorr->cd(i_pad_corr);
+                        fh2_energy_corr[i / 2]->Draw();
+
+                        cHit_MaxEnergyCorr->cd(i_pad_corr);
+                        fh2_energy_corr_max[i / 2]->Draw();
+
                         i_pad_corr++;
                     }
                 }
@@ -323,10 +395,16 @@ InitStatus R3BFootOnlineSpectra::Init()
                 cHit_Eta->cd(i_pad);
                 fh2_eta[i]->Draw();
 
+                cHit_Charge->cd(i_pad);
+                fh1_charge[i]->Draw();
+
                 cHit_MultSize->cd(i_pad_double);
                 fh1_size[i]->Draw();
                 cHit_MultSize->cd(i_pad_double + 1);
                 fh1_mult[i]->Draw();
+
+                cHit_position_charge->cd(i_pad);
+                fh2_pos_charge[i]->Draw();
 
                 i_pad_double++;
                 i_pad_double++;
@@ -386,10 +464,14 @@ void R3BFootOnlineSpectra::Reset_FOOT_Histo()
             fh1_mult[i]->Reset();
             fh1_size[i]->Reset();
             fh2_eta[i]->Reset();
+            fh1_charge[i]->Reset();
+            fh2_pos_charge[i]->Reset();
 
             if ((i % 2) == 0)
             {
                 fh2_foot_corr[i / 2]->Reset();
+                fh2_energy_corr[i / 2]->Reset();
+                fh2_energy_corr_max[i / 2]->Reset();
             }
         }
     }
@@ -438,6 +520,8 @@ void R3BFootOnlineSpectra::Exec(Option_t* option)
 
     // Vector to store the multiplicity of each event
     std::vector<int> mult(fNbDet, 0);
+    std::vector<std::vector<double>> energies(fNbDet);
+    std::vector<std::vector<double>> positions(fNbDet);
 
     // Fill hit data
     if (fHitItems && fHitItems->GetEntriesFast() > 0)
@@ -451,51 +535,18 @@ void R3BFootOnlineSpectra::Exec(Option_t* option)
             fh1_pos[hit->GetDetId() - 1]->Fill(hit->GetPos());
             fh1_ene[hit->GetDetId() - 1]->Fill(hit->GetEnergy());
             fh1_size[hit->GetDetId() - 1]->Fill(hit->GetMulStrip());
+            fh2_pos_charge[hit->GetDetId() - 1]->Fill(hit->GetPos(), hit->GetEnergy());
+
+            // Only calculate charge when it is on a constant eta-energy profile
+            if ((hit->GetEta() < 0.7) && (hit->GetEta() > 0.3))
+            {
+                fh1_charge[hit->GetDetId() - 1]->Fill(hit->GetZCharge());
+            }
+
             mult[hit->GetDetId() - 1]++;
             fh2_eta[hit->GetDetId() - 1]->Fill(hit->GetEta(), hit->GetEnergy());
-
-            int pairNdx = (hit->GetDetId() - 1) / 2;
-            int pairPos = (hit->GetDetId() - 1) % 2;
-
-            double pos1 = hit->GetPos();
-            double det1 = hit->GetDetId();
-
-            if (det1 > 9)
-            {
-                continue;
-            }
-
-            // Correlation position between each pair of FOOTs
-            if (ihit < nHits - 1)
-            {
-                for (Int_t ihit2 = ihit + 1; ihit2 < nHits; ihit2++)
-                {
-                    R3BFootHitData* hit2 = dynamic_cast<R3BFootHitData*>(fHitItems->At(ihit2));
-
-                    // The hit is in another pair
-                    if ((hit2->GetDetId() - 1) / 2 != pairNdx)
-                    {
-                        continue;
-                    }
-
-                    double pos2 = hit2->GetPos();
-                    double det2 = hit2->GetDetId();
-
-                    if (det1 == det2)
-                    {
-                        continue;
-                    }
-
-                    if (pairPos == 0) // Is the first FOOT on the pair
-                    {
-                        fh2_foot_corr[pairNdx]->Fill(pos1, pos2);
-                    }
-                    else
-                    {
-                        fh2_foot_corr[pairNdx]->Fill(pos2, pos1);
-                    }
-                }
-            }
+            energies[hit->GetDetId() - 1].push_back(hit->GetEnergy());
+            positions[hit->GetDetId() - 1].push_back(hit->GetPos());
         }
     }
 
@@ -506,7 +557,41 @@ void R3BFootOnlineSpectra::Exec(Option_t* option)
         {
             continue;
         }
+
         fh1_mult[i]->Fill(mult[i]);
+    }
+
+    std::vector<double> maxEnergy(fNbDet, 0.0);
+    // Fill maximum energy correlation
+    for (int i = 0; i < fNbDet; i++)
+    {
+        if (!energies[i].empty())
+        {
+            maxEnergy[i] = *std::max_element(energies[i].begin(), energies[i].end());
+        }
+    }
+
+    for (int i = 0; i < fNbDet / 2; i += 2)
+    {
+        // Max energy
+        if ((maxEnergy[i] > 0) && (maxEnergy[i + 1] > 0))
+        {
+            fh2_energy_corr_max[i / 2]->Fill(maxEnergy[i], maxEnergy[i + 1]);
+        }
+
+        // std::cout << energies[i].size() << " " << energies[i+1].size() << "\n";
+        //  Correlation between pairs of FOOTs
+        if ((!energies[i].empty()) && (!energies[i + 1].empty()))
+        {
+            for (int j1 = 0; j1 < energies[i].size(); j1++)
+            {
+                for (int j2 = 0; j2 < energies[i + 1].size(); j2++)
+                {
+                    fh2_energy_corr[i / 2]->Fill(energies[i][j1], energies[i + 1][j2]);
+                    fh2_foot_corr[i / 2]->Fill(positions[i + 1][j2], positions[i][j1]);
+                }
+            }
+        }
     }
 
     fNEvents += 1;
@@ -558,10 +643,13 @@ void R3BFootOnlineSpectra::FinishTask()
             fh1_mult[i]->Write();
             fh1_size[i]->Write();
             fh2_eta[i]->Write();
+            fh1_charge[i]->Write();
 
             if ((i % 2) == 0)
             {
                 fh2_foot_corr[i / 2]->Write();
+                fh2_energy_corr[i / 2]->Write();
+                fh2_energy_corr_max[i / 2]->Write();
             }
         }
     }

--- a/ssd/online/R3BFootOnlineSpectra.h
+++ b/ssd/online/R3BFootOnlineSpectra.h
@@ -102,6 +102,13 @@ class R3BFootOnlineSpectra : public FairTask
 
     void SetSigmaRefreshRate(int rate) { fSigmaRefreshRate = rate; }
 
+    void SetBinParams(double minE, double maxE, double binsE)
+    {
+        fMinE = minE;
+        fMaxE = maxE;
+        fBinsE = binsE;
+    }
+
     /**
      * Method to set the number of detectors
      */
@@ -127,6 +134,10 @@ class R3BFootOnlineSpectra : public FairTask
     int eventNumber = 0;
     int fSigmaRefreshRate = 5000;
 
+    double fMinE = -100.;
+    double fMaxE = 5000.;
+    double fBinsE = 1000;
+
     // Histograms for map data
     std::vector<TH2F*> fh2_EnergyVsStrip;
     // Histograms for cal data
@@ -140,6 +151,10 @@ class R3BFootOnlineSpectra : public FairTask
     std::vector<TH2F*> fh2_foot_corr;
     std::vector<TH1F*> fh1_mult;
     std::vector<TH1F*> fh1_size;
+    std::vector<TH1F*> fh1_charge;
+    std::vector<TH2F*> fh2_energy_corr;
+    std::vector<TH2F*> fh2_pos_charge;
+    std::vector<TH2F*> fh2_energy_corr_max;
 
   public:
     ClassDefOverride(R3BFootOnlineSpectra, 1)

--- a/ssd/online/R3BFootVsAlpideOnlineSpectra.cxx
+++ b/ssd/online/R3BFootVsAlpideOnlineSpectra.cxx
@@ -1,0 +1,327 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2025 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+// --------------------------------------------------------------
+// -----       R3BFootVsAlpideOnlineSpectra             --
+// -----    Created 17/02/19  by J.L. Rodriguez-Sanchez        --
+// ----- Fill FOOT and ALPIDE correlations in online histograms --
+// --------------------------------------------------------------
+
+/*
+ *  This taks reads hit data from FOOT and ALPIDE detectors and plots
+ *  online histograms
+ */
+
+#include "R3BFootVsAlpideOnlineSpectra.h"
+#include "R3BAlpideHitData.h"
+#include "R3BEventHeader.h"
+#include "R3BFootHitData.h"
+#include "R3BLogger.h"
+#include "R3BShared.h"
+#include "THttpServer.h"
+#include "TRandom.h"
+#include "TStyle.h"
+#include "TVector3.h"
+
+#include "R3BTCalEngine.h"
+
+#include "FairLogger.h"
+#include "FairRootManager.h"
+#include "FairRunAna.h"
+#include "FairRunOnline.h"
+#include "FairRuntimeDb.h"
+#include "TCanvas.h"
+#include "TFolder.h"
+#include "TH1F.h"
+#include "TH2F.h"
+
+#include "TClonesArray.h"
+#include "TMath.h"
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <ctime>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#define IS_NAN(x) TMath::IsNaN(x)
+
+using namespace std;
+
+R3BFootVsAlpideOnlineSpectra::R3BFootVsAlpideOnlineSpectra()
+    : FairTask("FootVsAlpideOnlineSpectra", 1)
+    , fHitItemsFoot(NULL)
+    , fHitItemsAlpide(NULL)
+    , fClockFreq(1. / VFTX_CLOCK_MHZ * 1000.)
+    , fTrigger(-1)
+    , fNEvents(0)
+    , fNbDet(8)
+{
+}
+
+R3BFootVsAlpideOnlineSpectra::R3BFootVsAlpideOnlineSpectra(const TString& name, Int_t iVerbose)
+    : FairTask(name, iVerbose)
+    , fHitItemsFoot(NULL)
+    , fHitItemsAlpide(NULL)
+    , fClockFreq(1. / VFTX_CLOCK_MHZ * 1000.)
+    , fTrigger(-1)
+    , fNEvents(0)
+    , fNbDet(8)
+{
+}
+
+R3BFootVsAlpideOnlineSpectra::~R3BFootVsAlpideOnlineSpectra() {}
+
+InitStatus R3BFootVsAlpideOnlineSpectra::Init()
+{
+
+    LOG(info) << "R3BFootVsAlpideOnlineSpectra::Init ";
+
+    // try to get a handle on the EventHeader. EventHeader may not be
+    // present though and hence may be null. Take care when using.
+
+    FairRootManager* mgr = FairRootManager::Instance();
+    if (NULL == mgr)
+        LOG(fatal) << "R3BFootVsAlpideOnlineSpectra::Init FairRootManager not found";
+    header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
+
+    FairRunOnline* run = FairRunOnline::Instance();
+    run->GetHttpServer()->Register("", this);
+
+    // create histograms of all detectors
+
+    // get access to Hit data
+    fHitItemsFoot = dynamic_cast<TClonesArray*>(mgr->GetObject("FootHitData"));
+    if (!fHitItemsFoot)
+    {
+        LOG(info) << "R3BFootVsAlpideOnlineSpectra::Init FootHitData not found";
+    }
+
+    // get access to Hit data
+    fHitItemsAlpide = dynamic_cast<TClonesArray*>(mgr->GetObject("AlpideHitData"));
+    if (!fHitItemsAlpide)
+    {
+        LOG(info) << "R3BFootVsAlpideOnlineSpectra::Init AlpideHitData not found";
+    }
+
+    // Name variables
+    char Name1[255];
+    char Name2[255];
+
+    // Folders
+    TFolder* mainfol = new TFolder("Foot-Alpide", "Foot-Alpide correlation info");
+
+    // ================ Position X correlation canvas =====================
+    cPosCorr = new TCanvas("Foot_vs_Alpide_pos_corr", "position correlation info", 10, 10, 500, 500);
+    cPosCorr->Divide(4, 2);
+    mainfol->Add(cPosCorr);
+
+    fh2_foot_alpide_pos_corr.resize(fNbDet);
+    int i_pad = 1;
+
+    for (int i = 0; i < fNbDet; i++)
+    {
+        sprintf(Name1, "fh2_foot_vs_alpide_posCorr_det_%d", i + 1);
+        sprintf(Name2, "FOOT vs ALPIDE position correlation for FOOT: %d", i + 1);
+
+        fh2_foot_alpide_pos_corr[i] = R3B::root_owned<TH2F>(Name1, Name2, 100, -50, 50, 100, -50, 50);
+        fh2_foot_alpide_pos_corr[i]->GetXaxis()->SetTitle("FOOT [mm]");
+        fh2_foot_alpide_pos_corr[i]->GetYaxis()->SetTitle("ALPIDE [mm]");
+        fh2_foot_alpide_pos_corr[i]->GetYaxis()->SetTitleOffset(1.4);
+        fh2_foot_alpide_pos_corr[i]->GetXaxis()->CenterTitle(true);
+        int foot_num = i + 1;
+        if (foot_num < 9)
+        {
+            cPosCorr->cd(i_pad);
+            gPad->SetLogz(true);
+            fh2_foot_alpide_pos_corr[i]->Draw("col");
+            i_pad++;
+        }
+    }
+
+    // ================ Energy correlation canvas =====================
+    cCharCorr = new TCanvas("Foot_vs_Alpide_char_corr", "Charge correlation info", 10, 10, 500, 500);
+    cCharCorr->Divide(4, 2);
+    mainfol->Add(cCharCorr);
+
+    fh2_foot_alpide_char_corr.resize(fNbDet);
+    i_pad = 1;
+
+    for (int i = 0; i < fNbDet; i++)
+    {
+        sprintf(Name1, "fh2_foot_vs_alpide_char_det_%d", i + 1);
+        sprintf(Name2, "FOOT vs ALPIDE charge correlation Y for FOOT: %d", i + 1);
+
+        fh2_foot_alpide_char_corr[i] = R3B::root_owned<TH2F>(Name1, Name2, 1000, 0, 5000, 100, 0, 100);
+        fh2_foot_alpide_char_corr[i]->GetXaxis()->SetTitle("FOOT Energy [channels]");
+        fh2_foot_alpide_char_corr[i]->GetYaxis()->SetTitle("ALPIDE Cluster Size");
+        fh2_foot_alpide_char_corr[i]->GetYaxis()->SetTitleOffset(1.4);
+        fh2_foot_alpide_char_corr[i]->GetXaxis()->CenterTitle(true);
+        int foot_num = i + 1;
+        if (foot_num < 9)
+        {
+            cCharCorr->cd(i_pad);
+            fh2_foot_alpide_char_corr[i]->Draw("col");
+            i_pad++;
+        }
+    }
+
+    run->AddObject(mainfol);
+
+    // Register command to reset histograms
+    run->GetHttpServer()->RegisterCommand("Reset", Form("/Objects/%s/->Reset_FOOT_ALPIDE_Histo()", GetName()));
+
+    return kSUCCESS;
+}
+
+void R3BFootVsAlpideOnlineSpectra::Reset_FOOT_ALPIDE_Histo()
+{
+    LOG(info) << "R3BFootVsAlpideOnlineSpectra::Reset_FOOT_ALPIDE_Histo";
+    for (int i = 0; i < fNbDet; i++)
+    {
+        fh2_foot_alpide_char_corr[i]->Reset();
+        fh2_foot_alpide_pos_corr[i]->Reset();
+    }
+
+    return;
+}
+
+void R3BFootVsAlpideOnlineSpectra::Exec(Option_t* option)
+{
+
+    FairRootManager* mgr = FairRootManager::Instance();
+    if (NULL == mgr)
+        LOG(fatal) << "R3BFootVsAlpideOnlineSpectra::Exec FairRootManager not found";
+
+    // if(header->GetTrigger()!=1){cout << header->GetTrigger()<<endl;}
+    // if ((fTrigger >= 0) && (header) && (header->GetTrigger() != 1))
+    // return;
+
+    // Check for requested trigger (Todo: should be done globablly / somewhere else)
+    if ((fTrigger >= 0) && (header != nullptr) && (header->GetTrigger() != fTrigger))
+        return;
+
+    if (fTpat1 >= 0 && fTpat2 >= 0 && (header))
+    {
+        // fTpat = 1-16; fTpat_bit = 0-15
+        Int_t fTpat_bit1 = fTpat1 - 1;
+        Int_t fTpat_bit2 = fTpat2 - 1;
+        Int_t tpatbin = 0;
+        for (int i = 0; i < 16; i++)
+        {
+            tpatbin = (header->GetTpat() & (1 << i));
+            if (tpatbin != 0 && (i < fTpat_bit1 || i > fTpat_bit2))
+            {
+                return;
+            }
+        }
+    }
+
+    //  ============= FOOT Hit data ==============
+
+    // Vector to store the info of the hits of each event
+    std::vector<std::vector<double>> footEnergies(fNbDet);
+    std::vector<std::vector<double>> footPositions(fNbDet);
+
+    if (fHitItemsFoot && fHitItemsFoot->GetEntriesFast() > 0)
+    {
+        auto nHits = fHitItemsFoot->GetEntriesFast();
+        for (Int_t ihit = 0; ihit < nHits; ihit++)
+        {
+            R3BFootHitData* hit = dynamic_cast<R3BFootHitData*>(fHitItemsFoot->At(ihit));
+            if (!hit)
+                continue;
+            if ((hit->GetEta() < 0.3) || (hit->GetEta() > 0.7))
+                continue;
+            footEnergies[hit->GetDetId() - 1].push_back(hit->GetEnergy());
+            footPositions[hit->GetDetId() - 1].push_back(hit->GetPos());
+        }
+    }
+
+    //  ============= ALPIDE Hit data ==============
+
+    // Vector to store the info of the hits of each event
+    std::vector<double> alpideEnergies;
+    std::vector<double> alpidePositionsX;
+    std::vector<double> alpidePositionsY;
+
+    if (fHitItemsAlpide && fHitItemsAlpide->GetEntriesFast() > 0)
+    {
+        auto nHits = fHitItemsAlpide->GetEntriesFast();
+        for (Int_t ihit = 0; ihit < nHits; ihit++)
+        {
+            R3BAlpideHitData* hit = dynamic_cast<R3BAlpideHitData*>(fHitItemsAlpide->At(ihit));
+            if (!hit)
+                continue;
+            alpideEnergies.push_back(hit->GetClusterSize());
+            alpidePositionsX.push_back(hit->GetX());
+            alpidePositionsY.push_back(hit->GetY());
+        }
+    }
+
+    // =============== Calculate the correlations =======
+    if (alpideEnergies.size() == 0)
+    {
+        // R3BLOG("info", "Different number of hits in FOOT and ALPIDE");
+        std::cout << "No ALPIDE hits";
+    }
+    else
+    {
+        for (int i = 0; i < alpidePositionsX.size(); i++)
+        {
+            for (int j = 0; j < fNbDet; j++)
+            {
+                for (int k = 0; k < footPositions[j].size(); k++)
+                {
+                    fh2_foot_alpide_char_corr[j]->Fill(footEnergies[j][k], alpideEnergies[i]);
+
+                    if ((j % 2) == 0) // Y
+                    {
+                        fh2_foot_alpide_pos_corr[j]->Fill(footPositions[j][k], alpidePositionsY[i]);
+                    }
+
+                    else
+                    {
+                        fh2_foot_alpide_pos_corr[j]->Fill(footPositions[j][k], alpidePositionsX[i]);
+                    }
+                }
+            }
+        }
+    }
+    fNEvents += 1;
+}
+
+void R3BFootVsAlpideOnlineSpectra::FinishEvent()
+{
+
+    if (fHitItemsFoot)
+    {
+        fHitItemsFoot->Clear();
+    }
+    if (fHitItemsAlpide)
+    {
+        fHitItemsAlpide->Clear();
+    }
+}
+
+void R3BFootVsAlpideOnlineSpectra::FinishTask()
+{
+
+    if (fHitItemsFoot && fHitItemsAlpide)
+    {
+        cPosCorr->Write();
+        cCharCorr->Write();
+    }
+}
+
+ClassImp(R3BFootVsAlpideOnlineSpectra)

--- a/ssd/online/R3BFootVsAlpideOnlineSpectra.h
+++ b/ssd/online/R3BFootVsAlpideOnlineSpectra.h
@@ -1,0 +1,127 @@
+/******************************************************************************
+ *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2019-2025 Members of R3B Collaboration                     *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+// --------------------------------------------------------------
+// -----       R3BFootVsAlpideOnlineSpectra             --
+// -----    Created 17/02/19  by J.L. Rodriguez-Sanchez        --
+// ----- Fill foot and alpide correlations in online histograms --
+// --------------------------------------------------------------
+
+#pragma once
+
+#include "FairTask.h"
+#include "R3BEventHeader.h"
+#include "TCanvas.h"
+#include "TH2F.h"
+#include "TMath.h"
+#include <array>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+class TClonesArray;
+class R3BEventHeader;
+
+/**
+ *  This taks reads hit data from foot and alpide detectors and plots
+ *  online histograms
+ */
+class R3BFootVsAlpideOnlineSpectra : public FairTask
+{
+
+  public:
+    /**
+     * Default constructor.
+     * Creates an instance of the task with default parameters.
+     */
+    R3BFootVsAlpideOnlineSpectra();
+
+    /**
+     * Standard constructor.
+     * Creates an instance of the task.
+     * @param name a name of the task.
+     * @param iVerbose a verbosity level.
+     */
+    R3BFootVsAlpideOnlineSpectra(const TString& name, Int_t iVerbose = 1);
+
+    /**
+     * Destructor.
+     * Frees the memory used by the object.
+     */
+    virtual ~R3BFootVsAlpideOnlineSpectra();
+
+    /**
+     * Method for task initialization.
+     * This function is called by the framework before
+     * the event loop.
+     * @return Initialization status. kSUCCESS, kERROR or kFATAL.
+     */
+    virtual InitStatus Init();
+
+    /**
+     * Method for event loop implementation.
+     * Is called by the framework every time a new event is read.
+     * @param option an execution option.
+     */
+    virtual void Exec(Option_t* option);
+
+    /**
+     * A method for finish of processing of an event.
+     * Is called by the framework for each event after executing
+     * the tasks.
+     */
+    virtual void FinishEvent();
+
+    /**
+     * Method for finish of the task execution.
+     * Is called by the framework after processing the event loop.
+     */
+    virtual void FinishTask();
+
+    /**
+     * Method for setting the number of FOOT detectors
+     */
+    void SetNumDet(Int_t NbDet) { fNbDet = NbDet; }
+    void SetTPat(Int_t tpat1, Int_t tpat2)
+    {
+        fTpat1 = tpat1;
+        fTpat2 = tpat2;
+    }
+    void SetTrigger(Int_t trig) { fTrigger = trig; }
+
+    void Reset_FOOT_ALPIDE_Histo();
+
+  private:
+    TClonesArray* fHitItemsFoot;   /**< Array with FOOT hit items. */
+    TClonesArray* fHitItemsAlpide; /**< Array with ALPIDE hit items. */
+
+    Double_t fClockFreq; /**< Clock cycle in [ns]. */
+
+    // check for trigger should be done globablly (somewhere else)
+    R3BEventHeader* header; /**< Event header. */
+    Int_t fTrigger = -1;    /**< Trigger value. */
+    Int_t fNEvents;         /**< Event counter. */
+    Int_t fTpat1 = -1;
+    Int_t fTpat2 = -1;
+
+    TCanvas *cPosCorr, *cCharCorr;
+
+    std::vector<TH2F*> fh2_foot_alpide_pos_corr;
+    std::vector<TH2F*> fh2_foot_alpide_char_corr;
+
+    Int_t fNbDet = 8; /**< Number of FOOT detectors. */
+
+  public:
+    ClassDef(R3BFootVsAlpideOnlineSpectra, 1)
+};

--- a/ssd/pars/R3BFootCalPar.cxx
+++ b/ssd/pars/R3BFootCalPar.cxx
@@ -63,7 +63,7 @@ void R3BFootCalPar::putParams(FairParamList* list)
     Int_t array_size = fNumDets * fNumStrips;
     LOG(info) << "Array Size: " << array_size;
 
-    fStripCalParams->Set(array_size);
+    fStripCalParams->Set(array_size * fNumParsFit);
 
     list->add("footDetNumberPar", fNumDets);
     list->add("footStripNumberPar", fNumStrips);

--- a/ssd/pars/R3BFootHitPar.cxx
+++ b/ssd/pars/R3BFootHitPar.cxx
@@ -30,12 +30,14 @@ R3BFootHitPar::R3BFootHitPar(const char* name, const char* title, const char* co
     : FairParGenericSet(name, title, context)
 {
     detName = "FootHit";
+    fCharCalPar = new TArrayF(fNumDets * fNumParsFit);
 }
 
 // ----  Destructor ------------------------------------------------------------
 R3BFootHitPar::~R3BFootHitPar()
 {
     this->clear(); // NOLINT
+    delete fCharCalPar;
 }
 
 // ----  Method clear ----------------------------------------------------------
@@ -55,7 +57,14 @@ void R3BFootHitPar::putParams(FairParamList* list)
         return;
     }
 
+    Int_t array_size = fNumDets;
+    LOG(info) << "Array Size: " << array_size;
+
+    fCharCalPar->Set(array_size * fNumParsFit);
+
     list->add("footDetNbPar", fNumDets);
+    list->add("footCharCalPar", *fCharCalPar);
+    list->add("footNumberParsFit", fNumParsFit);
 }
 
 // ----  Method getParams ------------------------------------------------------
@@ -73,6 +82,22 @@ Bool_t R3BFootHitPar::getParams(FairParamList* list)
         R3BLOG(error, "Could not initialize footDetNbPar");
         return kFALSE;
     }
+
+    if (!list->fill("footNumberParsFit", &fNumParsFit))
+    {
+        LOG(fatal) << "R3BFootCalPar::Could not initialize footNumberParsFit";
+        return kFALSE;
+    }
+
+    Int_t array_size = fNumDets;
+    fCharCalPar->Set(array_size * fNumParsFit);
+
+    if (!(list->fill("footCharCalPar", fCharCalPar)))
+    {
+        LOG(fatal) << "R3BFootCalPar::Could not initialize footCharCalPar";
+        return kFALSE;
+    }
+
     return kTRUE;
 }
 
@@ -84,6 +109,11 @@ void R3BFootHitPar::print()
     for (Int_t d = 0; d < fNumDets; d++)
     {
         R3BLOG(info, "Foot detector number: " << d + 1);
+
+        for (Int_t j = 0; j < fNumParsFit; j++)
+        {
+            LOG(info) << "FitParam(" << j + 1 << ") = " << fCharCalPar->GetAt(d * fNumParsFit + j);
+        }
     }
 }
 

--- a/ssd/pars/R3BFootHitPar.h
+++ b/ssd/pars/R3BFootHitPar.h
@@ -51,13 +51,18 @@ class R3BFootHitPar : public FairParGenericSet
 
     // Accessor functions
     [[nodiscard]] inline const int GetNumDets() const { return fNumDets; }
-
+    [[nodiscard]] inline const int GetNumParsFit() const { return fNumParsFit; }
     inline void SetNumDets(int ndet) { fNumDets = ndet; }
+    TArrayF* GetCharCalParams() { return fCharCalPar; }
 
-    /** Create more Methods if you need them! **/
+    // Method for setting the calibration parameters
+    inline void SetCharCalPars(float value, int index) { fCharCalPar->AddAt(value, index); }
+    inline void SetNumParsFit(int npar) { fNumParsFit = npar; }
 
   private:
-    int fNumDets = 8; // Number of detectors
+    int fNumDets = 8;     // Number of detectors
+    int fNumParsFit = 2;  // Number of parameters of for the calibration
+    TArrayF* fCharCalPar; // Parameters for the calibration charge vs energy
 
     const R3BFootHitPar& operator=(const R3BFootHitPar&);
     R3BFootHitPar(const R3BFootHitPar&);


### PR DESCRIPTION
Update of the online analysis of FOOTs and Alpide classes for the G-249 experiment. In particular, the main changes were:
 
- New class R3BFootVsAlpideOnlineSpectra, for checking correlations between FOOTs and Alpide.
- New histogram for storing the charge measured in FOOT. 
- Fixed some error in previous version of the FootOnlineSpectra

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
