### PR TITLE
totcal = 0 if totmap = 0 to avoid artifact in cal level

### DIFF
--- a/califa/calibration/R3BCalifaMapped2CrystalCal.cxx
+++ b/califa/calibration/R3BCalifaMapped2CrystalCal.cxx
@@ -259,7 +259,8 @@ void R3BCalifaMapped2CrystalCal::Exec(Option_t* /*option*/)
         {
             double a0 = params_tot.at(fNumTotParams * (crystalId - 1));
             double a1 = params_tot.at(fNumTotParams * (crystalId - 1) + 1);
-            TotCal = a0 * TMath::Exp(Tot / a1);
+            // TotCal = a0 * TMath::Exp(Tot / a1);
+            TotCal = (Tot == 0) ? 0 : a0 * TMath::Exp(Tot / a1);
         }
         AddCalData(crystalId, cal[en], cal[Nf], cal[Ns], wrts, TotCal);
     }


### PR DESCRIPTION
tot is calibrated into energy as Etot = a0 * exp(tot/a1). when tot = 0, Etot was being calibrated into Etot = a0, which is not correct. This was creating artificial counts.