### PR TITLE
feat(foot): Eta correction and charge calibration added

### DIFF
--- a/ssd/calibration/R3BFootStripCal2Hit.cxx
+++ b/ssd/calibration/R3BFootStripCal2Hit.cxx
@@ -14,6 +14,7 @@
 // ------------------------------------------------------------------------
 // -----            R3BFootStripCal2Hit source file                   -----
 // -----       Created 05/11/21 by J.L. Rodriguez-Sanchez             -----
+// -----       Modified 05/2025 by Pablo Gonzalez Rusell              -----
 // ------------------------------------------------------------------------
 
 // ROOT headers
@@ -24,6 +25,7 @@
 #include <TRandom3.h>
 #include <TSpectrum.h>
 #include <iomanip>
+#include <memory>
 #include <vector>
 
 // FAIR headers
@@ -60,6 +62,7 @@ void R3BFootStripCal2Hit::SetParContainers()
     // Parameter Container
     // Reading footMappingPar from FairRuntimeDb
     FairRuntimeDb* rtdb = FairRuntimeDb::instance();
+
     R3BLOG_IF(fatal, !rtdb, "FairRuntimeDb not found");
 
     fMap_Par = dynamic_cast<R3BFootMappingPar*>(rtdb->getContainer("footMappingPar"));
@@ -73,7 +76,9 @@ void R3BFootStripCal2Hit::SetParContainers()
     }
 
     R3BLOG(info, "Calling SetParContainers()");
+
     fHit_Par = dynamic_cast<R3BFootHitPar*>(rtdb->getContainer("footHitPar"));
+
     if (!fHit_Par)
     {
         R3BLOG(error, "SetParContainers(): footHitPar not found");
@@ -105,26 +110,59 @@ void R3BFootStripCal2Hit::SetParameter()
     }
     fMap_Par->printParams();
 
-    if (!fHit_Par)
+    // Hit parameters
+    if (!fHit_Par || fHit_Par->GetNumParsFit() == -1)
     {
         R3BLOG(error, "SetParameter(): fHit_Par is NULL");
+        fHit_Par = nullptr;
+        return;
     }
     else
     {
         R3BLOG(info, TString::Format("SetParameter(): fHit_Par is VALID, NumParsFit = %d", fHit_Par->GetNumParsFit()));
     }
 
-    fNumParsFit = fHit_Par->GetNumParsFit();
-    HitCalParams = fHit_Par->GetCharCalParams();
-    Int_t array_size = fMaxNumDet * fNumParsFit;
-    HitCalParams->Set(array_size);
+    // Number of parameters for the eta-fit and the charge-energy fit
+    fNumParsCal = fHit_Par->GetNumParsFit();
+    fNumParsEtaCorr = fHit_Par->GetNumParsEtaCorr();
 
-    for (int d = 0; d < fMaxNumDet; d++)
+    constexpr int asicNum = 10;
+
+    // Get the multiplicity vector. It contains the amount of charge
+    // states seen by each asic
+    for (int i = 0; i < fMaxNumDet * asicNum; i++)
     {
-        for (int j = 0; j < fNumParsFit; j++)
+        fMultCharPar.push_back(fHit_Par->GetMultCharParams()->At(i));
+    }
+
+    // One vector per asic
+    fCharCalPar.resize(fMaxNumDet * asicNum);
+    fCharCalParSM.resize(fMaxNumDet * asicNum);
+    fEtaCorrPar.resize(fMaxNumDet * asicNum);
+
+    // Now we iterate over the multiplicity of each asic. If the asic is from
+    // a dead foot (i.e, mult == 0, we continue). Otherwise, we start filling
+    // with the pol coeficients of each charge state (eta band) in each asic.
+    int nParsEta = 0;
+    int nParsCal = 0;
+
+    for (int i = 0; i < fMultCharPar.size(); i++)
+    {
+        for (int j = nParsEta; j < nParsEta + fMultCharPar[i]; j++)
+            fEtaCorrPar[i].push_back(fHit_Par->GetEtaCorrParams()->At(j));
+
+        nParsEta += fMultCharPar[i];
+
+        if (fMultCharPar[i] == 0)
+            continue;
+
+        for (int j = nParsCal; j < nParsCal + fNumParsCal; j++)
         {
-            fCharCalPar.push_back(HitCalParams->GetAt(d * fNumParsFit + j));
+            fCharCalPar[i].push_back(fHit_Par->GetCharCalParams()->At(j));
+            fCharCalParSM[i].push_back(fHit_Par->GetCharCalParamsSM()->At(j));
         }
+
+        nParsCal += fNumParsCal;
     }
 }
 
@@ -144,13 +182,13 @@ InitStatus R3BFootStripCal2Hit::Init()
         return kFATAL;
     }
 
-    // Set container with mapping parameters
-    SetParameter();
-
     // Output data
     fFootHitData = new TClonesArray("R3BFootHitData");
     rootManager->Register("FootHitData", "FOOT Hit", fFootHitData, !fOnline);
     fFootHitData->Clear();
+
+    // Set container with mapping parameters
+    SetParameter();
 
     return kSUCCESS;
 }
@@ -291,6 +329,7 @@ void R3BFootStripCal2Hit::Exec(Option_t* /*option*/)
 
                 ClusterPos[i][j] += ClusterE[i][j][k] * ClusterI[i][j][k];
             }
+
             ClusterPos[i][j] = ClusterPos[i][j] / ClusterESum[i][j];
             Eta[i][j] = ClusterPos[i][j] - (int)ClusterPos[i][j];
         }
@@ -332,6 +371,10 @@ void R3BFootStripCal2Hit::Exec(Option_t* /*option*/)
         {
             double pos = 100. * ClusterPos[i][j] / 640. - fMiddle;
 
+            // Identify the asic to which the hit belongs
+            // (useful for later corrections)
+            int asicId = static_cast<int>(ClusterPos[i][j] / 64);
+
             if (fAnglePhi[i] == 0.)
             { // X-Foot (StripId numbered from left to right)
                 x = pos * TMath::Cos(fAngleTheta[i] * TMath::DegToRad()) + fOffsetX[i];
@@ -362,27 +405,89 @@ void R3BFootStripCal2Hit::Exec(Option_t* /*option*/)
             }
 
             TVector3 master(x, y, z);
-            // TODO: Eta correction not used at the moment
 
-            // Charge calibration (charge = m * energy + n)
-            double m = 1;
-            double n = 0;
+            // *********** Eta correction *********** //
 
-            if (fCharCalPar.size() > 0)
+            int generalIndex = i * 10 + asicId;
+
+            double energyCorrected = -1;
+            double charge = -1;
+
+            if (!fHit_Par)
             {
-                if (fCharCalPar[i * fNumParsFit] != 0)
+                energyCorrected = ClusterESum[i][j];
+                charge = energyCorrected;
+            }
+            else
+            {
+                int nCharges = fMultCharPar[generalIndex] / fNumParsEtaCorr;
+
+                // If the asic has no correction parameters we continue
+                if (nCharges == 0)
+                    continue;
+
+                // With a good asic, we have to identify how many charge
+                // states does it see (i.e. how many eta bands)
+                std::vector<std::unique_ptr<TF1>> polCoefs(nCharges);
+
+                for (int iCharge = 0; iCharge < nCharges; iCharge++)
                 {
-                    m = fCharCalPar[i * fNumParsFit];
-                    n = fCharCalPar[i * fNumParsFit + 1];
+                    // One polynom per charge state
+                    auto name = Form("pol_foot_%i_asic_%i_charge_%i", i, asicId, iCharge);
+                    auto polType = Form("pol%i", fNumParsEtaCorr - 1);
+                    polCoefs[iCharge] = std::make_unique<TF1>(name, polType, 0, 1);
+
+                    for (int iCoef = 0; iCoef < fNumParsEtaCorr; iCoef++)
+                    {
+                        polCoefs[iCharge]->SetParameter(iCoef,
+                                                        fEtaCorrPar[generalIndex][iCoef + iCharge * fNumParsEtaCorr]);
+                    }
                 }
+
+                // Now, for our Eta value, we calculate all the predicted energies
+                // (one per polynom), and then, the min of the would be the charge
+                // state to which our hit belongs
+                std::vector<double> diffCharge(nCharges);
+                int minIndex = 0;
+
+                for (int iCharge = 0; iCharge < nCharges; iCharge++)
+                {
+                    diffCharge[iCharge] = polCoefs[iCharge]->Eval(Eta[i][j]) - ClusterESum[i][j];
+
+                    if (std::abs(diffCharge[iCharge]) < std::abs(diffCharge[minIndex]))
+                        minIndex = iCharge;
+                }
+
+                // Correct the energy for eta > 0
+                if (Eta[i][j] != 0)
+                    energyCorrected = polCoefs[minIndex]->Eval(0.5) - diffCharge[minIndex];
+                else
+                    energyCorrected = ClusterESum[i][j];
+
+                // *********** Charge calibration *********** //
+
+                // Get the coeficients for this asic
+                auto name = Form("fitFunc_foot_%i_asic_%i", i, asicId);
+                auto polType = Form("pol%i", fNumParsCal - 1);
+                auto fitFunc = std::make_unique<TF1>(name, polType);
+
+                auto chargeParams = fCharCalPar;
+
+                if (Eta[i][j] == 0)
+                    chargeParams = fCharCalParSM;
+
+                for (int iPol = 0; iPol < fNumParsCal; iPol++)
+                {
+                    fitFunc->SetParameter(iPol, chargeParams[generalIndex][iPol]);
+                }
+
+                charge = fitFunc->Eval(energyCorrected);
             }
 
-            double charge = m * ClusterESum[i][j] + n;
-
-            if (ClusterESum[i][j] > fThSum && j < fMaxNumClusters)
+            if (energyCorrected > fThSum && j < fMaxNumClusters)
             {
-                AddHitData(
-                    i + 1, ClusterNStrip[i][j], pos, master, ClusterESum[i][j], ClusterMult[i], Eta[i][j], charge);
+
+                AddHitData(i + 1, ClusterMult[i], pos, master, energyCorrected, ClusterNStrip[i][j], Eta[i][j], charge);
             }
             else
             {

--- a/ssd/calibration/R3BFootStripCal2Hit.h
+++ b/ssd/calibration/R3BFootStripCal2Hit.h
@@ -14,6 +14,7 @@
 // ---------------------------------------------------------------------
 // -----            R3BFootStripCal2Hit source file                -----
 // -----       Created 05/11/21 by J.L. Rodriguez-Sanchez          -----
+// -----       Modified 05/2025 by Pablo Gonzalez Rusell           -----
 // ---------------------------------------------------------------------
 
 #pragma once
@@ -88,18 +89,24 @@ class R3BFootStripCal2Hit : public FairTask
     std::vector<double> fAnglePhi;
     std::vector<double> fOffsetX;
     std::vector<double> fOffsetY;
-    std::vector<double> fCharCalPar;
     std::vector<TH1F*> hssd;
     TArrayF* HitCalParams = nullptr;
 
-    std::vector<int> ClusterMult;                 // Cluster multiplicity
-    std::vector<std::vector<double>> ClusterPos;  // Position of Cluster from Weighted Average
-    std::vector<std::vector<double>> Eta;         // Decimal part of the average position of the cluster
-    std::vector<std::vector<double>> ClusterESum; // Sum of Energies in the Cluster
-    // std::vector<std::vector<double>> Nu;       // Nu for Energy/Position correction
+    std::vector<int> ClusterMult;                           // Cluster multiplicity
+    std::vector<std::vector<double>> ClusterPos;            // Position of Cluster from Weighted Average
+    std::vector<std::vector<double>> Eta;                   // Decimal part of the average position of the cluster
+    std::vector<std::vector<double>> ClusterESum;           // Sum of Energies in the Cluster
     std::vector<std::vector<int>> ClusterNStrip;            // Number of Strips in Cluster
     std::vector<std::vector<std::vector<double>>> ClusterI; // Id Strip in Cluster
     std::vector<std::vector<std::vector<double>>> ClusterE; // Energy of Strip in Cluster
+
+    // Parameters for the eta correction and calibration
+    int fNumParsCal = 2;
+    int fNumParsEtaCorr = 5;
+    std::vector<int> fMultCharPar;
+    std::vector<std::vector<double>> fEtaCorrPar;
+    std::vector<std::vector<double>> fCharCalPar;
+    std::vector<std::vector<double>> fCharCalParSM;
 
     R3BFootMappingPar* fMap_Par = nullptr; // Parameter container with mapping
     R3BFootHitPar* fHit_Par = nullptr;     // Parameter container with hit params

--- a/ssd/online/R3BFootOnlineSpectra.cxx
+++ b/ssd/online/R3BFootOnlineSpectra.cxx
@@ -14,6 +14,7 @@
 // ------------------------------------------------------------
 // -----             R3BFootOnlineSpectra                 -----
 // -----    Created 16/07/21 by J.L. Rodriguez-Sanchez    -----
+// -----       Modified 05/2025 by Pablo Gonzalez Rusell  -----
 // -----          Fill FOOT online histograms             -----
 // ------------------------------------------------------------
 
@@ -25,6 +26,7 @@
 #include "R3BEventHeader.h"
 #include "R3BFootCalData.h"
 #include "R3BFootHitData.h"
+#include "R3BFootHitPar.h"
 #include "R3BFootMappedData.h"
 #include "R3BFootMappingPar.h"
 #include "R3BLogger.h"
@@ -76,13 +78,24 @@ void R3BFootOnlineSpectra::SetParContainers()
     {
         R3BLOG(info, "footMappingPar found");
     }
+
+    fHit_Par = dynamic_cast<R3BFootHitPar*>(rtdb->getContainer("footHitPar"));
+    if (!fHit_Par)
+    {
+        R3BLOG(warn,
+               "Couldn't get handle on footHitgPar container. Eta correction and charge calibration will be disabled.");
+    }
+    else
+    {
+        R3BLOG(info, "footHitPar found");
+    }
 }
 
 void R3BFootOnlineSpectra::SetParameter()
 {
     if (!fMap_Par)
     {
-        R3BLOG(warn, "Container footMappingPar not found");
+        R3BLOG(warn, "Container footMappingPar not found.");
         return;
     }
     //--- Parameter Container ---
@@ -107,6 +120,13 @@ void R3BFootOnlineSpectra::SetParameter()
         {
             fYNdx.push_back(i);
         }
+    }
+
+    if (!fHit_Par || fHit_Par->GetNumParsFit() == -1)
+    {
+        R3BLOG(error, "SetParameter(): fHit_Par is NULL");
+        fHit_Par = nullptr;
+        return;
     }
 }
 
@@ -204,7 +224,7 @@ InitStatus R3BFootOnlineSpectra::Init()
         {
             sprintf(Name1, "fh2_energy_vs_strip_cal_det_%d", i + 1);
             sprintf(Name2, "Cal-energy vs strip number for FOOT Det: %d", i + 1);
-            fh2_EnergyVsStrip_cal[i] = R3B::root_owned<TH2F>(Name1, Name2, 640, 1, 641, fBinsE, fMinE, fMaxE / 3.);
+            fh2_EnergyVsStrip_cal[i] = R3B::root_owned<TH2F>(Name1, Name2, 640, 1, 641, fBinsE, fMinE, fMaxE);
             fh2_EnergyVsStrip_cal[i]->GetXaxis()->SetTitle("Strip number");
             fh2_EnergyVsStrip_cal[i]->GetYaxis()->SetTitle("Energy [channels]");
             fh2_EnergyVsStrip_cal[i]->GetYaxis()->SetTitleOffset(1.4);
@@ -217,7 +237,7 @@ InitStatus R3BFootOnlineSpectra::Init()
             fh2_EnergyVsStrip_cal[i]->Draw("col");
             for (int i_asic = 1; i_asic < 10; i_asic++)
             {
-                TLine* l = new TLine(64.5 * i_asic, fMinE, 64.5 * i_asic, fMaxE / 3.);
+                TLine* l = new TLine(64.5 * i_asic, fMinE, 64.5 * i_asic, fMaxE);
                 l->Draw("same");
                 l->SetLineStyle(7);
                 l->SetLineWidth(1);
@@ -369,6 +389,13 @@ InitStatus R3BFootOnlineSpectra::Init()
         fh2_XX_max_corr.resize(dim);
         fh2_YY_max_corr.resize(dim);
 
+        // If there is no charge calibration charge ~ energy
+        if (!fHit_Par)
+        {
+            fMinZ = fMinE;
+            fMaxZ = fMaxE;
+        }
+
         R3BLOG_IF(fatal,
                   fXNdx.size() != fYNdx.size(),
                   "You don't have the same number of X detector than Y detectors... Is it ok?");
@@ -495,7 +522,7 @@ InitStatus R3BFootOnlineSpectra::Init()
 
             sprintf(Name1, "fh1_charge_det_%d", i + 1);
             sprintf(Name2, "Charge for FOOT Det: %d", i + 1);
-            fh1_charge[i] = R3B::root_owned<TH1F>(Name1, Name2, fBinsE, fMinE, fMaxE);
+            fh1_charge[i] = R3B::root_owned<TH1F>(Name1, Name2, fBinsE, fMinZ, fMaxZ);
             fh1_charge[i]->GetXaxis()->SetTitle("Charge");
             fh1_charge[i]->GetYaxis()->SetTitle("Counts");
             fh1_charge[i]->GetYaxis()->SetTitleOffset(1.4);
@@ -504,7 +531,7 @@ InitStatus R3BFootOnlineSpectra::Init()
 
             sprintf(Name1, "fh2_pos_charge_det_%d", i + 1);
             sprintf(Name2, " Position vs Energy for FOOT Det: %d", i + 1);
-            fh2_pos_charge[i] = R3B::root_owned<TH2F>(Name1, Name2, 200, -50., 50., fBinsE / 2., 0, fMaxE);
+            fh2_pos_charge[i] = R3B::root_owned<TH2F>(Name1, Name2, 200, -50., 50., fBinsE / 2., fMinZ, fMaxZ);
             fh2_pos_charge[i]->GetXaxis()->SetTitle("Position [mm]");
             fh2_pos_charge[i]->GetYaxis()->SetTitle("Charge");
             fh2_pos_charge[i]->GetYaxis()->SetTitleOffset(1.4);
@@ -536,7 +563,8 @@ InitStatus R3BFootOnlineSpectra::Init()
 
                 sprintf(Name1, "fh2_energ_corr_dets_%d_%d", fXNdx[i / 2] + 1, fYNdx[i / 2]);
                 sprintf(Name2, "Cluster energy correlation for FOOTs: %d and %d", fXNdx[i / 2] + 1, fYNdx[i / 2] + 1);
-                fh2_energy_corr[i / 2] = R3B::root_owned<TH2F>(Name1, Name2, fBinsE, 0, fMaxE, fBinsE, 0, fMaxE);
+                fh2_energy_corr[i / 2] =
+                    R3B::root_owned<TH2F>(Name1, Name2, fBinsE, fMinZ, fMaxZ, fBinsE, fMinZ, fMaxZ);
 
                 sprintf(Name1, "Energy det %d [channels]", fXNdx[i / 2] + 1);
                 fh2_energy_corr[i / 2]->GetXaxis()->SetTitle(Name1);
@@ -552,7 +580,7 @@ InitStatus R3BFootOnlineSpectra::Init()
                         fXNdx[i / 2] + 1,
                         fYNdx[i / 2] + 1);
                 fh2_energy_corr_max[i / 2] =
-                    R3B::root_owned<TH2F>(Name1, Name2, fBinsE / 2, 0, fMaxE, fBinsE / 2, 0, fMaxE);
+                    R3B::root_owned<TH2F>(Name1, Name2, fBinsE / 2, fMinZ, fMaxZ, fBinsE / 2, fMinZ, fMaxZ);
 
                 sprintf(Name1, "Max energy det %d [channels]", fXNdx[i / 2] + 1);
                 fh2_energy_corr_max[i / 2]->GetXaxis()->SetTitle(Name1);
@@ -770,13 +798,13 @@ void R3BFootOnlineSpectra::Exec(Option_t* option)
             fh1_size[hit->GetDetId() - 1]->Fill(hit->GetMulStrip());
 
             // Only calculate charge when it is on a constant eta-energy profile
-            if ((hit->GetEta() < 0.7) && (hit->GetEta() > 0.3))
+            if (fHit_Par || ((hit->GetEta() < 0.7) && (hit->GetEta() > 0.3)))
             {
                 fh1_charge[hit->GetDetId() - 1]->Fill(hit->GetZCharge());
-                fh2_pos_charge[hit->GetDetId() - 1]->Fill(hit->GetPosLab()[XorY], hit->GetEnergy());
+                fh2_pos_charge[hit->GetDetId() - 1]->Fill(hit->GetPosLab()[XorY], hit->GetZCharge());
             }
 
-            energies[hit->GetDetId() - 1].push_back(hit->GetEnergy());
+            energies[hit->GetDetId() - 1].push_back(hit->GetZCharge());
             positions[hit->GetDetId() - 1].push_back(hit->GetPosLab()[XorY]);
             mult[hit->GetDetId() - 1]++;
             fh2_eta[hit->GetDetId() - 1]->Fill(hit->GetEta(), hit->GetEnergy());
@@ -816,7 +844,7 @@ void R3BFootOnlineSpectra::Exec(Option_t* option)
         if (maxNdx[i] > -1)
         {
 
-            if ((etas[i][maxNdx[i]] > 0.3) && (etas[i][maxNdx[i]] < 0.7))
+            if (fHit_Par || ((etas[i][maxNdx[i]] > 0.3) && (etas[i][maxNdx[i]] < 0.7)))
             {
                 fh1_eneMax[i]->Fill(energies[i][maxNdx[i]]);
             }
@@ -832,8 +860,8 @@ void R3BFootOnlineSpectra::Exec(Option_t* option)
         // Max energy
         if ((maxEnergy[fXNdx[i]] > 0) && (maxEnergy[fYNdx[i]] > 0))
         {
-            if ((etas[fXNdx[i]][maxNdx[fXNdx[i]]] > 0.3) && (etas[fXNdx[i]][maxNdx[fXNdx[i]]] < 0.7) &&
-                (etas[fYNdx[i]][maxNdx[fYNdx[i]]] > 0.3) && (etas[fYNdx[i]][maxNdx[fYNdx[i]]] < 0.7))
+            if (fHit_Par || ((etas[fXNdx[i]][maxNdx[fXNdx[i]]] > 0.3) && (etas[fXNdx[i]][maxNdx[fXNdx[i]]] < 0.7) &&
+                             (etas[fYNdx[i]][maxNdx[fYNdx[i]]] > 0.3) && (etas[fYNdx[i]][maxNdx[fYNdx[i]]] < 0.7)))
             {
                 fh2_energy_corr_max[i]->Fill(maxEnergy[fXNdx[i]], maxEnergy[fYNdx[i]]);
             }
@@ -849,8 +877,8 @@ void R3BFootOnlineSpectra::Exec(Option_t* option)
                 {
 
                     // Only fill if energy is the central eta region
-                    if ((etas[fXNdx[i]][j1] > 0.3) && (etas[fXNdx[i]][j1] < 0.7) && (etas[fYNdx[i]][j2] > 0.3) &&
-                        (etas[fYNdx[i]][j2] < 0.7))
+                    if (fHit_Par || ((etas[fXNdx[i]][j1] > 0.3) && (etas[fXNdx[i]][j1] < 0.7) &&
+                                     (etas[fYNdx[i]][j2] > 0.3) && (etas[fYNdx[i]][j2] < 0.7)))
                     {
                         fh2_energy_corr[i]->Fill(energies[fXNdx[i]][j1], energies[fYNdx[i]][j2]);
                     }

--- a/ssd/online/R3BFootOnlineSpectra.h
+++ b/ssd/online/R3BFootOnlineSpectra.h
@@ -14,6 +14,7 @@
 // ------------------------------------------------------------
 // -----             R3BFootOnlineSpectra                 -----
 // -----    Created 16/07/21 by J.L. Rodriguez-Sanchez    -----
+// -----       Modified 05/2025 by Pablo Gonzalez Rusell  -----
 // -----          Fill FOOT online histograms             -----
 // ------------------------------------------------------------
 
@@ -34,6 +35,7 @@
 class TClonesArray;
 class R3BEventHeader;
 class R3BFootMappingPar;
+class R3BFootHitPar;
 class TH1F;
 class TH2F;
 
@@ -106,11 +108,13 @@ class R3BFootOnlineSpectra : public FairTask
 
     void SetSigmaRefreshRate(int rate) { fSigmaRefreshRate = rate; }
 
-    void SetBinParams(double minE, double maxE, double binsE)
+    void SetBinParams(double minE, double maxE, double binsE, double minZ, double maxZ)
     {
         fMinE = minE;
         fMaxE = maxE;
         fBinsE = binsE;
+        fMinZ = minZ;
+        fMaxZ = maxZ;
     }
 
     void SetMaxSize(double max) { fMaxSize = max; }
@@ -136,6 +140,7 @@ class R3BFootOnlineSpectra : public FairTask
     TClonesArray* fHitItems = nullptr;      // Array with hit items.
 
     R3BFootMappingPar* fMap_Par = nullptr; // Parameter container with mapping
+    R3BFootHitPar* fHit_Par = nullptr;     // Parameter container with mapping
 
     int fTrigger = -1; // Trigger value.
     int fTpat = 0;
@@ -148,6 +153,9 @@ class R3BFootOnlineSpectra : public FairTask
     double fMinE = -100.;
     double fMaxE = 5000.;
     double fBinsE = 1000;
+
+    double fMinZ = 0;
+    double fMaxZ = 15;
 
     // Maximum size of the cluster (-1 for no maximum)
     double fMaxSize = -1;

--- a/ssd/pars/R3BFootHitPar.cxx
+++ b/ssd/pars/R3BFootHitPar.cxx
@@ -13,7 +13,7 @@
 
 // ------------------------------------------------------------------
 // -----                R3BFootHitPar source file               -----
-// -----         Created 17/05/25 by J.L. Rodriguez-Sanchez     -----
+// -----         Created 17/05/25 by Pablo González Rusell      -----
 // ------------------------------------------------------------------
 
 #include "R3BFootHitPar.h"
@@ -30,7 +30,10 @@ R3BFootHitPar::R3BFootHitPar(const char* name, const char* title, const char* co
     : FairParGenericSet(name, title, context)
 {
     detName = "FootHit";
-    fCharCalPar = new TArrayF(fNumDets * fNumParsFit);
+    fMultCharPar = new TArrayF(fNumDets * 10);
+    fCharCalPar = new TArrayF();
+    fCharCalParSM = new TArrayF();
+    fEtaCorrPar = new TArrayF();
 }
 
 // ----  Destructor ------------------------------------------------------------
@@ -38,6 +41,13 @@ R3BFootHitPar::~R3BFootHitPar()
 {
     this->clear(); // NOLINT
     delete fCharCalPar;
+    fCharCalPar = nullptr;
+    delete fCharCalParSM;
+    fCharCalParSM = nullptr;
+    delete fMultCharPar;
+    fMultCharPar = nullptr;
+    delete fEtaCorrPar;
+    fEtaCorrPar = nullptr;
 }
 
 // ----  Method clear ----------------------------------------------------------
@@ -57,14 +67,28 @@ void R3BFootHitPar::putParams(FairParamList* list)
         return;
     }
 
-    Int_t array_size = fNumDets;
-    LOG(info) << "Array Size: " << array_size;
+    // Get the size of the parameters
+    Int_t array_size = 0;
 
-    fCharCalPar->Set(array_size * fNumParsFit);
+    for (int i = 0; i < fMultCharPar->GetSize(); ++i)
+        array_size += static_cast<int>(fMultCharPar->At(i));
 
+    R3BLOG(info, Form("Number of active asics: %i", array_size));
+
+    // Create the charge and eta arrays
+    fCharCalPar->Set(array_size * fNumParsCal);
+    fCharCalParSM->Set(array_size * fNumParsCal);
+    fEtaCorrPar->Set(array_size * fNumParsEtaCorr);
+
+    // Save the values
     list->add("footDetNbPar", fNumDets);
+    list->add("footNumberCalPars", fNumParsCal);
+    list->add("footNumberEtaCorrPars", fNumParsEtaCorr);
+
     list->add("footCharCalPar", *fCharCalPar);
-    list->add("footNumberParsFit", fNumParsFit);
+    list->add("footCharCalParSM", *fCharCalParSM);
+    list->add("footEtaCorrPar", *fEtaCorrPar);
+    list->add("footMultCharPar", *fMultCharPar);
 }
 
 // ----  Method getParams ------------------------------------------------------
@@ -83,18 +107,49 @@ Bool_t R3BFootHitPar::getParams(FairParamList* list)
         return kFALSE;
     }
 
-    if (!list->fill("footNumberParsFit", &fNumParsFit))
+    if (!list->fill("footNumberCalPars", &fNumParsCal))
     {
-        LOG(fatal) << "R3BFootCalPar::Could not initialize footNumberParsFit";
+        R3BLOG(fatal, "R3BFootHitPar::Could not initialize footNumberCalPars");
         return kFALSE;
     }
 
-    Int_t array_size = fNumDets;
-    fCharCalPar->Set(array_size * fNumParsFit);
+    if (!list->fill("footNumberEtaCorrPars", &fNumParsEtaCorr))
+    {
+        R3BLOG(fatal, "R3BFootHitPar::Could not initialize footNumberEtaCorrPars");
+        return kFALSE;
+    }
+
+    if (!list->fill("footMultCharPar", fMultCharPar))
+    {
+        R3BLOG(fatal, "R3BFootHitPar::Could not initialize footMultCharPar");
+        return kFALSE;
+    }
+
+    Int_t array_size = 0;
+
+    for (int i = 0; i < fMultCharPar->GetSize(); ++i)
+        array_size += static_cast<int>(fMultCharPar->At(i));
+
+    fCharCalPar->Set(array_size * fNumParsCal);
+    fCharCalParSM->Set(array_size * fNumParsCal);
+    fEtaCorrPar->Set(array_size * fNumParsEtaCorr);
 
     if (!(list->fill("footCharCalPar", fCharCalPar)))
     {
-        LOG(fatal) << "R3BFootCalPar::Could not initialize footCharCalPar";
+        R3BLOG(fatal, "R3BFootHitPar::Could not initialize footCharCalPar");
+        return kFALSE;
+    }
+
+    // We assume that the calibration parameters are the same for all multiplicities
+    R3BLOG_IF(warn,
+              !(list->fill("footCharCalParSM", fCharCalParSM)),
+              "R3BFootHitPar::Could not initialize footCharCalParSM. Single multiplicity calibration will not be used");
+
+    list->fill("footCharCalPar", fCharCalParSM);
+
+    if (!(list->fill("footEtaCorrPar", fEtaCorrPar)))
+    {
+        R3BLOG(fatal, "R3BFootHitPar::Could not initialize footEtaCorrPar");
         return kFALSE;
     }
 
@@ -105,16 +160,8 @@ Bool_t R3BFootHitPar::getParams(FairParamList* list)
 void R3BFootHitPar::print()
 {
     R3BLOG(info, "Foot Hit Parameters");
-
-    for (Int_t d = 0; d < fNumDets; d++)
-    {
-        R3BLOG(info, "Foot detector number: " << d + 1);
-
-        for (Int_t j = 0; j < fNumParsFit; j++)
-        {
-            LOG(info) << "FitParam(" << j + 1 << ") = " << fCharCalPar->GetAt(d * fNumParsFit + j);
-        }
-    }
+    R3BLOG(info, Form("Number of calibration parameters: %i", fNumParsCal));
+    R3BLOG(info, Form("Number of eta correction parameters: %i", fNumParsEtaCorr));
 }
 
 ClassImp(R3BFootHitPar)

--- a/ssd/pars/R3BFootHitPar.h
+++ b/ssd/pars/R3BFootHitPar.h
@@ -13,7 +13,7 @@
 
 // ------------------------------------------------------------------
 // -----                R3BFootHitPar source file               -----
-// -----         Created 17/05/25 by J.L. Rodriguez-Sanchez     -----
+// -----         Created 17/05/25 by Pablo González Rusell      -----
 // ------------------------------------------------------------------
 
 #pragma once
@@ -49,20 +49,35 @@ class R3BFootHitPar : public FairParGenericSet
     // Method to print values of parameters to the standard output
     void print() override;
 
-    // Accessor functions
+    // Getters
     [[nodiscard]] inline const int GetNumDets() const { return fNumDets; }
-    [[nodiscard]] inline const int GetNumParsFit() const { return fNumParsFit; }
-    inline void SetNumDets(int ndet) { fNumDets = ndet; }
-    TArrayF* GetCharCalParams() { return fCharCalPar; }
+    [[nodiscard]] inline const int GetNumParsFit() const { return fNumParsCal; }
+    [[nodiscard]] inline const int GetNumParsEtaCorr() const { return fNumParsEtaCorr; }
 
-    // Method for setting the calibration parameters
+    [[nodiscard]] inline const TArrayF* GetMultCharParams() { return fMultCharPar; }
+    [[nodiscard]] inline const TArrayF* GetCharCalParams() { return fCharCalPar; }
+    [[nodiscard]] inline const TArrayF* GetCharCalParamsSM() { return fCharCalParSM; }
+    [[nodiscard]] inline const TArrayF* GetEtaCorrParams() { return fEtaCorrPar; }
+
+    // Setters
+    inline void SetNumDets(int ndet) { fNumDets = ndet; }
+    inline void SetNumParsCal(int npar) { fNumParsCal = npar; }
+    inline void SetNumParsEtaCorr(int npar) { fNumParsEtaCorr = npar; }
+
     inline void SetCharCalPars(float value, int index) { fCharCalPar->AddAt(value, index); }
-    inline void SetNumParsFit(int npar) { fNumParsFit = npar; }
+    inline void SetCharCalParsSM(float value, int index) { fCharCalParSM->AddAt(value, index); }
+    inline void SetEtaCorrParams(float value, int index) { fEtaCorrPar->AddAt(value, index); }
+    inline void SetMultCharParams(float value, int index) { fMultCharPar->AddAt(value, index); }
 
   private:
-    int fNumDets = 8;     // Number of detectors
-    int fNumParsFit = 2;  // Number of parameters of for the calibration
-    TArrayF* fCharCalPar; // Parameters for the calibration charge vs energy
+    int fNumDets = 8;        // Number of detectors
+    int fNumParsCal = -1;    // Number of parameters of for the calibration
+    int fNumParsEtaCorr = 5; // Number of parameters for the eta correction
+
+    TArrayF* fMultCharPar;  // Number of charge states at every asic
+    TArrayF* fCharCalPar;   // Parameters for the calibration charge vs energy
+    TArrayF* fCharCalParSM; // Parameters for the calibration charge vs energy (single strip case)
+    TArrayF* fEtaCorrPar;   // Parameters for the eta correction
 
     const R3BFootHitPar& operator=(const R3BFootHitPar&);
     R3BFootHitPar(const R3BFootHitPar&);


### PR DESCRIPTION
New features have been added to FOOT:

- Eta correction and charge calibration parameters read from the .par file.
- In the cal2hit level, if hit parameters are provided, eta correction + charge calibration will be performed.
- In the online spectra class, if hit parameters are provided, the charge will be plotted in charge units range and without eta-cut.

This PR has, in principle, backwards compatibility with previous version. If hit parameter file is not provided the behavior of these clases should be the same as before. 

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
