### PR TITLE
Added backwards compatibility with previous experiments.

### DIFF
--- a/ssd/calibration/R3BFootMapped2StripCal.cxx
+++ b/ssd/calibration/R3BFootMapped2StripCal.cxx
@@ -132,12 +132,13 @@ void R3BFootMapped2StripCal::SetParameter()
     }
     else
     {
-        R3BLOG(warn, "FineSigmas array not found, initializing with default value .0");
+        R3BLOG(warn,
+               "FineSigmas array not found, initializing with default value 20. Please, disregard the 10.000 entries!");
         for (Int_t d = 0; d < fNDets; d++)
         {
             for (Int_t i = 0; i < fNStrip; i++)
             {
-                fine_sigmas[d][i] = 0.;
+                fine_sigmas[d][i] = 20.;
                 fCal_Par->SetFineSigma(0., d * fNStrip + i);
             }
         }

--- a/ssd/online/R3BFootOnlineSpectra.cxx
+++ b/ssd/online/R3BFootOnlineSpectra.cxx
@@ -158,7 +158,7 @@ InitStatus R3BFootOnlineSpectra::Init()
     mainfol->Add(mapfol);
 
     auto cMap = new TCanvas("FOOT_mapped", "mapped info", 10, 10, 500, 500);
-    cMap->Divide(4, 2);
+    cMap->Divide(4, fNbDet / 4);
     mapfol->Add(cMap);
 
     //================  Mapped data =====================
@@ -176,26 +176,24 @@ InitStatus R3BFootOnlineSpectra::Init()
         fh2_EnergyVsStrip[i]->GetYaxis()->SetTitleOffset(1.4);
         fh2_EnergyVsStrip[i]->GetXaxis()->CenterTitle(true);
         int foot_num = i + 1;
-        if (foot_num < 9)
+
+        cMap->cd(i_pad);
+        fh2_EnergyVsStrip[i]->Draw("col");
+        for (int i_asic = 1; i_asic < 10; i_asic++)
         {
-            cMap->cd(i_pad);
-            fh2_EnergyVsStrip[i]->Draw("col");
-            for (int i_asic = 1; i_asic < 10; i_asic++)
-            {
-                TLine* l = new TLine(64.5 * i_asic, fMinE, 64.5 * i_asic, fMaxE);
-                l->Draw("same");
-                l->SetLineStyle(7);
-                l->SetLineWidth(1);
-                l->SetLineColor(13);
-            }
-            i_pad++;
+            TLine* l = new TLine(64.5 * i_asic, fMinE, 64.5 * i_asic, fMaxE);
+            l->Draw("same");
+            l->SetLineStyle(7);
+            l->SetLineWidth(1);
+            l->SetLineColor(13);
         }
+        i_pad++;
     }
 
     //============ CAL data ==================
 
     auto cCal = new TCanvas("FOOT_cal", "cal info", 10, 10, 500, 500);
-    cCal->Divide(4, 2);
+    cCal->Divide(4, fNbDet / 4);
     calfol->Add(cCal);
 
     if (fCalItems)
@@ -213,27 +211,27 @@ InitStatus R3BFootOnlineSpectra::Init()
             fh2_EnergyVsStrip_cal[i]->GetXaxis()->CenterTitle(true);
             fh2_EnergyVsStrip_cal[i]->GetYaxis()->CenterTitle(true);
             int foot_num = i + 1;
-            if (foot_num < 9)
+            // if (foot_num < 9)
+            //{
+            cCal->cd(i_pad);
+            fh2_EnergyVsStrip_cal[i]->Draw("col");
+            for (int i_asic = 1; i_asic < 10; i_asic++)
             {
-                cCal->cd(i_pad);
-                fh2_EnergyVsStrip_cal[i]->Draw("col");
-                for (int i_asic = 1; i_asic < 10; i_asic++)
-                {
-                    TLine* l = new TLine(64.5 * i_asic, fMinE, 64.5 * i_asic, fMaxE / 3.);
-                    l->Draw("same");
-                    l->SetLineStyle(7);
-                    l->SetLineWidth(1);
-                    l->SetLineColor(13);
-                }
-                i_pad++;
+                TLine* l = new TLine(64.5 * i_asic, fMinE, 64.5 * i_asic, fMaxE / 3.);
+                l->Draw("same");
+                l->SetLineStyle(7);
+                l->SetLineWidth(1);
+                l->SetLineColor(13);
             }
+            i_pad++;
+            //}
         }
     }
 
     //------------- SIGMA -------------------
 
     auto cSigma = new TCanvas("FOOT_sigma", "Sigma info", 10, 10, 500, 500);
-    cSigma->Divide(4, 2);
+    cSigma->Divide(4, fNbDet / 4);
     calfol->Add(cSigma);
 
     fh2_SigmaVsStrip.resize(fNbDet);
@@ -251,25 +249,25 @@ InitStatus R3BFootOnlineSpectra::Init()
         fh2_SigmaVsStrip[i]->GetYaxis()->CenterTitle(true);
 
         int foot_num = i + 1;
-        if (foot_num < 9)
+        // if (foot_num < 9)
+        //{
+        cSigma->cd(i_pad);
+        fh2_SigmaVsStrip[i]->Draw("col");
+        for (int i_asic = 1; i_asic < 10; i_asic++)
         {
-            cSigma->cd(i_pad);
-            fh2_SigmaVsStrip[i]->Draw("col");
-            for (int i_asic = 1; i_asic < 10; i_asic++)
-            {
-                TLine* l = new TLine(64.5 * i_asic, 0, 64.5 * i_asic, 15);
-                l->Draw("same");
-                l->SetLineStyle(7);
-                l->SetLineWidth(1);
-                l->SetLineColor(13);
-            }
-            i_pad++;
+            TLine* l = new TLine(64.5 * i_asic, 0, 64.5 * i_asic, 15);
+            l->Draw("same");
+            l->SetLineStyle(7);
+            l->SetLineWidth(1);
+            l->SetLineColor(13);
         }
+        i_pad++;
+        //}
     }
 
     //================ HIT data ==========================
 
-    int n = fNbDet / 2;
+    int n = fXNdx.size();
     int r = 2;
 
     R3BLOG_IF(fatal, n > 100, Form("Number of FOOT is too high. Are you sure you have %d FOOTs?", 2 * n));
@@ -278,52 +276,61 @@ InitStatus R3BFootOnlineSpectra::Init()
 
     // General canvas info (cluster position and energy)
     auto cHit = new TCanvas("FOOT_hit", "hit general info", 10, 10, 500, 500);
-    cHit->Divide(4, 4);
+    cHit->Divide(2 * fNbDet / 4, 4);
 
     // General canvas info (cluster position and energy)
     auto cHitMax = new TCanvas("FOOT_hitMax", "hit general info (max energy)", 10, 10, 500, 500);
-    cHitMax->Divide(4, 4);
+    cHitMax->Divide(2 * fNbDet / 4, 4);
 
     // Correlation position between detectors
     auto cHit_PosCorr = new TCanvas("FOOT_posCorr", "hit position correlation info", 10, 10, 500, 500);
-    cHit_PosCorr->Divide(2, 2);
+    cHit_PosCorr->Divide(fNbDet / 4, 2);
 
     // Eta
     auto cHit_Eta = new TCanvas("FOOT_eta", "hit eta plot info", 10, 10, 500, 500);
-    cHit_Eta->Divide(4, 2);
+    cHit_Eta->Divide(fNbDet / 2, 2);
 
     // Eta
     auto cHit_EtaMax = new TCanvas("FOOT_etaMax", "hit eta plot info (max energy)", 10, 10, 500, 500);
-    cHit_EtaMax->Divide(4, 2);
+    cHit_EtaMax->Divide(fNbDet / 2, 2);
 
     // Multiplicity and cluster size
     auto cHit_MultSize = new TCanvas("FOOT_mulSize", "hit multiplicity and size info", 10, 10, 500, 500);
-    cHit_MultSize->Divide(4, 4);
+    cHit_MultSize->Divide(2 * fNbDet / 4, 4);
 
     // Energy correlation
     auto cHit_EnergyCorr = new TCanvas("FOOT_energyCorr", "Energy correlation", 10, 10, 500, 500);
-    cHit_EnergyCorr->Divide(2, 2);
+    cHit_EnergyCorr->Divide(fNbDet / 4, 2);
 
     // Max energy correlation
     auto cHit_MaxEnergyCorr = new TCanvas("FOOT_maxEnergyCorr", "Max energy correlation", 10, 10, 500, 500);
-    cHit_MaxEnergyCorr->Divide(2, 2);
+    cHit_MaxEnergyCorr->Divide(fNbDet / 4, 2);
 
     // Eta
     auto cHit_Charge = new TCanvas("FOOT_charge", "charge info", 10, 10, 500, 500);
-    cHit_Charge->Divide(4, 2);
+    cHit_Charge->Divide(fNbDet / 4, 4);
 
     // position vs energy
     auto cHit_position_charge = new TCanvas("FOOT_position_charge", "charge info", 10, 10, 500, 500);
-    cHit_position_charge->Divide(4, 2);
+    cHit_position_charge->Divide(fNbDet / 4, 4);
 
     // Max pos correlation
     auto cHit_XYCorrMax = new TCanvas("FOOT_XYCorrMax", "Position correlation XY (max energy)", 10, 10, 500, 500);
-    cHit_XYCorrMax->Divide(2, 2);
+    cHit_XYCorrMax->Divide(fNbDet / 4, 2);
 
     // Max pos correlation
     auto cHit_SameCorrMax =
         new TCanvas("FOOT_SameCorrMax", "Position correlation XX and YY (max energy)", 10, 10, 500, 500);
-    cHit_SameCorrMax->Divide(4, 3);
+
+    // Different combinations depending on the setup
+    if (dim % 8 == 0)
+        cHit_SameCorrMax->Divide(dim / 4, 8);
+    else if (dim % 4 == 0)
+        cHit_SameCorrMax->Divide(dim / 2, 4);
+    else if (dim % 5 == 0)
+        cHit_SameCorrMax->Divide(dim / 5 * 2, 5);
+    else
+        cHit_SameCorrMax->Divide(dim, 2);
 
     hitfol->Add(cHit);
     hitfol->Add(cHitMax);
@@ -378,8 +385,6 @@ InitStatus R3BFootOnlineSpectra::Init()
             }
         }
 
-        // dim = fCorrNdxX.size() / 2;
-
         for (int i = 0; i < dim; i++)
         {
 
@@ -410,7 +415,7 @@ InitStatus R3BFootOnlineSpectra::Init()
             cHit_SameCorrMax->cd(i + 1);
             fh2_XX_max_corr[i]->Draw();
 
-            cHit_SameCorrMax->cd(i + 7);
+            cHit_SameCorrMax->cd(i + 1 + dim);
             fh2_YY_max_corr[i]->Draw();
         }
 
@@ -506,7 +511,7 @@ InitStatus R3BFootOnlineSpectra::Init()
             fh2_pos_charge[i]->GetXaxis()->CenterTitle(true);
             fh2_pos_charge[i]->GetYaxis()->CenterTitle(true);
 
-            if ((i % 2) == 0)
+            if ((i % 2) == 0 && (i / 2 + 1 <= fXNdx.size()))
             {
                 sprintf(Name1, "fh2_pos_corr_dets_%d_%d", fXNdx[i / 2] + 1, fYNdx[i / 2] + 1);
                 sprintf(Name2, "Cluster position correlation for FOOTs: %d and %d", fXNdx[i / 2] + 1, fYNdx[i / 2] + 1);
@@ -559,61 +564,56 @@ InitStatus R3BFootOnlineSpectra::Init()
             }
 
             int foot_num = i + 1;
-            if (foot_num < 9)
+
+            cHit->cd(i_pad_double);
+            fh1_ene[i]->Draw();
+            cHit->cd(i_pad_double + 1);
+            fh1_pos[i]->Draw();
+
+            cHitMax->cd(i_pad_double);
+            fh1_eneMax[i]->Draw();
+            cHitMax->cd(i_pad_double + 1);
+            fh1_posMax[i]->Draw();
+
+            if ((foot_num % 2) == 1 && (i / 2 + 1 <= fXNdx.size()))
             {
 
-                cHit->cd(i_pad_double);
-                fh1_ene[i]->Draw();
-                cHit->cd(i_pad_double + 1);
-                fh1_pos[i]->Draw();
+                cHit_PosCorr->cd(i_pad_corr);
+                fh2_foot_corr[i / 2]->Draw();
 
-                cHitMax->cd(i_pad_double);
-                fh1_eneMax[i]->Draw();
-                cHitMax->cd(i_pad_double + 1);
-                fh1_posMax[i]->Draw();
+                cHit_EnergyCorr->cd(i_pad_corr);
+                fh2_energy_corr[i / 2]->Draw();
 
-                if ((foot_num % 2) == 1)
-                {
-                    if (foot_num < 12) // do not change!
-                    {
-                        cHit_PosCorr->cd(i_pad_corr);
-                        fh2_foot_corr[i / 2]->Draw();
+                cHit_MaxEnergyCorr->cd(i_pad_corr);
+                fh2_energy_corr_max[i / 2]->Draw();
 
-                        cHit_EnergyCorr->cd(i_pad_corr);
-                        fh2_energy_corr[i / 2]->Draw();
+                cHit_XYCorrMax->cd(i_pad_corr);
+                fh2_XY_max_corr[i / 2]->Draw();
 
-                        cHit_MaxEnergyCorr->cd(i_pad_corr);
-                        fh2_energy_corr_max[i / 2]->Draw();
-
-                        cHit_XYCorrMax->cd(i_pad_corr);
-                        fh2_XY_max_corr[i / 2]->Draw();
-
-                        i_pad_corr++;
-                    }
-                }
-
-                cHit_Eta->cd(i_pad);
-                fh2_eta[i]->Draw();
-
-                cHit_EtaMax->cd(i_pad);
-                fh2_etaMax[i]->Draw();
-
-                cHit_Charge->cd(i_pad);
-                fh1_charge[i]->Draw();
-
-                cHit_MultSize->cd(i_pad_double);
-                fh1_size[i]->Draw();
-                cHit_MultSize->cd(i_pad_double + 1);
-                fh1_mult[i]->Draw();
-
-                cHit_position_charge->cd(i_pad);
-                fh2_pos_charge[i]->Draw();
-
-                i_pad_double++;
-                i_pad_double++;
-
-                i_pad++;
+                i_pad_corr++;
             }
+
+            cHit_Eta->cd(i_pad);
+            fh2_eta[i]->Draw();
+
+            cHit_EtaMax->cd(i_pad);
+            fh2_etaMax[i]->Draw();
+
+            cHit_Charge->cd(i_pad);
+            fh1_charge[i]->Draw();
+
+            cHit_MultSize->cd(i_pad_double);
+            fh1_size[i]->Draw();
+            cHit_MultSize->cd(i_pad_double + 1);
+            fh1_mult[i]->Draw();
+
+            cHit_position_charge->cd(i_pad);
+            fh2_pos_charge[i]->Draw();
+
+            i_pad_double++;
+            i_pad_double++;
+
+            i_pad++;
         }
     }
 
@@ -658,6 +658,7 @@ void R3BFootOnlineSpectra::Reset_FOOT_Histo()
     }
 
     // Hit data
+
     if (fHitItems)
     {
         for (Int_t i = 0; i < fNbDet; i++)
@@ -673,7 +674,7 @@ void R3BFootOnlineSpectra::Reset_FOOT_Histo()
             fh1_charge[i]->Reset();
             fh2_pos_charge[i]->Reset();
 
-            if ((i % 2) == 0)
+            if ((i % 2) == 0 && (i / 2 + 1 <= fXNdx.size()))
             {
                 fh2_foot_corr[i / 2]->Reset();
                 fh2_energy_corr[i / 2]->Reset();
@@ -688,6 +689,7 @@ void R3BFootOnlineSpectra::Reset_FOOT_Histo()
             fh2_YY_max_corr[i]->Reset();
         }
     }
+
     return;
 }
 
@@ -824,8 +826,9 @@ void R3BFootOnlineSpectra::Exec(Option_t* option)
         }
     }
 
-    for (int i = 0; i < fNbDet / 2; i++)
+    for (int i = 0; i < fXNdx.size(); i++)
     {
+
         // Max energy
         if ((maxEnergy[fXNdx[i]] > 0) && (maxEnergy[fYNdx[i]] > 0))
         {
@@ -896,6 +899,7 @@ void R3BFootOnlineSpectra::FinishEvent()
     {
         fCalItems->Clear();
     }
+
     if (fHitItems)
     {
         fHitItems->Clear();
@@ -936,7 +940,7 @@ void R3BFootOnlineSpectra::FinishTask()
             fh2_etaMax[i]->Write();
             fh1_charge[i]->Write();
 
-            if ((i % 2) == 0)
+            if ((i % 2) == 0 && (i / 2 + 1 <= fXNdx.size()))
             {
                 fh2_foot_corr[i / 2]->Write();
                 fh2_energy_corr[i / 2]->Write();
@@ -951,6 +955,7 @@ void R3BFootOnlineSpectra::FinishTask()
             fh2_YY_max_corr[i]->Write();
         }
     }
+
     return;
 }
 

--- a/ssd/online/R3BFootOnlineSpectra.h
+++ b/ssd/online/R3BFootOnlineSpectra.h
@@ -155,7 +155,7 @@ class R3BFootOnlineSpectra : public FairTask
     // Number of posible combinations of correlations
     int dim = 6;
 
-    // Variables measured by each foot
+    // Variables measured by each foot (example of G-249 experiment)
     std::vector<int> fXNdx = { 0, 2, 5, 7 };
     std::vector<int> fYNdx = { 1, 3, 4, 6 };
 

--- a/ssd/pars/R3BFootCalPar.cxx
+++ b/ssd/pars/R3BFootCalPar.cxx
@@ -109,11 +109,13 @@ Bool_t R3BFootCalPar::getParams(FairParamList* list)
         LOG(fatal) << "R3BFootCalPar::Could not initialize footStripCalPar";
         return kFALSE;
     }
+
     fFineSigmas->Set(fNumDets * fNumStrips);
 
     if (!(list->fill("footFineSigmas", fFineSigmas)))
     {
-        LOG(fatal) << "R3BFootCalPar::Could not initialize footFineSigmas";
+        LOG(warn)
+            << "R3BFootCalPar::Could not initialize footFineSigmas. This is ok if your experiment is older than g249.";
         return kFALSE;
     }
 


### PR DESCRIPTION
Fixed two main problemas:

- In the remake of the calibration classes for the g249, a variable fine_sigmas was added both to the cal data level and to the cal parameter container. Since fine_sigmas are calculated at the map2cal level, running the common online chain (reader, map2cal, cal2hit, onlineSpectra) should not generate errors, even when using data from previous experiments. However, since fine sigmas have to be initialized to some value, the new map2cal class expected it to be provided by the parameter container. This was obviously missing in .par files from previous experiments, generating an error. Now it is fixed and, if not provided, an initial value of 20 is assumed. (NB, fine sigmas are recalculated, by default, every 10,000 events, so please make a reset on the histograms after this events to see the good plots or just adapt the .par file to the new class).

- In the OnlineSpectra class, new histograms displaying correlations between positions of the same coordinate (XX and YY), as well as XY points have been included. Since this is relatively dependent on the experiment, two general ideas were considered. 

1. FOOTs are assumed to be ordered, and the coordinate is determined by footAnglePhiPar (0 or 180 for X, 90 or 270 for Y), **assuming the same number of X and Y detectors**. Although this may not seem very general, it can be made to work by using the mapping function and **modifying the .par file accordingly**.

2. For XX and YY correlations, all possible combinations were considered. For instance, if 1, 3, 5 are X and 2, 4, 6 are Y we will have, 1-3, 1-5, 3-5, 2-4, 2-6, 4-6. 

These two points had one issue: if a .par file contains values like 0, 270, 0, 0 (not used), 90, 180, 0 (not used), 90, meaning that two FOOTs (4 and 7) were unused, an error will occur due to an imbalance in the number of X and Y coordinates. To fix this, use a different value (e.g., -1) instead of 0 for unused FOOTs. This will fix the problem and make everything run again.

To sum up, if you want to run a full online with old data you should:

- Run following the usual process (reader, map2cal, cal2hit, onlineSpectra) and reset histograms (in the online) after 10,000 events (and disregard these events in the posterior analysis, or manually assign the fine sigma).  
- Set to -1 the footAnglePhiPar variable in the .par file of unused FOOT (if any).
---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
