### PR TITLE
Modification on CMakeLists to give MacOS compatibility

### DIFF
--- a/cmake/modules/R3BMacros.cmake
+++ b/cmake/modules/R3BMacros.cmake
@@ -60,7 +60,7 @@ ENDMACRO (ROOT_GENERATE_DICTIONARY_OLD_EXTRA)
 Macro (R3B_Generate_Version_Info)
   Add_Custom_Target(svnr3bheader ALL)
 
-  Add_Custom_Command(TARGET svnr3bheader
+  Add_Custom_Command(TARGET svnr3bheader POST_BUILD
                      COMMAND ${CMAKE_COMMAND} -DSOURCE_DIR=${CMAKE_SOURCE_DIR}
                      -DBINARY_DIR=${CMAKE_BINARY_DIR}
                      -DINCLUDE_OUTPUT_DIRECTORY=${INCLUDE_OUTPUT_DIRECTORY}

--- a/evtvis/CMakeLists.txt
+++ b/evtvis/CMakeLists.txt
@@ -39,6 +39,8 @@ add_library_with_dictionary(
     INCLUDEDIRS
     ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDENCIES
+    ROOT::Eve
+    FairRoot::EventDisplay
     R3BCalifa)
 
 # set(DEPENDENCIES

--- a/r3bbase/CMakeLists.txt
+++ b/r3bbase/CMakeLists.txt
@@ -49,7 +49,7 @@ set(HEADERS
     R3BTsplinePar.h
     R3BWhiterabbitPropagator.h)
 
-set(DEPENDENCIES FairRoot::Generators FairRoot::Online)
+set(DEPENDENCIES FairRoot::Generators FairRoot::Online ROOT::RHTTP)
 
 add_library_with_dictionary(
     LIBNAME

--- a/ssd/CMakeLists.txt
+++ b/ssd/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library_with_dictionary(
     pars
     sim
     DEPENDENCIES
+    ROOT::Spectrum
     R3BTracking R3BTCal R3BNeulandShared)
 
 add_subdirectory(test)

--- a/tofd/CMakeLists.txt
+++ b/tofd/CMakeLists.txt
@@ -75,4 +75,5 @@ add_library_with_dictionary(
     sim
     DEPENDENCIES
     R3BTracking
+    ROOT::Spectrum
     R3BTCal)

--- a/tofi/CMakeLists.txt
+++ b/tofi/CMakeLists.txt
@@ -66,4 +66,5 @@ add_library_with_dictionary(
     sim
     DEPENDENCIES
     R3BTCal
+    ROOT::Spectrum
     R3BTracking)


### PR DESCRIPTION
For MacOS, classes using ROOT or FairRoot classes need to include them as dependencies in the CMakeLists.txt.

(NB, this version still does not compile for MacOS, it seems a problem with neuland/executables/neulandSim.cxx dependencies).

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
