### PR TITLE
Github CI: Fix the cache hit issue

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -35,7 +35,7 @@ runs:
           r3b-build-
 
     - name: build ucesb
-      if: steps.cache-ucesb.outputs.cache-hit != 'true'
+      if: steps.cache-ucesb.outputs.cache-hit == ''
       run: |
         echo "ucesb directory is set as ${UCESB_DIR}"
         export LD_LIBRARY_PATH="${SIMPATH}/lib/:${LD_LIBRARY_PATH}"


### PR DESCRIPTION
Just encountered an issue due to `cache-hit` not correctly handled.

See this: https://github.com/actions/cache/issues/1566

> The `cache` action provides a `cache-hit` output which is set to `true` when the cache is restored using the primary `key` and `false` when the cache is restored using `restore-keys`. If no cache is restored, it is set to the empty string.


---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
