### PR TITLE
Fixed an error in the incoming tracking with FOOTs

### DIFF
--- a/analysis/online/R3BIncomingTrackingFootOnlineSpectra.cxx
+++ b/analysis/online/R3BIncomingTrackingFootOnlineSpectra.cxx
@@ -349,16 +349,22 @@ void R3BIncomingTrackingFootOnlineSpectra::Exec(Option_t* /*option*/)
     {
         std::vector<double> footPos(fNbDet, std::nan(""));
 
-        auto hit = dynamic_cast<R3BFootHitData*>(fHitFootData->At(0));
-        auto detId = hit->GetDetId() - 1;
+        auto nHits = fHitFootData->GetEntriesFast();
+        for (size_t ihit = 0; ihit < nHits; ihit++)
+        {
+            auto hit = dynamic_cast<R3BFootHitData*>(fHitFootData->At(ihit));
+            auto detId = hit->GetDetId() - 1;
+            if (detId >= fNbDet)
+                continue;
 
-        R3BLOG_IF(fatal, hit->GetDetId() - 1 > fNbDet, "You are selecting a FOOT that does not exist...");
+            if (std::find(fDetIdX.begin(), fDetIdX.end(), detId) != fDetIdX.end())
+                if (!std::isfinite(footPos[detId]))
+                    footPos[detId] = hit->GetPosLab()[0];
 
-        if (std::find(fDetIdX.begin(), fDetIdX.end(), detId) != fDetIdX.end())
-            footPos[detId] = hit->GetPosLab()[0];
-
-        if (std::find(fDetIdY.begin(), fDetIdY.end(), detId) != fDetIdY.end())
-            footPos[detId] = hit->GetPosLab()[1];
+            if (std::find(fDetIdY.begin(), fDetIdY.end(), detId) != fDetIdY.end())
+                if (!std::isfinite(footPos[detId]))
+                    footPos[detId] = hit->GetPosLab()[1];
+        }
 
         // Calculations for tracking with X before target
         if (std::isfinite(footPos[fDetIds[0]]) && std::isfinite(footPos[fDetIds[2]]))


### PR DESCRIPTION

Previously only the most energetic of all the hits was taken into account. This means that only one FOOT was considered for the tracking and, therefore, the other 7 were empty, leading to never filling any point.



---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
