### PR TITLE
Califa clustering upgrade

### DIFF
--- a/califa/calibration/R3BCalifaMapped2CrystalCal.cxx
+++ b/califa/calibration/R3BCalifaMapped2CrystalCal.cxx
@@ -56,7 +56,6 @@ void R3BCalifaMapped2CrystalCal::SetParContainers()
     {
         R3BLOG(info, "califaCrystalCalPar container opened");
     }
-
     fTotCal_Par = dynamic_cast<R3BCalifaTotCalPar*>(rtdb->getContainer("CalifaTotCalPar"));
     if (!fTotCal_Par)
     {
@@ -108,8 +107,28 @@ void R3BCalifaMapped2CrystalCal::SetParameter()
     // (where barrel is always in [1, 1952]) with an old calibration
 
     constexpr int offset = 2432;
-    auto& cal = *fCalParams; // because (*ptr)[i] is ugly and error-prone
+
+    auto& cal = *fCalParams;
     auto& tot = *fCalTotParams;
+    bool hasDefault = false;
+    params_tot.reserve(tot.GetSize()); // optional optimization if vector size is known
+
+    for (int i = 0; i < tot.GetSize(); ++i)
+    {
+        auto value = tot.GetAt(i);
+
+        if (value == 0)
+            hasDefault = true;
+
+        int fallback = (i % 2 == 0) ? 10000 : 1000; // default thr=10MeV, tau=1000
+        params_tot.push_back(value != 0 ? value : fallback);
+    }
+
+    if (hasDefault)
+    {
+        R3BLOG(info, "Could not find some Tot params, set to default values");
+    }
+
     if (fNumParams != 2 || fNumCrystals < 2 * offset)
     {
         R3BLOG(warn, "Not checking calibration in former proton range.");
@@ -238,8 +257,8 @@ void R3BCalifaMapped2CrystalCal::Exec(Option_t* /*option*/)
         double TotCal = Tot;
         if (fCalTotParams)
         {
-            double a0 = fCalTotParams->GetAt(fNumTotParams * (crystalId - 1));
-            double a1 = fCalTotParams->GetAt(fNumTotParams * (crystalId - 1) + 1);
+            double a0 = params_tot.at(fNumTotParams * (crystalId - 1));
+            double a1 = params_tot.at(fNumTotParams * (crystalId - 1) + 1);
             TotCal = a0 * TMath::Exp(Tot / a1);
         }
         AddCalData(crystalId, cal[en], cal[Nf], cal[Ns], wrts, TotCal);

--- a/califa/calibration/R3BCalifaMapped2CrystalCal.h
+++ b/califa/calibration/R3BCalifaMapped2CrystalCal.h
@@ -68,6 +68,7 @@ class R3BCalifaMapped2CrystalCal : public FairTask
     UInt_t fNumTotParams = 2;
     TArrayF* fCalParams;
     TArrayF* fCalTotParams;
+    std::vector<float> params_tot;
     // Don't store data for online
     bool fOnline = false;
 

--- a/califa/online/R3BCalifaOnlineSpectra.cxx
+++ b/califa/online/R3BCalifaOnlineSpectra.cxx
@@ -119,7 +119,6 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     FairRootManager* mgr = FairRootManager::Instance();
 
     R3BLOG_IF(fatal, mgr == nullptr, "FairRootManager not found");
-
     header = dynamic_cast<R3BEventHeader*>(mgr->GetObject("EventHeader."));
 
     FairRunOnline* run = FairRunOnline::Instance();
@@ -671,7 +670,7 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     // CANVAS Multiplicity
     cCalifaMult = new TCanvas("Califa_Multiplicity", "Califa_Multiplicity", 10, 10, 500, 500);
     fh1_Califa_Mult =
-        R3B::root_owned<TH1F>("fh1_Califa_Mult", "Califa multiplicity (crystal:blue, cluster:red)", 341, -0.5, 340.5);
+        R3B::root_owned<TH1F>("fh1_Califa_Mult", "Califa multiplicity (crystal:blue, cluster:red)", 501, -0.5, 500.5);
     fh1_Califa_MultHit = R3B::root_owned<TH1F>("fh1_Califa_MultHit", "Califa multiplicity", 341, -0.5, 340.5);
     fh1_Califa_Mult->GetXaxis()->SetTitle("Multiplicity");
     fh1_Califa_Mult->GetXaxis()->CenterTitle(true);
@@ -688,14 +687,8 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     cCalifaCoinE->Divide(2, 1);
     cCalifaCoinE->cd(1);
 
-    fh2_Califa_coinE = R3B::root_owned<TH2F>("fh2_Califa_energy_correlations",
-                                             "Califa energy correlations",
-                                             (maxE - minE) / 1000.,
-                                             minE / 1000.,
-                                             maxE / 1000.,
-                                             (maxE - minE) / 1000.,
-                                             minE / 1000.,
-                                             maxE / 1000.);
+    fh2_Califa_coinE = R3B::root_owned<TH2F>(
+        "fh2_Califa_energy_correlations", "Califa energy correlations", 400, 0, 500., 400., 0., 500.);
     fh2_Califa_coinE->GetXaxis()->SetTitle("Energy (MeV)");
     fh2_Califa_coinE->GetYaxis()->SetTitle("Energy (MeV)");
     fh2_Califa_coinE->GetYaxis()->SetTitleOffset(1.2);
@@ -704,14 +697,8 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     fh2_Califa_coinE->Draw("COLZ");
 
     cCalifaCoinE->cd(2);
-    fh2_Califa_coinE_p2p = R3B::root_owned<TH2F>("fh2_Califa_energy_correlations_p2p",
-                                                 "Califa energy correlations for p2p",
-                                                 (maxE - minE) / 1000.,
-                                                 minE / 1000.,
-                                                 maxE / 1000.,
-                                                 (maxE - minE) / 1000.,
-                                                 minE / 1000.,
-                                                 maxE / 1000.);
+    fh2_Califa_coinE_p2p = R3B::root_owned<TH2F>(
+        "fh2_Califa_energy_correlations_p2p", "Califa energy correlations for p2p", 400, 0., 500., 400., 0., 500.);
     fh2_Califa_coinE_p2p->GetXaxis()->SetTitle("Energy (MeV)");
     fh2_Califa_coinE_p2p->GetYaxis()->SetTitle("Energy (MeV)");
     fh2_Califa_coinE_p2p->GetYaxis()->SetTitleOffset(1.2);
@@ -775,7 +762,8 @@ InitStatus R3BCalifaOnlineSpectra::Init()
     cCalifa_theta_energy->Divide(1, 2);
     cCalifa_theta_energy->cd(1);
     fh2_Califa_theta_energy_pr =
-        R3B::root_owned<TH2F>(Name2.c_str(), Name3.c_str(), 500, 0, 92, fMaxEnergyPR, 0, fMaxEnergyPR);
+        R3B::root_owned<TH2F>(Name2.c_str(), Name3.c_str(), 500, 0, 92, fMaxEnergyPR, 0, 3000.);
+    // R3B::root_owned<TH2F>(Name2.c_str(), Name3.c_str(), 500, 0, 92, fMaxEnergyPR, 0, fMaxEnergyPR);
     fh2_Califa_theta_energy_pr->GetXaxis()->SetTitle("Theta [deg]");
     fh2_Califa_theta_energy_pr->GetYaxis()->SetTitle("Energy [MeV]");
     fh2_Califa_theta_energy_pr->GetYaxis()->SetTitleOffset(1.4);
@@ -1582,7 +1570,7 @@ void R3BCalifaOnlineSpectra::Exec(Option_t* /*option*/)
             int febex_ch = fMap_Par->GetFebexChannel(cryId);
             int febex_mod = fMap_Par->GetFebexMod(cryId);
             // compensate slave exploder delays:
-            int64_t wrc = hit->GetWrts();
+            int64_t wrc = hit->GetWrts() /*+ 245 * (fMap_Par->GetPreamp(cryId) > 8)*/;
             if (wrm > 0.)
             {
                 float this_califa_wr = 0;
@@ -1735,43 +1723,57 @@ void R3BCalifaOnlineSpectra::Exec(Option_t* /*option*/)
                 maxEL = califa_e[i1];
             }
         }
-        if (maxEL > fMinProtonE && maxER > fMinProtonE)
-        {
-            auto opa = master[0].Angle(master[1]) * TMath::RadToDeg();
-            fh1_openangle->Fill(opa);
-            if (opa < 90. && opa > 68.)
-                fh2_Califa_coinE_p2p->Fill(maxEL / 1000., maxER / 1000.);
-            for (const auto& itpat : tpatindex)
-                fh2_openangle_tpat->Fill(itpat, master[0].Angle(master[1]) * TMath::RadToDeg());
-        }
+        /*bool coplanar = false;
+            if (maxEL/1000. > 50 && maxER/1000. > 50)
+            //if (maxEL > fMinProtonE && maxER > fMinProtonE)
+            {
+        std::cout << "maxER=" << maxEL << " maxER=" << maxER << std::endl;
+                auto opa = master[0].Angle(master[1]) * TMath::RadToDeg();
+                //fh1_openangle->Fill(opa);
+                if (opa < 90. && opa > 68.)
+                    fh2_Califa_coinE_p2p->Fill(maxEL / 1000., maxER / 1000.);
+                for (const auto& itpat : tpatindex)
+                    fh2_openangle_tpat->Fill(itpat, master[0].Angle(master[1]) * TMath::RadToDeg());
+            }*/
 
         // Comparison of hits to get energy, theta and phi correlations between them
         for (Int_t i1 = 0; i1 < califa_theta.size(); i1++)
         {
+            master[0].SetMagThetaPhi(1., califa_theta[i1] * TMath::DegToRad(), califa_phi[i1] * TMath::DegToRad());
             for (Int_t i2 = i1 + 1; i2 < califa_theta.size(); i2++)
             {
-                if (gRandom->Uniform(0., 1.) < 0.5)
+                master[1].SetMagThetaPhi(1., califa_theta[i2] * TMath::DegToRad(), califa_phi[i2] * TMath::DegToRad());
+                fh2_Califa_coinPhi->Fill(califa_phi[i1], califa_phi[i2]);
+                if (abs(abs(califa_phi[i1] - califa_phi[i2]) - 180) < 30 && califa_e[i1] / 1000. > 100 &&
+                    califa_e[i2] / 1000. > 100)
                 {
-                    fh2_Califa_coinE->Fill(califa_e[i1] / 1000., califa_e[i2] / 1000.);
-                    fh2_Califa_coinTheta->Fill(califa_theta[i1], califa_theta[i2]);
-                    fh2_Califa_coinPhi->Fill(califa_phi[i1], califa_phi[i2]);
-
-                    if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 &&
-                        master[0].Angle(master[1]) * TMath::RadToDeg() < 90)
+                    fh1_openangle->Fill(master[0].Angle(master[1]) * TMath::RadToDeg());
+                    if (gRandom->Uniform(0., 1.) < 0.5)
                     {
-                        fh2_Califa_coinTheta_cutOPA->Fill(califa_theta[i1], califa_theta[i2]);
+                        fh2_Califa_coinE->Fill(califa_e[i1] / 1000., califa_e[i2] / 1000.);
+                        fh2_Califa_coinTheta->Fill(califa_theta[i1], califa_theta[i2]);
+
+                        if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 &&
+                            master[0].Angle(master[1]) * TMath::RadToDeg() < 90)
+                        // if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 && master[0].Angle(master[1]) *
+                        // TMath::RadToDeg() < 90)
+                        {
+                            fh2_Califa_coinTheta_cutOPA->Fill(califa_theta[i1], califa_theta[i2]);
+                            fh2_Califa_coinE_p2p->Fill(califa_e[i1] / 1000., califa_e[i2] / 1000.);
+                        }
                     }
-                }
-                else
-                {
-                    fh2_Califa_coinE->Fill(califa_e[i2] / 1000., califa_e[i1] / 1000.);
-                    fh2_Califa_coinTheta->Fill(califa_theta[i2], califa_theta[i1]);
-                    fh2_Califa_coinPhi->Fill(califa_phi[i2], califa_phi[i1]);
-
-                    if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 &&
-                        master[0].Angle(master[1]) * TMath::RadToDeg() < 90)
+                    else
                     {
-                        fh2_Califa_coinTheta_cutOPA->Fill(califa_theta[i2], califa_theta[i1]);
+                        fh2_Califa_coinE->Fill(califa_e[i2] / 1000., califa_e[i1] / 1000.);
+                        fh2_Califa_coinTheta->Fill(califa_theta[i2], califa_theta[i1]);
+                        // fh2_Califa_coinPhi->Fill(califa_phi[i2], califa_phi[i1]);
+
+                        if (master[0].Angle(master[1]) * TMath::RadToDeg() > 68 &&
+                            master[0].Angle(master[1]) * TMath::RadToDeg() < 90)
+                        {
+                            fh2_Califa_coinE_p2p->Fill(califa_e[i2] / 1000., califa_e[i1] / 1000.);
+                            fh2_Califa_coinTheta_cutOPA->Fill(califa_theta[i2], califa_theta[i1]);
+                        }
                     }
                 }
             }

--- a/r3bdata/califaData/R3BCalifaCrystalCalData.h
+++ b/r3bdata/califaData/R3BCalifaCrystalCalData.h
@@ -13,7 +13,9 @@
 
 #pragma once
 
+#include <TMath.h>
 #include <TObject.h>
+#include <cmath>
 #include <cstdint>
 #include <iostream>
 #include <string>
@@ -48,7 +50,20 @@ class R3BCalifaCrystalCalData : public TObject
 
     // Accessors with [[nodiscard]]
     [[nodiscard]] inline const uint16_t& GetCrystalId() const { return fCrystalId; }
-    [[nodiscard]] inline const double& GetEnergy() const { return fEnergy; }
+    //[[nodiscard]] inline double GetEnergy() const { return fEnergy ? fEnergy : 10*TMath::Exp(fToT_Energy/950); }
+    [[nodiscard]] inline double GetEnergy() const
+    {
+        if (!std::isnan(fEnergy))
+            return fEnergy;
+        else if (!std::isnan(fToT_Energy))
+            return fToT_Energy;
+        else
+        {
+            std::cout << "tot was nan" << std::endl;
+            return 0.;
+        }
+    }
+    //[[nodiscard]] inline const double& GetEnergy() const { return fEnergy;}
     [[nodiscard]] inline const double& GetNf() const { return fNf; }
     [[nodiscard]] inline const double& GetNs() const { return fNs; }
     [[nodiscard]] inline const ULong64_t& GetTime() const { return fTime; }

--- a/ssd/online/R3BFootOnlineSpectra.cxx
+++ b/ssd/online/R3BFootOnlineSpectra.cxx
@@ -255,6 +255,14 @@ InitStatus R3BFootOnlineSpectra::Init()
         {
             cSigma->cd(i_pad);
             fh2_SigmaVsStrip[i]->Draw("col");
+            for (int i_asic = 1; i_asic < 10; i_asic++)
+            {
+                TLine* l = new TLine(64.5 * i_asic, 0, 64.5 * i_asic, 15);
+                l->Draw("same");
+                l->SetLineStyle(7);
+                l->SetLineWidth(1);
+                l->SetLineColor(13);
+            }
             i_pad++;
         }
     }


### PR DESCRIPTION
- R3BCalifaCrystalCalData.h -> GetEnergy() returns ToT [keV] if energy is NaN. This avoids bad behaviour when the clustering algorithm finds an overflow in energy
- Minor changes in the online spectra
- Tot params are set to default (thr = 10MeV, tau = 1000) if params are not found
- Minor change in the style of FOOT histograms

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
