### PR TITLE
Add utilities to clear or resize multiple containers

### DIFF
--- a/r3bbase/R3BShared.h
+++ b/r3bbase/R3BShared.h
@@ -215,4 +215,17 @@ namespace R3B
         std::sort(filelist.begin(), filelist.end());
         return filelist;
     }
+
+    // batch clear and resize for STL containers
+    template <typename... Containers>
+    inline void ClearAll(Containers&... containers)
+    {
+        (containers.clear(), ...);
+    }
+
+    template <typename... Containers>
+    inline void ResizeAll(std::size_t n, Containers&... containers)
+    {
+        (containers.resize(n), ...);
+    }
 } // namespace R3B


### PR DESCRIPTION
This PR introduces ClearAll and ResizeAll, which simplify repetitive operations on multiple containers, such as clearing or resizing vectors holding histogram pointers in online analysis code.
---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
