### PR TITLE
R3BCalifaCrystalCalData->GetEnergy() method changed to better handling of overflows when clustering

### DIFF
--- a/califa/calibration/R3BCalifaCrystalCal2Cluster.cxx
+++ b/califa/calibration/R3BCalifaCrystalCal2Cluster.cxx
@@ -264,6 +264,17 @@ void R3BCalifaCrystalCal2Cluster::Exec(Option_t* /*opt*/)
         cryId = dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i))->GetCrystalId();
         cryEnergy = dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i))->GetEnergy();
 
+
+	if (std::isnan(cryEnergy))
+	{
+	    cryEnergy = dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i))->GetToTEnergy();
+	    //cryEnergy = 10*TMath::Exp(cryEnergy/950.);
+	    std::cout << cryId << " was overflowed, now its value taken from tot " << cryEnergy << "\n"; 
+	    //cryEnergy = fProtonClusterThreshold;
+	    //std::cout << cryId << " was overflowed, now its value is set to threshold " << fProtonClusterThreshold << "\n"; 
+	}
+
+
         if (cryEnergy >= fCrystalThreshold)
             allCrystalVec.push_back(dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i)));
 

--- a/califa/calibration/R3BCalifaMapped2CrystalCal.cxx
+++ b/califa/calibration/R3BCalifaMapped2CrystalCal.cxx
@@ -56,7 +56,6 @@ void R3BCalifaMapped2CrystalCal::SetParContainers()
     {
         R3BLOG(info, "califaCrystalCalPar container opened");
     }
-
     fTotCal_Par = dynamic_cast<R3BCalifaTotCalPar*>(rtdb->getContainer("CalifaTotCalPar"));
     if (!fTotCal_Par)
     {
@@ -110,88 +109,107 @@ void R3BCalifaMapped2CrystalCal::SetParameter()
     constexpr int offset = 2432;
     auto& cal = *fCalParams; // because (*ptr)[i] is ugly and error-prone
     auto& tot = *fCalTotParams;
+    bool some_default = false;
+    for (int i=0;i<fCalTotParams->GetSize();i++)
+    {
+	    if (fCalTotParams->GetAt(i)==0) some_default = true;
+	    if (i%2)
+	    {
+	    if (fCalTotParams->GetAt(i)==0) {params_tot.push_back(10000);}
+	    if (fCalTotParams->GetAt(i)!=0) {params_tot.push_back(fCalTotParams->GetAt(i));}
+            }
+	    else
+            {
+	    
+	    if (fCalTotParams->GetAt(i)!=0) {params_tot.push_back(fCalTotParams->GetAt(i));}
+	    if (fCalTotParams->GetAt(i)==0) {params_tot.push_back(1000);}
+	    }
+    
+    }
+    if (some_default) {R3BLOG(info, "Could not find some Tot params, set to default values");}
+
     if (fNumParams != 2 || fNumCrystals < 2 * offset)
     {
-        R3BLOG(warn, "Not checking calibration in former proton range.");
-        return;
+	    R3BLOG(warn, "Not checking calibration in former proton range.");
+	    return;
     }
     auto invalid = [&cal](int id)
     {
-        auto a = cal.GetAt(2 * (id - 1) + 0);
-        auto b = cal.GetAt(2 * (id - 1) + 1);
-        return (std::isnan(a) || a == 0.0) && (std::isnan(a) || a == 0.0);
+	    auto a = cal.GetAt(2 * (id - 1) + 0);
+	    auto b = cal.GetAt(2 * (id - 1) + 1);
+	    return (std::isnan(a) || a == 0.0) && (std::isnan(a) || a == 0.0);
     };
 
     int replaced{};
     for (int id = 1; id <= 1952; id++) // barrel range, formerly barrel gamma range
-        if (invalid(id) && !invalid(id + offset))
-        {
-            ++replaced;
-            // Note:  (*a)[n]=...
-            for (int p = 0; p < fNumParams; p++)
-                cal[fNumParams * (id - 1) + p] = cal[fNumParams * (id - 1 + offset) + p];
-            for (int p = 0; p < fNumTotParams; p++)
-                tot[fNumTotParams * (id - 1) + p] = tot[fNumTotParams * (id - 1 + offset) + p];
-        }
+	    if (invalid(id) && !invalid(id + offset))
+	    {
+		    ++replaced;
+		    // Note:  (*a)[n]=...
+		    for (int p = 0; p < fNumParams; p++)
+			    cal[fNumParams * (id - 1) + p] = cal[fNumParams * (id - 1 + offset) + p];
+		    for (int p = 0; p < fNumTotParams; p++)
+		            tot[fNumTotParams * (id - 1) + p] = tot[fNumTotParams * (id - 1 + offset) + p];
+	    }
 
     R3BLOG_IF(warn,
-              replaced,
-              replaced << " missing calibrations for crIDs in [1, 1952] have been copied over from the legacy proton "
-                          "barrel range.");
+		    replaced,
+		    replaced << " missing calibrations for crIDs in [1, 1952] have been copied over from the legacy proton "
+		    "barrel range.");
 }
 
 InitStatus R3BCalifaMapped2CrystalCal::Init()
 {
-    R3BLOG(info, "");
+	R3BLOG(info, "");
 
-    FairRootManager* rootManager = FairRootManager::Instance();
-    R3BLOG_IF(fatal, rootManager == nullptr, "FairRootManager not found");
+	FairRootManager* rootManager = FairRootManager::Instance();
+	R3BLOG_IF(fatal, rootManager == nullptr, "FairRootManager not found");
 
-    // INPUT DATA
-    fCalifaMappedDataCA = dynamic_cast<TClonesArray*>(rootManager->GetObject("CalifaMappedData"));
-    R3BLOG_IF(fatal, fCalifaMappedDataCA == nullptr, "CalifaMappedData not found");
+	// INPUT DATA
+	fCalifaMappedDataCA = dynamic_cast<TClonesArray*>(rootManager->GetObject("CalifaMappedData"));
+	R3BLOG_IF(fatal, fCalifaMappedDataCA == nullptr, "CalifaMappedData not found");
 
-    // OUTPUT DATA
-    fCalifaCryCalDataCA = new TClonesArray("R3BCalifaCrystalCalData");
-    rootManager->Register("CalifaCrystalCalData", "CALIFA Crystal Cal", fCalifaCryCalDataCA, !fOnline);
+	// OUTPUT DATA
+	fCalifaCryCalDataCA = new TClonesArray("R3BCalifaCrystalCalData");
+	rootManager->Register("CalifaCrystalCalData", "CALIFA Crystal Cal", fCalifaCryCalDataCA, !fOnline);
 
-    SetParameter();
-    return kSUCCESS;
+	SetParameter();
+	return kSUCCESS;
 }
 
 InitStatus R3BCalifaMapped2CrystalCal::ReInit()
 {
-    SetParContainers();
-    SetParameter();
-    return kSUCCESS;
+	SetParContainers();
+	SetParameter();
+	return kSUCCESS;
 }
 
 void R3BCalifaMapped2CrystalCal::Exec(Option_t* /*option*/)
 {
-    // Reset entries in output arrays, local arrays
-    Reset();
+	// Reset entries in output arrays, local arrays
+	Reset();
 
-    // Reading the Input -- Mapped Data --
-    auto nHits = fCalifaMappedDataCA->GetEntriesFast();
+	// Reading the Input -- Mapped Data --
+	auto nHits = fCalifaMappedDataCA->GetEntriesFast();
 
-    // Overflow (R3BROOT-speech "Errors") handling:
-    // If an error bit indicates that the data is invalid,
-    // the correct approach is to set the invalid fields to NaN, imho
+	// Overflow (R3BROOT-speech "Errors") handling:
+	// If an error bit indicates that the data is invalid,
+	// the correct approach is to set the invalid fields to NaN, imho
 
-    // source: mbs f_user dir, struct_event_115a.h
-    // bit      name        invalidates
+	// source: mbs f_user dir, struct_event_115a.h
+	// bit      name        invalidates
 
-    //   0      CFD         nothing, trigger branch overflow
-    //   1      Baseline    everything
-    //   2      MAU         everything
-    //   3      MWD         everything
+	//   0      CFD         nothing, trigger branch overflow
+	//   1      Baseline    everything
+	//   2      MAU         everything
+	//   3      MWD         everything
 
-    //   4      PeakSensing everything????
-    //   5      E->EvntBuf  Energy
-    //   6      Trace->EBuf nothing, traces are not handled by R3BROOT
-    //   7      Nf->EvntBuf Nf
+	//   4      PeakSensing everything????
+	//   5      E->EvntBuf  Energy
+	//   6      Trace->EBuf nothing, traces are not handled by R3BROOT
+	//   7      Nf->EvntBuf Nf
 
-    //   8      Ns->EvntBuf Ns
+	//   8      Ns->EvntBuf Ns
     //   9      ADC         everything
     //   a      ADC underfl everything
     //   b      QPID Nf     Nf
@@ -238,8 +256,8 @@ void R3BCalifaMapped2CrystalCal::Exec(Option_t* /*option*/)
         double TotCal = Tot;
         if (fCalTotParams)
         {
-            double a0 = fCalTotParams->GetAt(fNumTotParams * (crystalId - 1));
-            double a1 = fCalTotParams->GetAt(fNumTotParams * (crystalId - 1) + 1);
+            double a0 = params_tot.at(fNumTotParams * (crystalId - 1));
+            double a1 = params_tot.at(fNumTotParams * (crystalId - 1) + 1);
             TotCal = a0 * TMath::Exp(Tot / a1);
         }
         AddCalData(crystalId, cal[en], cal[Nf], cal[Ns], wrts, TotCal);

--- a/califa/calibration/R3BCalifaMapped2CrystalCal.cxx
+++ b/califa/calibration/R3BCalifaMapped2CrystalCal.cxx
@@ -107,109 +107,110 @@ void R3BCalifaMapped2CrystalCal::SetParameter()
     // (where barrel is always in [1, 1952]) with an old calibration
 
     constexpr int offset = 2432;
-    auto& cal = *fCalParams; // because (*ptr)[i] is ugly and error-prone
+
+    auto& cal = *fCalParams;
     auto& tot = *fCalTotParams;
-    bool some_default = false;
-    for (int i=0;i<fCalTotParams->GetSize();i++)
+    bool hasDefault = false;
+    params_tot.reserve(tot.GetSize()); // optional optimization if vector size is known
+
+    for (int i = 0; i < tot.GetSize(); ++i)
     {
-	    if (fCalTotParams->GetAt(i)==0) some_default = true;
-	    if (i%2)
-	    {
-	    if (fCalTotParams->GetAt(i)==0) {params_tot.push_back(10000);}
-	    if (fCalTotParams->GetAt(i)!=0) {params_tot.push_back(fCalTotParams->GetAt(i));}
-            }
-	    else
-            {
-	    
-	    if (fCalTotParams->GetAt(i)!=0) {params_tot.push_back(fCalTotParams->GetAt(i));}
-	    if (fCalTotParams->GetAt(i)==0) {params_tot.push_back(1000);}
-	    }
-    
+    	auto value = tot.GetAt(i);
+
+    	if (value == 0)
+           hasDefault = true;
+
+        int fallback = (i % 2 == 0) ? 1000 : 10000;
+        params_tot.push_back(value != 0 ? value : fallback);
     }
-    if (some_default) {R3BLOG(info, "Could not find some Tot params, set to default values");}
+
+    if (hasDefault)
+    {
+        R3BLOG(info, "Could not find some Tot params, set to default values");
+    }
 
     if (fNumParams != 2 || fNumCrystals < 2 * offset)
     {
-	    R3BLOG(warn, "Not checking calibration in former proton range.");
-	    return;
+        R3BLOG(warn, "Not checking calibration in former proton range.");
+        return;
     }
     auto invalid = [&cal](int id)
     {
-	    auto a = cal.GetAt(2 * (id - 1) + 0);
-	    auto b = cal.GetAt(2 * (id - 1) + 1);
-	    return (std::isnan(a) || a == 0.0) && (std::isnan(a) || a == 0.0);
+        auto a = cal.GetAt(2 * (id - 1) + 0);
+        auto b = cal.GetAt(2 * (id - 1) + 1);
+        return (std::isnan(a) || a == 0.0) && (std::isnan(a) || a == 0.0);
     };
 
     int replaced{};
     for (int id = 1; id <= 1952; id++) // barrel range, formerly barrel gamma range
-	    if (invalid(id) && !invalid(id + offset))
-	    {
-		    ++replaced;
-		    // Note:  (*a)[n]=...
-		    for (int p = 0; p < fNumParams; p++)
-			    cal[fNumParams * (id - 1) + p] = cal[fNumParams * (id - 1 + offset) + p];
-		    for (int p = 0; p < fNumTotParams; p++)
-		            tot[fNumTotParams * (id - 1) + p] = tot[fNumTotParams * (id - 1 + offset) + p];
-	    }
+        if (invalid(id) && !invalid(id + offset))
+        {
+            ++replaced;
+            // Note:  (*a)[n]=...
+            for (int p = 0; p < fNumParams; p++)
+                cal[fNumParams * (id - 1) + p] = cal[fNumParams * (id - 1 + offset) + p];
+            for (int p = 0; p < fNumTotParams; p++)
+                tot[fNumTotParams * (id - 1) + p] = tot[fNumTotParams * (id - 1 + offset) + p];
+        }
 
     R3BLOG_IF(warn,
-		    replaced,
-		    replaced << " missing calibrations for crIDs in [1, 1952] have been copied over from the legacy proton "
-		    "barrel range.");
+              replaced,
+              replaced << " missing calibrations for crIDs in [1, 1952] have been copied over from the legacy proton "
+                          "barrel range.");
 }
 
 InitStatus R3BCalifaMapped2CrystalCal::Init()
 {
-	R3BLOG(info, "");
+    R3BLOG(info, "");
 
-	FairRootManager* rootManager = FairRootManager::Instance();
-	R3BLOG_IF(fatal, rootManager == nullptr, "FairRootManager not found");
+    FairRootManager* rootManager = FairRootManager::Instance();
+    R3BLOG_IF(fatal, rootManager == nullptr, "FairRootManager not found");
 
-	// INPUT DATA
-	fCalifaMappedDataCA = dynamic_cast<TClonesArray*>(rootManager->GetObject("CalifaMappedData"));
-	R3BLOG_IF(fatal, fCalifaMappedDataCA == nullptr, "CalifaMappedData not found");
+    // INPUT DATA
+    fCalifaMappedDataCA = dynamic_cast<TClonesArray*>(rootManager->GetObject("CalifaMappedData"));
+    R3BLOG_IF(fatal, fCalifaMappedDataCA == nullptr, "CalifaMappedData not found");
 
-	// OUTPUT DATA
-	fCalifaCryCalDataCA = new TClonesArray("R3BCalifaCrystalCalData");
-	rootManager->Register("CalifaCrystalCalData", "CALIFA Crystal Cal", fCalifaCryCalDataCA, !fOnline);
+    // OUTPUT DATA
+    fCalifaCryCalDataCA = new TClonesArray("R3BCalifaCrystalCalData");
+    rootManager->Register("CalifaCrystalCalData", "CALIFA Crystal Cal", fCalifaCryCalDataCA, !fOnline);
 
-	SetParameter();
-	return kSUCCESS;
+    SetParameter();
+    return kSUCCESS;
 }
 
 InitStatus R3BCalifaMapped2CrystalCal::ReInit()
 {
-	SetParContainers();
-	SetParameter();
-	return kSUCCESS;
+    SetParContainers();
+    SetParameter();
+    return kSUCCESS;
 }
 
 void R3BCalifaMapped2CrystalCal::Exec(Option_t* /*option*/)
 {
-	// Reset entries in output arrays, local arrays
-	Reset();
+    // Reset entries in output arrays, local arrays
+    Reset();
 
-	// Reading the Input -- Mapped Data --
-	auto nHits = fCalifaMappedDataCA->GetEntriesFast();
+    // Reading the Input -- Mapped Data --
+    auto nHits = fCalifaMappedDataCA->GetEntriesFast();
 
-	// Overflow (R3BROOT-speech "Errors") handling:
-	// If an error bit indicates that the data is invalid,
-	// the correct approach is to set the invalid fields to NaN, imho
+    // Overflow (R3BROOT-speech "Errors") handling:
+    // If an error bit indicates that the data is invalid,
+    // the correct approach is to set the invalid fields to NaN, imho
 
-	// source: mbs f_user dir, struct_event_115a.h
-	// bit      name        invalidates
+    // source: mbs f_user dir, struct_event_115a.h
+    // bit      name        invalidates
 
-	//   0      CFD         nothing, trigger branch overflow
-	//   1      Baseline    everything
-	//   2      MAU         everything
-	//   3      MWD         everything
+    //   0      CFD         nothing, trigger branch overflow
+    //   1      Baseline    everything
+    //   2      MAU         everything
+    //   3      MWD         everything
 
-	//   4      PeakSensing everything????
-	//   5      E->EvntBuf  Energy
-	//   6      Trace->EBuf nothing, traces are not handled by R3BROOT
-	//   7      Nf->EvntBuf Nf
+    //   4      PeakSensing everything????
+    //   5      E->EvntBuf  Energy
+    //   6      Trace->EBuf nothing, traces are not handled by R3BROOT
+    //   7      Nf->EvntBuf Nf
 
-	//   8      Ns->EvntBuf Ns
+    //   8      Ns->EvntBuf Ns
     //   9      ADC         everything
     //   a      ADC underfl everything
     //   b      QPID Nf     Nf

--- a/califa/calibration/R3BCalifaMapped2CrystalCal.h
+++ b/califa/calibration/R3BCalifaMapped2CrystalCal.h
@@ -68,6 +68,7 @@ class R3BCalifaMapped2CrystalCal : public FairTask
     UInt_t fNumTotParams = 2;
     TArrayF* fCalParams;
     TArrayF* fCalTotParams;
+    std::vector<float> params_tot;
     // Don't store data for online
     bool fOnline = false;
 

--- a/califa/online/R3BCalifaOnlineSpectra.cxx
+++ b/califa/online/R3BCalifaOnlineSpectra.cxx
@@ -119,7 +119,6 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     FairRootManager* mgr = FairRootManager::Instance();
 
     R3BLOG_IF(fatal, mgr == nullptr, "FairRootManager not found");
-
     header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
 
     FairRunOnline* run = FairRunOnline::Instance();
@@ -671,7 +670,7 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     // CANVAS Multiplicity
     cCalifaMult = new TCanvas("Califa_Multiplicity", "Califa_Multiplicity", 10, 10, 500, 500);
     fh1_Califa_Mult =
-        R3B::root_owned<TH1F>("fh1_Califa_Mult", "Califa multiplicity (crystal:blue, cluster:red)", 341, -0.5, 340.5);
+        R3B::root_owned<TH1F>("fh1_Califa_Mult", "Califa multiplicity (crystal:blue, cluster:red)", 501, -0.5, 500.5);
     fh1_Califa_MultHit = R3B::root_owned<TH1F>("fh1_Califa_MultHit", "Califa multiplicity", 341, -0.5, 340.5);
     fh1_Califa_Mult->GetXaxis()->SetTitle("Multiplicity");
     fh1_Califa_Mult->GetXaxis()->CenterTitle(true);
@@ -690,12 +689,12 @@ InitStatus R3BCalifaOnlineSpectra::Init()
 
     fh2_Califa_coinE = R3B::root_owned<TH2F>("fh2_Califa_energy_correlations",
                                              "Califa energy correlations",
-                                             (maxE - minE) / 1000.,
-                                             minE / 1000.,
-                                             maxE / 1000.,
-                                             (maxE - minE) / 1000.,
-                                             minE / 1000.,
-                                             maxE / 1000.);
+                                             400,
+                                             0,
+                                             500.,
+                                             400.,
+                                             0.,
+                                             500.);
     fh2_Califa_coinE->GetXaxis()->SetTitle("Energy (MeV)");
     fh2_Califa_coinE->GetYaxis()->SetTitle("Energy (MeV)");
     fh2_Califa_coinE->GetYaxis()->SetTitleOffset(1.2);
@@ -706,12 +705,12 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     cCalifaCoinE->cd(2);
     fh2_Califa_coinE_p2p = R3B::root_owned<TH2F>("fh2_Califa_energy_correlations_p2p",
                                                  "Califa energy correlations for p2p",
-                                                 (maxE - minE) / 1000.,
-                                                 minE / 1000.,
-                                                 maxE / 1000.,
-                                                 (maxE - minE) / 1000.,
-                                                 minE / 1000.,
-                                                 maxE / 1000.);
+                                                 400,
+                                                 0.,
+                                                 500.,
+                                                 400.,
+                                                 0.,
+                                                 500.);
     fh2_Califa_coinE_p2p->GetXaxis()->SetTitle("Energy (MeV)");
     fh2_Califa_coinE_p2p->GetYaxis()->SetTitle("Energy (MeV)");
     fh2_Califa_coinE_p2p->GetYaxis()->SetTitleOffset(1.2);
@@ -775,7 +774,8 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     cCalifa_theta_energy->Divide(1, 2);
     cCalifa_theta_energy->cd(1);
     fh2_Califa_theta_energy_pr =
-        R3B::root_owned<TH2F>(Name2.c_str(), Name3.c_str(), 500, 0, 92, fMaxEnergyPR, 0, fMaxEnergyPR);
+        R3B::root_owned<TH2F>(Name2.c_str(), Name3.c_str(), 500, 0, 92, fMaxEnergyPR, 0, 3000.);
+        //R3B::root_owned<TH2F>(Name2.c_str(), Name3.c_str(), 500, 0, 92, fMaxEnergyPR, 0, fMaxEnergyPR);
     fh2_Califa_theta_energy_pr->GetXaxis()->SetTitle("Theta [deg]");
     fh2_Califa_theta_energy_pr->GetYaxis()->SetTitle("Energy [MeV]");
     fh2_Califa_theta_energy_pr->GetYaxis()->SetTitleOffset(1.4);
@@ -1582,7 +1582,7 @@ void R3BCalifaOnlineSpectra::Exec(Option_t* /*option*/)
             int febex_ch = fMap_Par->GetFebexChannel(cryId);
             int febex_mod = fMap_Par->GetFebexMod(cryId);
             // compensate slave exploder delays:
-            int64_t wrc = hit->GetWrts();
+            int64_t wrc = hit->GetWrts() /*+ 245 * (fMap_Par->GetPreamp(cryId) > 8)*/;
             if (wrm > 0.)
             {
                 float this_califa_wr = 0;
@@ -1735,45 +1735,55 @@ void R3BCalifaOnlineSpectra::Exec(Option_t* /*option*/)
                 maxEL = califa_e[i1];
             }
         }
-        if (maxEL > fMinProtonE && maxER > fMinProtonE)
+	/*bool coplanar = false;
+        if (maxEL/1000. > 50 && maxER/1000. > 50)
+        //if (maxEL > fMinProtonE && maxER > fMinProtonE)
         {
+	std::cout << "maxER=" << maxEL << " maxER=" << maxER << std::endl; 
             auto opa = master[0].Angle(master[1]) * TMath::RadToDeg();
-            fh1_openangle->Fill(opa);
+            //fh1_openangle->Fill(opa);
             if (opa < 90. && opa > 68.)
                 fh2_Califa_coinE_p2p->Fill(maxEL / 1000., maxER / 1000.);
             for (const auto& itpat : tpatindex)
                 fh2_openangle_tpat->Fill(itpat, master[0].Angle(master[1]) * TMath::RadToDeg());
-        }
+        }*/
 
         // Comparison of hits to get energy, theta and phi correlations between them
         for (Int_t i1 = 0; i1 < califa_theta.size(); i1++)
-        {
+        { 
+            master[0].SetMagThetaPhi(1., califa_theta[i1] * TMath::DegToRad(), califa_phi[i1] * TMath::DegToRad());
             for (Int_t i2 = i1 + 1; i2 < califa_theta.size(); i2++)
             {
+                master[1].SetMagThetaPhi(1., califa_theta[i2] * TMath::DegToRad(), califa_phi[i2] * TMath::DegToRad());
+                fh2_Califa_coinPhi->Fill(califa_phi[i1], califa_phi[i2]);
+		if (abs(abs(califa_phi[i1]-califa_phi[i2])-180)<30 && califa_e[i1]/1000.>100 && califa_e[i2]/1000.>100)
+		{
+		fh1_openangle->Fill(master[0].Angle(master[1])*TMath::RadToDeg());
                 if (gRandom->Uniform(0., 1.) < 0.5)
                 {
                     fh2_Califa_coinE->Fill(califa_e[i1] / 1000., califa_e[i2] / 1000.);
                     fh2_Califa_coinTheta->Fill(califa_theta[i1], califa_theta[i2]);
-                    fh2_Califa_coinPhi->Fill(califa_phi[i1], califa_phi[i2]);
 
-                    if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 &&
-                        master[0].Angle(master[1]) * TMath::RadToDeg() < 90)
+                    if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 && master[0].Angle(master[1]) * TMath::RadToDeg() < 90)
+                    //if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 && master[0].Angle(master[1]) * TMath::RadToDeg() < 90)
                     {
                         fh2_Califa_coinTheta_cutOPA->Fill(califa_theta[i1], califa_theta[i2]);
+                       fh2_Califa_coinE_p2p->Fill(califa_e[i1] / 1000., califa_e[i2] / 1000.);
                     }
                 }
                 else
                 {
                     fh2_Califa_coinE->Fill(califa_e[i2] / 1000., califa_e[i1] / 1000.);
                     fh2_Califa_coinTheta->Fill(califa_theta[i2], califa_theta[i1]);
-                    fh2_Califa_coinPhi->Fill(califa_phi[i2], califa_phi[i1]);
+                    //fh2_Califa_coinPhi->Fill(califa_phi[i2], califa_phi[i1]);
 
-                    if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 &&
-                        master[0].Angle(master[1]) * TMath::RadToDeg() < 90)
+                    if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 && master[0].Angle(master[1]) * TMath::RadToDeg() < 90)
                     {
+                        fh2_Califa_coinE_p2p->Fill(califa_e[i2] / 1000., califa_e[i1] / 1000.);
                         fh2_Califa_coinTheta_cutOPA->Fill(califa_theta[i2], califa_theta[i1]);
                     }
                 }
+		}
             }
         }
     }

--- a/califa/online/R3BCalifaOnlineSpectra.cxx
+++ b/califa/online/R3BCalifaOnlineSpectra.cxx
@@ -687,14 +687,8 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     cCalifaCoinE->Divide(2, 1);
     cCalifaCoinE->cd(1);
 
-    fh2_Califa_coinE = R3B::root_owned<TH2F>("fh2_Califa_energy_correlations",
-                                             "Califa energy correlations",
-                                             400,
-                                             0,
-                                             500.,
-                                             400.,
-                                             0.,
-                                             500.);
+    fh2_Califa_coinE = R3B::root_owned<TH2F>(
+        "fh2_Califa_energy_correlations", "Califa energy correlations", 400, 0, 500., 400., 0., 500.);
     fh2_Califa_coinE->GetXaxis()->SetTitle("Energy (MeV)");
     fh2_Califa_coinE->GetYaxis()->SetTitle("Energy (MeV)");
     fh2_Califa_coinE->GetYaxis()->SetTitleOffset(1.2);
@@ -703,14 +697,8 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     fh2_Califa_coinE->Draw("COLZ");
 
     cCalifaCoinE->cd(2);
-    fh2_Califa_coinE_p2p = R3B::root_owned<TH2F>("fh2_Califa_energy_correlations_p2p",
-                                                 "Califa energy correlations for p2p",
-                                                 400,
-                                                 0.,
-                                                 500.,
-                                                 400.,
-                                                 0.,
-                                                 500.);
+    fh2_Califa_coinE_p2p = R3B::root_owned<TH2F>(
+        "fh2_Califa_energy_correlations_p2p", "Califa energy correlations for p2p", 400, 0., 500., 400., 0., 500.);
     fh2_Califa_coinE_p2p->GetXaxis()->SetTitle("Energy (MeV)");
     fh2_Califa_coinE_p2p->GetYaxis()->SetTitle("Energy (MeV)");
     fh2_Califa_coinE_p2p->GetYaxis()->SetTitleOffset(1.2);
@@ -775,7 +763,7 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     cCalifa_theta_energy->cd(1);
     fh2_Califa_theta_energy_pr =
         R3B::root_owned<TH2F>(Name2.c_str(), Name3.c_str(), 500, 0, 92, fMaxEnergyPR, 0, 3000.);
-        //R3B::root_owned<TH2F>(Name2.c_str(), Name3.c_str(), 500, 0, 92, fMaxEnergyPR, 0, fMaxEnergyPR);
+    // R3B::root_owned<TH2F>(Name2.c_str(), Name3.c_str(), 500, 0, 92, fMaxEnergyPR, 0, fMaxEnergyPR);
     fh2_Califa_theta_energy_pr->GetXaxis()->SetTitle("Theta [deg]");
     fh2_Califa_theta_energy_pr->GetYaxis()->SetTitle("Energy [MeV]");
     fh2_Califa_theta_energy_pr->GetYaxis()->SetTitleOffset(1.4);
@@ -1735,55 +1723,59 @@ void R3BCalifaOnlineSpectra::Exec(Option_t* /*option*/)
                 maxEL = califa_e[i1];
             }
         }
-	/*bool coplanar = false;
-        if (maxEL/1000. > 50 && maxER/1000. > 50)
-        //if (maxEL > fMinProtonE && maxER > fMinProtonE)
-        {
-	std::cout << "maxER=" << maxEL << " maxER=" << maxER << std::endl; 
-            auto opa = master[0].Angle(master[1]) * TMath::RadToDeg();
-            //fh1_openangle->Fill(opa);
-            if (opa < 90. && opa > 68.)
-                fh2_Califa_coinE_p2p->Fill(maxEL / 1000., maxER / 1000.);
-            for (const auto& itpat : tpatindex)
-                fh2_openangle_tpat->Fill(itpat, master[0].Angle(master[1]) * TMath::RadToDeg());
-        }*/
+        /*bool coplanar = false;
+            if (maxEL/1000. > 50 && maxER/1000. > 50)
+            //if (maxEL > fMinProtonE && maxER > fMinProtonE)
+            {
+        std::cout << "maxER=" << maxEL << " maxER=" << maxER << std::endl;
+                auto opa = master[0].Angle(master[1]) * TMath::RadToDeg();
+                //fh1_openangle->Fill(opa);
+                if (opa < 90. && opa > 68.)
+                    fh2_Califa_coinE_p2p->Fill(maxEL / 1000., maxER / 1000.);
+                for (const auto& itpat : tpatindex)
+                    fh2_openangle_tpat->Fill(itpat, master[0].Angle(master[1]) * TMath::RadToDeg());
+            }*/
 
         // Comparison of hits to get energy, theta and phi correlations between them
         for (Int_t i1 = 0; i1 < califa_theta.size(); i1++)
-        { 
+        {
             master[0].SetMagThetaPhi(1., califa_theta[i1] * TMath::DegToRad(), califa_phi[i1] * TMath::DegToRad());
             for (Int_t i2 = i1 + 1; i2 < califa_theta.size(); i2++)
             {
                 master[1].SetMagThetaPhi(1., califa_theta[i2] * TMath::DegToRad(), califa_phi[i2] * TMath::DegToRad());
                 fh2_Califa_coinPhi->Fill(califa_phi[i1], califa_phi[i2]);
-		if (abs(abs(califa_phi[i1]-califa_phi[i2])-180)<30 && califa_e[i1]/1000.>100 && califa_e[i2]/1000.>100)
-		{
-		fh1_openangle->Fill(master[0].Angle(master[1])*TMath::RadToDeg());
-                if (gRandom->Uniform(0., 1.) < 0.5)
+                if (abs(abs(califa_phi[i1] - califa_phi[i2]) - 180) < 30 && califa_e[i1] / 1000. > 100 &&
+                    califa_e[i2] / 1000. > 100)
                 {
-                    fh2_Califa_coinE->Fill(califa_e[i1] / 1000., califa_e[i2] / 1000.);
-                    fh2_Califa_coinTheta->Fill(califa_theta[i1], califa_theta[i2]);
-
-                    if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 && master[0].Angle(master[1]) * TMath::RadToDeg() < 90)
-                    //if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 && master[0].Angle(master[1]) * TMath::RadToDeg() < 90)
+                    fh1_openangle->Fill(master[0].Angle(master[1]) * TMath::RadToDeg());
+                    if (gRandom->Uniform(0., 1.) < 0.5)
                     {
-                        fh2_Califa_coinTheta_cutOPA->Fill(califa_theta[i1], califa_theta[i2]);
-                       fh2_Califa_coinE_p2p->Fill(califa_e[i1] / 1000., califa_e[i2] / 1000.);
+                        fh2_Califa_coinE->Fill(califa_e[i1] / 1000., califa_e[i2] / 1000.);
+                        fh2_Califa_coinTheta->Fill(califa_theta[i1], califa_theta[i2]);
+
+                        if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 &&
+                            master[0].Angle(master[1]) * TMath::RadToDeg() < 90)
+                        // if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 && master[0].Angle(master[1]) *
+                        // TMath::RadToDeg() < 90)
+                        {
+                            fh2_Califa_coinTheta_cutOPA->Fill(califa_theta[i1], califa_theta[i2]);
+                            fh2_Califa_coinE_p2p->Fill(califa_e[i1] / 1000., califa_e[i2] / 1000.);
+                        }
+                    }
+                    else
+                    {
+                        fh2_Califa_coinE->Fill(califa_e[i2] / 1000., califa_e[i1] / 1000.);
+                        fh2_Califa_coinTheta->Fill(califa_theta[i2], califa_theta[i1]);
+                        // fh2_Califa_coinPhi->Fill(califa_phi[i2], califa_phi[i1]);
+
+                        if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 &&
+                            master[0].Angle(master[1]) * TMath::RadToDeg() < 90)
+                        {
+                            fh2_Califa_coinE_p2p->Fill(califa_e[i2] / 1000., califa_e[i1] / 1000.);
+                            fh2_Califa_coinTheta_cutOPA->Fill(califa_theta[i2], califa_theta[i1]);
+                        }
                     }
                 }
-                else
-                {
-                    fh2_Califa_coinE->Fill(califa_e[i2] / 1000., califa_e[i1] / 1000.);
-                    fh2_Califa_coinTheta->Fill(califa_theta[i2], califa_theta[i1]);
-                    //fh2_Califa_coinPhi->Fill(califa_phi[i2], califa_phi[i1]);
-
-                    if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 && master[0].Angle(master[1]) * TMath::RadToDeg() < 90)
-                    {
-                        fh2_Califa_coinE_p2p->Fill(califa_e[i2] / 1000., califa_e[i1] / 1000.);
-                        fh2_Califa_coinTheta_cutOPA->Fill(califa_theta[i2], califa_theta[i1]);
-                    }
-                }
-		}
             }
         }
     }

--- a/r3bdata/califaData/R3BCalifaCrystalCalData.h
+++ b/r3bdata/califaData/R3BCalifaCrystalCalData.h
@@ -13,12 +13,12 @@
 
 #pragma once
 
+#include <TMath.h>
 #include <TObject.h>
+#include <cmath>
 #include <cstdint>
 #include <iostream>
 #include <string>
-#include <TMath.h>
-#include <cmath>
 
 class R3BCalifaCrystalCalData : public TObject
 {
@@ -50,17 +50,15 @@ class R3BCalifaCrystalCalData : public TObject
 
     // Accessors with [[nodiscard]]
     [[nodiscard]] inline const uint16_t& GetCrystalId() const { return fCrystalId; }
-    //[[nodiscard]] inline double GetEnergy() const { return fEnergy ? fEnergy : 10*TMath::Exp(fToT_Energy/950); }
     [[nodiscard]] inline double GetEnergy() const
-{
-    if (!std::isnan(fEnergy))
-        return fEnergy;
-    else if (!std::isnan(fToT_Energy))
-        return fToT_Energy;
-    else
-    { std::cout << "tot was nan" << std::endl;
-	return 0.;}
-}
+    {
+        if (!std::isnan(fEnergy))
+            return fEnergy;
+        else if (!std::isnan(fToT_Energy))
+            return fToT_Energy;
+        else
+            return 0.;
+    }
     //[[nodiscard]] inline const double& GetEnergy() const { return fEnergy;}
     [[nodiscard]] inline const double& GetNf() const { return fNf; }
     [[nodiscard]] inline const double& GetNs() const { return fNs; }

--- a/r3bdata/califaData/R3BCalifaCrystalCalData.h
+++ b/r3bdata/califaData/R3BCalifaCrystalCalData.h
@@ -17,6 +17,8 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
+#include <TMath.h>
+#include <cmath>
 
 class R3BCalifaCrystalCalData : public TObject
 {
@@ -48,7 +50,18 @@ class R3BCalifaCrystalCalData : public TObject
 
     // Accessors with [[nodiscard]]
     [[nodiscard]] inline const uint16_t& GetCrystalId() const { return fCrystalId; }
-    [[nodiscard]] inline const double& GetEnergy() const { return fEnergy; }
+    //[[nodiscard]] inline double GetEnergy() const { return fEnergy ? fEnergy : 10*TMath::Exp(fToT_Energy/950); }
+    [[nodiscard]] inline double GetEnergy() const
+{
+    if (!std::isnan(fEnergy))
+        return fEnergy;
+    else if (!std::isnan(fToT_Energy))
+        return fToT_Energy;
+    else
+    { std::cout << "tot was nan" << std::endl;
+	return 0.;}
+}
+    //[[nodiscard]] inline const double& GetEnergy() const { return fEnergy;}
     [[nodiscard]] inline const double& GetNf() const { return fNf; }
     [[nodiscard]] inline const double& GetNs() const { return fNs; }
     [[nodiscard]] inline const ULong64_t& GetTime() const { return fTime; }


### PR DESCRIPTION
R3BCalifaCrystalCalData->GetEnergy() method returns energy, but if energy is NaN, returns calibrated ToT. 

If Tot params do not exist, they are set to default values (thr=10MeV, tau=1000)

minor changes in the R3BCalifaOnlineSpectra.cxx