### PR TITLE
fixing bug with mapping of trigger channels

### DIFF
--- a/los/calib/R3BLosMapped2Cal.cxx
+++ b/los/calib/R3BLosMapped2Cal.cxx
@@ -348,13 +348,13 @@ void R3BLosMapped2Cal::Exec(Option_t*)
             {
                 time_ns = (mapped->GetTimeCoarse() + 1) * fClockFreq - time_ns;
                 if (iType == 1)
-                    caltrigger->fTimeV_ns[0] = time_ns;
+                    caltrigger->fTimeV_ns[iChannel - 1] = time_ns;
                 else if (iType == 2)
-                    caltrigger->fTimeL_ns[0] = time_ns;
+                    caltrigger->fTimeL_ns[iChannel - 1] = time_ns;
                 else if (iType == 3)
-                    caltrigger->fTimeT_ns[0] = time_ns;
+                    caltrigger->fTimeT_ns[iChannel - 1] = time_ns;
                 else if (iType == 4)
-                    caltrigger->fTimeM_ns[0] = time_ns;
+                    caltrigger->fTimeM_ns[iChannel - 1] = time_ns;
             }
         }
     }


### PR DESCRIPTION
When we moved from one to two trigger times, the R3BLosMapped2Cal was not updated to follow up the changes.

Code was changed so that in the future, in the case we add more trigger times, this will not break... I hope

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
