### PR TITLE
Refactor of the Cal2Hit class for FOOTs

### DIFF
--- a/ssd/calibration/R3BFootStripCal2Hit.cxx
+++ b/ssd/calibration/R3BFootStripCal2Hit.cxx
@@ -23,7 +23,9 @@
 #include <TH1F.h>
 #include <TMath.h>
 #include <TRandom3.h>
+#include <TRotation.h>
 #include <TSpectrum.h>
+#include <TVector3.h>
 #include <iomanip>
 #include <memory>
 #include <vector>
@@ -105,6 +107,7 @@ void R3BFootStripCal2Hit::SetParameter()
         fDistTarget.push_back(fMap_Par->GetDist2target(i + 1));
         fAngleTheta.push_back(fMap_Par->GetAngleTheta(i + 1));
         fAnglePhi.push_back(fMap_Par->GetAnglePhi(i + 1));
+        fAnglePsi.push_back(fMap_Par->GetAnglePsi(i + 1));
         fOffsetX.push_back(fMap_Par->GetOffsetX(i + 1));
         fOffsetY.push_back(fMap_Par->GetOffsetY(i + 1));
     }
@@ -126,19 +129,17 @@ void R3BFootStripCal2Hit::SetParameter()
     fNumParsCal = fHit_Par->GetNumParsFit();
     fNumParsEtaCorr = fHit_Par->GetNumParsEtaCorr();
 
-    constexpr int asicNum = 10;
-
     // Get the multiplicity vector. It contains the amount of charge
     // states seen by each asic
-    for (int i = 0; i < fMaxNumDet * asicNum; i++)
+    for (int i = 0; i < fMaxNumDet * fNumAsic; i++)
     {
         fMultCharPar.push_back(fHit_Par->GetMultCharParams()->At(i));
     }
 
     // One vector per asic
-    fCharCalPar.resize(fMaxNumDet * asicNum);
-    fCharCalParSM.resize(fMaxNumDet * asicNum);
-    fEtaCorrPar.resize(fMaxNumDet * asicNum);
+    fCharCalPar.resize(fMaxNumDet * fNumAsic);
+    fCharCalParSM.resize(fMaxNumDet * fNumAsic);
+    fEtaCorrPar.resize(fMaxNumDet * fNumAsic);
 
     // Now we iterate over the multiplicity of each asic. If the asic is from
     // a dead foot (i.e, mult == 0, we continue). Otherwise, we start filling
@@ -146,7 +147,7 @@ void R3BFootStripCal2Hit::SetParameter()
     int nParsEta = 0;
     int nParsCal = 0;
 
-    for (int i = 0; i < fMultCharPar.size(); i++)
+    for (auto i = 0; i < fMultCharPar.size(); i++)
     {
         for (int j = nParsEta; j < nParsEta + fMultCharPar[i]; j++)
             fEtaCorrPar[i].push_back(fHit_Par->GetEtaCorrParams()->At(j));
@@ -201,16 +202,9 @@ InitStatus R3BFootStripCal2Hit::ReInit()
     return kSUCCESS;
 }
 
-// -----   Public method Execution   --------------------------------------------
-void R3BFootStripCal2Hit::Exec(Option_t* /*option*/)
+// -----    Filling the vector with CalData     ---------------------------------
+void R3BFootStripCal2Hit::FillCalData(double nHits)
 {
-    // Reset entries in output arrays, local arrays
-    Reset();
-
-    // Reading the Input Cal Data
-    int nHits = fFootCalData->GetEntriesFast();
-    if (nHits == 0)
-        return;
 
     // Data from cal level
     int detId;
@@ -218,11 +212,7 @@ void R3BFootStripCal2Hit::Exec(Option_t* /*option*/)
     double energy;
     double sigma;
     double x = 0., y = 0., z = 0.;
-    std::vector<std::vector<int>> StripI;
-    std::vector<std::vector<double>> StripE;
-    std::vector<std::vector<double>> StripS;
 
-    // Clustering algorithm - A. Revel
     StripI.resize(fMaxNumDet);
     StripE.resize(fMaxNumDet);
     StripS.resize(fMaxNumDet);
@@ -231,11 +221,11 @@ void R3BFootStripCal2Hit::Exec(Option_t* /*option*/)
     ClusterPos.resize(fMaxNumDet);
     Eta.resize(fMaxNumDet);
     ClusterESum.resize(fMaxNumDet);
+    ClusterCharge.resize(fMaxNumDet);
     ClusterNStrip.resize(fMaxNumDet);
     ClusterI.resize(fMaxNumDet);
     ClusterE.resize(fMaxNumDet);
 
-    // Filling vectors
     for (int i = 0; i < nHits; i++)
     {
         auto calData = static_cast<R3BFootCalData*>(fFootCalData->At(i));
@@ -248,7 +238,11 @@ void R3BFootStripCal2Hit::Exec(Option_t* /*option*/)
         StripE[detId].push_back(energy);
         StripS[detId].push_back(sigma);
     }
+}
 
+// -----    Clustering ----------------------------------------------------------
+void R3BFootStripCal2Hit::ClusterizeStrips()
+{
     // Sort elements
     for (int i = 0; i < fMaxNumDet; ++i)
     {
@@ -312,7 +306,11 @@ void R3BFootStripCal2Hit::Exec(Option_t* /*option*/)
 
         ClusterMult[i] = ClusterCount;
     }
+}
 
+// -----   Calculate position and eta parameter ---------------------------------
+void R3BFootStripCal2Hit::ComputeClusterParams()
+{
     // Compute Sum Energy, Position and Eta
     for (int i = 0; i < fMaxNumDet; i++)
     {
@@ -320,6 +318,7 @@ void R3BFootStripCal2Hit::Exec(Option_t* /*option*/)
         ClusterPos[i].resize(ClusterMult[i], 0.0);
         Eta[i].resize(ClusterMult[i], 0.0);
         ClusterESum[i].resize(ClusterMult[i], 0.0);
+        ClusterCharge[i].resize(ClusterMult[i], 0.0);
 
         for (int j = 0; j < ClusterMult[i]; j++)
         {
@@ -362,132 +361,151 @@ void R3BFootStripCal2Hit::Exec(Option_t* /*option*/)
                 }
             }
         }
+
+        for (int j = 0; j < ClusterMult[i]; j++)
+        {
+            ClusterCharge[i][j] = ClusterESum[i][j];
+        }
     }
+}
+
+// -----   Eta Correction and Charge Calibration --------------------------------
+void R3BFootStripCal2Hit::EtaCorrectionAndChargeCal()
+{
+    for (int i = 0; i < fMaxNumDet; i++)
+    {
+        for (int j = 0; j < ClusterMult[i]; j++)
+        {
+
+            int asicId = static_cast<int>(ClusterPos[i][j] / (fNumStrips / 10.));
+
+            int generalIndex = i * fNumAsic + asicId;
+            double energyCorrected = -1;
+            double charge = -1;
+
+            int nCharges = fMultCharPar[generalIndex] / fNumParsEtaCorr;
+
+            // If the asic has no correction parameters we continue
+            if (nCharges == 0)
+                continue;
+
+            // With a good asic, we have to identify how many charge
+            // states does it see (i.e. how many eta bands)
+            std::vector<std::unique_ptr<TF1>> polCoefs(nCharges);
+
+            for (int iCharge = 0; iCharge < nCharges; iCharge++)
+            {
+                // One polynom per charge state
+                auto name = Form("pol_foot_%i_asic_%i_charge_%i", i, asicId, iCharge);
+                auto polType = Form("pol%i", fNumParsEtaCorr - 1);
+                polCoefs[iCharge] = std::make_unique<TF1>(name, polType, 0, 1);
+
+                for (int iCoef = 0; iCoef < fNumParsEtaCorr; iCoef++)
+                {
+                    polCoefs[iCharge]->SetParameter(iCoef,
+                                                    fEtaCorrPar[generalIndex][iCoef + iCharge * fNumParsEtaCorr]);
+                }
+            }
+
+            // Now, for our Eta value, we calculate all the predicted energies
+            // (one per polynom), and then, the min of the would be the charge
+            // state to which our hit belongs
+            std::vector<double> diffCharge(nCharges);
+            int minIndex = 0;
+
+            for (int iCharge = 0; iCharge < nCharges; iCharge++)
+            {
+                diffCharge[iCharge] = polCoefs[iCharge]->Eval(Eta[i][j]) - ClusterESum[i][j];
+
+                if (std::abs(diffCharge[iCharge]) < std::abs(diffCharge[minIndex]))
+                    minIndex = iCharge;
+            }
+
+            // Correct the energy for eta > 0
+            if (Eta[i][j] != 0)
+                energyCorrected = polCoefs[minIndex]->Eval(fEtaCenter) - diffCharge[minIndex];
+            else
+                energyCorrected = ClusterESum[i][j];
+
+            // *********** Charge calibration *********** //
+
+            // Get the coeficients for this asic
+            auto name = Form("fitFunc_foot_%i_asic_%i", i, asicId);
+            auto polType = Form("pol%i", fNumParsCal - 1);
+            auto fitFunc = std::make_unique<TF1>(name, polType);
+
+            auto chargeParams = fCharCalPar;
+
+            if (Eta[i][j] == 0)
+                chargeParams = fCharCalParSM;
+
+            for (int iPol = 0; iPol < fNumParsCal; iPol++)
+            {
+                fitFunc->SetParameter(iPol, chargeParams[generalIndex][iPol]);
+            }
+
+            charge = fitFunc->Eval(energyCorrected);
+
+            ClusterESum[i][j] = energyCorrected;
+            ClusterCharge[i][j] = charge;
+        }
+    }
+}
+
+// -----    Calculate detector frame positions ----------------------------------
+TVector3 R3BFootStripCal2Hit::ComputeHitPosition(int i, double pos)
+{
+    TVector3 master(pos, 0., 0.);
+
+    TRotation det2lab;
+    det2lab.RotateZ(fAnglePhi[i] * TMath::DegToRad());
+    det2lab.RotateY(fAngleTheta[i] * TMath::DegToRad());
+    det2lab.RotateX(fAnglePsi[i] * TMath::DegToRad());
+
+    master.Transform(det2lab);
+
+    return master;
+}
+
+// -----   Public method Execution   --------------------------------------------
+void R3BFootStripCal2Hit::Exec(Option_t* /*option*/)
+{
+
+    // Reset entries in output arrays, local arrays
+    Reset();
+
+    // Check that the event has data
+    int nHits = fFootCalData->GetEntriesFast();
+    if (nHits == 0)
+        return;
+
+    FillCalData(nHits);
+    ClusterizeStrips();
+    ComputeClusterParams();
+
+    // If we have hit parameters, do eta correction and charge calibration
+    if (fHit_Par)
+        EtaCorrectionAndChargeCal();
 
     // Filling HitData
     for (uint8_t i = 0; i < fMaxNumDet; i++)
     {
         for (int j = 0; j < ClusterMult[i]; j++)
         {
-            double pos = 100. * ClusterPos[i][j] / 640. - fMiddle;
+            double pos = 100. * ClusterPos[i][j] / fNumStrips - fMiddle;
+            TVector3 master = ComputeHitPosition(i, pos);
 
-            // Identify the asic to which the hit belongs
-            // (useful for later corrections)
-            int asicId = static_cast<int>(ClusterPos[i][j] / 64);
-
-            if (fAnglePhi[i] == 0.)
-            { // X-Foot (StripId numbered from left to right)
-                x = pos * TMath::Cos(fAngleTheta[i] * TMath::DegToRad()) + fOffsetX[i];
-                y = fOffsetY[i];
-                z = pos * TMath::Sin(fAngleTheta[i] * TMath::DegToRad()) + fDistTarget[i];
-            }
-            else if (fAnglePhi[i] == 90.)
-            { // Y-Foot (StripId numbered from bottom to top)
-                x = fOffsetX[i];
-                y = pos + fOffsetY[i];
-                z = fDistTarget[i];
-            }
-            else if (fAnglePhi[i] == 180.)
-            { // X-Foot (StripId numbered from right to left)
-                x = -pos * TMath::Cos(fAngleTheta[i] * TMath::DegToRad()) + fOffsetX[i];
-                y = fOffsetY[i];
-                z = -pos * TMath::Sin(fAngleTheta[i] * TMath::DegToRad()) + fDistTarget[i];
-            }
-            else if (fAnglePhi[i] == 270.)
-            { // Y-Foot (StripId numbered from top to bottom)
-                x = fOffsetX[i];
-                y = -pos + fOffsetY[i];
-                z = fDistTarget[i];
-            }
-            else
-            {
-                LOG(info) << "R3BFootStripCal2Hit::AnglePhi is Wrong !";
-            }
-
-            TVector3 master(x, y, z);
-
-            // *********** Eta correction *********** //
-
-            int generalIndex = i * 10 + asicId;
-
-            double energyCorrected = -1;
-            double charge = -1;
-
-            if (!fHit_Par)
-            {
-                energyCorrected = ClusterESum[i][j];
-                charge = energyCorrected;
-            }
-            else
-            {
-                int nCharges = fMultCharPar[generalIndex] / fNumParsEtaCorr;
-
-                // If the asic has no correction parameters we continue
-                if (nCharges == 0)
-                    continue;
-
-                // With a good asic, we have to identify how many charge
-                // states does it see (i.e. how many eta bands)
-                std::vector<std::unique_ptr<TF1>> polCoefs(nCharges);
-
-                for (int iCharge = 0; iCharge < nCharges; iCharge++)
-                {
-                    // One polynom per charge state
-                    auto name = Form("pol_foot_%i_asic_%i_charge_%i", i, asicId, iCharge);
-                    auto polType = Form("pol%i", fNumParsEtaCorr - 1);
-                    polCoefs[iCharge] = std::make_unique<TF1>(name, polType, 0, 1);
-
-                    for (int iCoef = 0; iCoef < fNumParsEtaCorr; iCoef++)
-                    {
-                        polCoefs[iCharge]->SetParameter(iCoef,
-                                                        fEtaCorrPar[generalIndex][iCoef + iCharge * fNumParsEtaCorr]);
-                    }
-                }
-
-                // Now, for our Eta value, we calculate all the predicted energies
-                // (one per polynom), and then, the min of the would be the charge
-                // state to which our hit belongs
-                std::vector<double> diffCharge(nCharges);
-                int minIndex = 0;
-
-                for (int iCharge = 0; iCharge < nCharges; iCharge++)
-                {
-                    diffCharge[iCharge] = polCoefs[iCharge]->Eval(Eta[i][j]) - ClusterESum[i][j];
-
-                    if (std::abs(diffCharge[iCharge]) < std::abs(diffCharge[minIndex]))
-                        minIndex = iCharge;
-                }
-
-                // Correct the energy for eta > 0
-                if (Eta[i][j] != 0)
-                    energyCorrected = polCoefs[minIndex]->Eval(0.5) - diffCharge[minIndex];
-                else
-                    energyCorrected = ClusterESum[i][j];
-
-                // *********** Charge calibration *********** //
-
-                // Get the coeficients for this asic
-                auto name = Form("fitFunc_foot_%i_asic_%i", i, asicId);
-                auto polType = Form("pol%i", fNumParsCal - 1);
-                auto fitFunc = std::make_unique<TF1>(name, polType);
-
-                auto chargeParams = fCharCalPar;
-
-                if (Eta[i][j] == 0)
-                    chargeParams = fCharCalParSM;
-
-                for (int iPol = 0; iPol < fNumParsCal; iPol++)
-                {
-                    fitFunc->SetParameter(iPol, chargeParams[generalIndex][iPol]);
-                }
-
-                charge = fitFunc->Eval(energyCorrected);
-            }
-
-            if (energyCorrected > fThSum && j < fMaxNumClusters)
+            if (ClusterESum[i][j] > fThSum && ClusterMult[i] < fMaxNumClusters && ClusterNStrip[i][j] < fMaxNumStrips)
             {
 
-                AddHitData(i + 1, ClusterMult[i], pos, master, energyCorrected, ClusterNStrip[i][j], Eta[i][j], charge);
+                AddHitData(i + 1,
+                           ClusterMult[i],
+                           pos,
+                           master,
+                           ClusterESum[i][j],
+                           ClusterNStrip[i][j],
+                           Eta[i][j],
+                           ClusterCharge[i][j]);
             }
             else
             {
@@ -503,6 +521,7 @@ void R3BFootStripCal2Hit::Exec(Option_t* /*option*/)
     ClusterMult.clear();
     ClusterPos.clear();
     ClusterESum.clear();
+    ClusterCharge.clear();
     ClusterNStrip.clear();
     Eta.clear();
     ClusterI.clear();

--- a/ssd/calibration/R3BFootStripCal2Hit.h
+++ b/ssd/calibration/R3BFootStripCal2Hit.h
@@ -68,34 +68,50 @@ class R3BFootStripCal2Hit : public FairTask
     /** Accessor for selecting online mode **/
     inline void SetOnline(Bool_t option) { fOnline = option; }
 
-    /** Accessor for selecting max. number of clusters per ams detector **/
+    /** Accessor for selecting max. number of clusters per FOOT detector **/
     inline void SetMaxNumClusters(int max) { fMaxNumClusters = max; }
 
     /** Accessor to set up the threshold for the cluster energy sum **/
     inline void SetClusterEnergy(double thsum) { fThSum = thsum; }
 
+    // Method for setting the maximum number of strips for each cluster
+    inline void SetMaxNumStrips(int max) { fMaxNumStrips = max; }
+
   private:
     void SetParameter();
+    void FillCalData(double nHits);
+    void ClusterizeStrips();
+    void ComputeClusterParams();
+    void EtaCorrectionAndChargeCal();
+    TVector3 ComputeHitPosition(int detId, double pos);
 
-    double fPitch = 157.7;
-    double fMiddle = 50.;
+    static constexpr double fMiddle = 50.;
+    static constexpr int fNumAsic = 10;
+    static constexpr int fNumStrips = 640;
+    static constexpr double fEtaCenter = 0.5;
+
+    int fMaxNumDet = 16;
     double fThSum = 20.;
     double fTimesSigmas = 3.;
-    int fMaxNumDet = 16;
+
     int fMaxNumClusters = 10;
-    int fNumParsFit = 2;
+    int fMaxNumStrips = 640;
+
     std::vector<double> fDistTarget;
     std::vector<double> fAngleTheta;
     std::vector<double> fAnglePhi;
+    std::vector<double> fAnglePsi;
     std::vector<double> fOffsetX;
     std::vector<double> fOffsetY;
-    std::vector<TH1F*> hssd;
-    TArrayF* HitCalParams = nullptr;
 
+    std::vector<std::vector<int>> StripI;                   // Strip Id
+    std::vector<std::vector<double>> StripE;                // Strip energy
+    std::vector<std::vector<double>> StripS;                // Strip Sigma
     std::vector<int> ClusterMult;                           // Cluster multiplicity
     std::vector<std::vector<double>> ClusterPos;            // Position of Cluster from Weighted Average
     std::vector<std::vector<double>> Eta;                   // Decimal part of the average position of the cluster
     std::vector<std::vector<double>> ClusterESum;           // Sum of Energies in the Cluster
+    std::vector<std::vector<double>> ClusterCharge;         // Sum of Energies in the Cluster
     std::vector<std::vector<int>> ClusterNStrip;            // Number of Strips in Cluster
     std::vector<std::vector<std::vector<double>>> ClusterI; // Id Strip in Cluster
     std::vector<std::vector<std::vector<double>>> ClusterE; // Energy of Strip in Cluster
@@ -115,7 +131,6 @@ class R3BFootStripCal2Hit : public FairTask
     TClonesArray* fFootHitData = nullptr; // Array with FOOT Hit-output data
 
     bool fOnline = false; // Don't store data for online
-    Double_t* fChannelPeaks;
 
     // Private method AddHitData
     R3BFootHitData* AddHitData(uint8_t detid,

--- a/ssd/pars/R3BFootMappingPar.cxx
+++ b/ssd/pars/R3BFootMappingPar.cxx
@@ -14,10 +14,12 @@
 // ----------------------------------------------------------------
 // -----        R3BFootMappingPar source file                 -----
 // -----    Created 05/11/21  by J.L. Rodriguez-Sanchez       -----
-// -----    for the info from the lookup table	        -----
+// -----    for the info from the lookup table	              -----
+// -----    Modified 08/2025 by Pablo González Rusell         -----
 // ----------------------------------------------------------------
 
 #include "R3BFootMappingPar.h"
+#include "R3BLogger.h"
 
 #include "FairLogger.h"
 #include "FairParamList.h"
@@ -37,6 +39,8 @@ R3BFootMappingPar::R3BFootMappingPar(const TString& name, const TString& title, 
     fDistance2target = new TArrayF(fNumDet);
     fAngleTheta = new TArrayF(fNumDet);
     fAnglePhi = new TArrayF(fNumDet);
+    fAnglePsi = new TArrayF(fNumDet);
+    fAnglePsi->Reset(0.0);
     fOffsetX = new TArrayF(fNumDet);
     fOffsetY = new TArrayF(fNumDet);
     fEnevsPosCorr = new TArrayF(fPolPar * fNumDet);
@@ -52,6 +56,8 @@ R3BFootMappingPar::~R3BFootMappingPar()
         delete fAngleTheta;
     if (fAnglePhi)
         delete fAnglePhi;
+    if (fAnglePsi)
+        delete fAnglePsi;
     if (fOffsetX)
         delete fOffsetX;
     if (fOffsetY)
@@ -83,6 +89,8 @@ void R3BFootMappingPar::putParams(FairParamList* list)
     list->add("footAngleThetaPar", *fAngleTheta);
     fAnglePhi->Set(fNumDet);
     list->add("footAnglePhiPar", *fAnglePhi);
+    fAnglePsi->Set(fNumDet);
+    list->add("footAnglePsiPar", *fAnglePsi);
     fOffsetX->Set(fNumDet);
     list->add("footOffsetXPar", *fOffsetX);
     fOffsetY->Set(fNumDet);
@@ -95,60 +103,68 @@ void R3BFootMappingPar::putParams(FairParamList* list)
 // ----  Method getParams ------------------------------------------------------
 Bool_t R3BFootMappingPar::getParams(FairParamList* list)
 {
-    LOG(info) << "R3BFootMappingPar::getParams() called";
+    R3BLOG(info, "getParams() called");
     if (!list)
     {
         return kFALSE;
     }
     if (!list->fill("footGeoPar", &fGeo))
     {
-        LOG(info) << "Could not initialize footGeoPar";
+        R3BLOG(info, "Could not initialize footGeoPar");
         return kFALSE;
     }
     if (!list->fill("footDetPar", &fNumDet))
     {
-        LOG(info) << "Could not initialize footDetPar";
+        R3BLOG(info, "Could not initialize footDetPar");
         return kFALSE;
     }
     fDistance2target->Set(fNumDet);
     if (!(list->fill("footDistance2targetPar", fDistance2target)))
     {
-        LOG(info) << "Could not initialize footDistance2targetPar";
+        R3BLOG(info, "Could not initialize footDistance2targetPar");
         return kFALSE;
     }
     fAngleTheta->Set(fNumDet);
     if (!(list->fill("footAngleThetaPar", fAngleTheta)))
     {
-        LOG(info) << "Could not initialize footAngleThetaPar";
+        R3BLOG(info, "Could not initialize footAngleThetaPar");
         return kFALSE;
     }
     fAnglePhi->Set(fNumDet);
     if (!(list->fill("footAnglePhiPar", fAnglePhi)))
     {
-        LOG(info) << "Could not initialize footAnglePhiPar";
+        R3BLOG(info, "Could not initialize footAnglePhiPar");
         return kFALSE;
     }
+
+    fAnglePsi->Set(fNumDet);
+    if (!(list->fill("footAnglePsiPar", fAnglePsi)))
+    {
+        R3BLOG(info, "Could not initialize footAnglePsiPar. (Setting to zero by default)");
+        fAnglePsi->Reset(0.0);
+    }
+
     fOffsetX->Set(fNumDet);
     if (!(list->fill("footOffsetXPar", fOffsetX)))
     {
-        LOG(info) << "Could not initialize footOffsetXPar";
+        R3BLOG(info, "Could not initialize footOffsetXPar");
         return kFALSE;
     }
     fOffsetY->Set(fNumDet);
     if (!(list->fill("footOffsetYPar", fOffsetY)))
     {
-        LOG(info) << "Could not initialize footOffsetYPar";
+        R3BLOG(info, "Could not initialize footOffsetYPar");
         return kFALSE;
     }
     if (!list->fill("footPolPar", &fPolPar))
     {
-        LOG(info) << "Could not initialize footPolPar";
+        R3BLOG(info, "Could not initialize footPolPar");
         return kFALSE;
     }
     fEnevsPosCorr->Set(fNumDet * fPolPar);
     if (!(list->fill("footEnevsPosCorrPar", fEnevsPosCorr)))
     {
-        LOG(info) << "Could not initialize footEnevsPosCorrPar";
+        R3BLOG(info, "Could not initialize footEnevsPosCorrPar");
         return kFALSE;
     }
 
@@ -161,37 +177,39 @@ void R3BFootMappingPar::print() { printParams(); }
 // ----  Method printParams ----------------------------------------------------
 void R3BFootMappingPar::printParams()
 {
-    LOG(info) << "R3BFootMappingPar::FOOT mapping parameters for geometry " << fGeo << ": ";
+    R3BLOG(info, Form("FOOT mapping parameters for geometry %i:", fGeo));
 
-    LOG(info) << "Detector"
-              << " "
-              << "Distance_to_target"
-              << " "
-              << "Angle_theta"
-              << " "
-              << "Angle_Phi"
-              << " "
-              << "Offset_X"
-              << " "
-              << "Offset_Y";
+    R3BLOG(info,
+           "Detector"
+           " Distance_to_target"
+           " Angle_theta"
+           " Angle_Phi"
+           " Angle_Psi"
+           " Offset_X"
+           " Offset_Y");
 
     for (Int_t i = 0; i < fNumDet; i++)
     {
-        LOG(info) << i + 1 << "\t"
-                  << "\t" << fDistance2target->GetAt(i) << "\t\t" << fAngleTheta->GetAt(i) << "\t"
-                  << fAnglePhi->GetAt(i) << "\t" << fOffsetX->GetAt(i) << "\t" << fOffsetY->GetAt(i);
+        R3BLOG(info,
+               TString::Format("%d\t\t%.2f\t\t%.2f\t%.2f\t%.2f\t%.2f\t%.2f",
+                               i + 1,
+                               fDistance2target->GetAt(i),
+                               fAngleTheta->GetAt(i),
+                               fAnglePhi->GetAt(i),
+                               fAnglePsi->GetAt(i),
+                               fOffsetX->GetAt(i),
+                               fOffsetY->GetAt(i)));
     }
 
-    LOG(info) << "Energy vs Position Correction Parameters : ";
+    R3BLOG(info, "Energy vs Position Correction Parameters :");
 
     for (Int_t i = 0; i < fNumDet; i++)
     {
-        LOG(info) << "FOOT " << i + 1 << " : ";
+        R3BLOG(info, TString::Format("FOOT %d :", i + 1));
 
         for (Int_t j = 0; j < fPolPar; j++)
         {
-            LOG(info) << "Pol" << j << "\t"
-                      << "\t" << fEnevsPosCorr->GetAt(i * fPolPar + j);
+            R3BLOG(info, TString::Format("Pol%d\t\t%.6f", j, fEnevsPosCorr->GetAt(i * fPolPar + j)));
         }
     }
 }

--- a/ssd/pars/R3BFootMappingPar.h
+++ b/ssd/pars/R3BFootMappingPar.h
@@ -14,6 +14,7 @@
 // ----------------------------------------------------------------
 // -----        R3BFootMappingPar source file                 -----
 // -----    Created 05/11/21 by J.L. Rodriguez-Sanchez        -----
+// -----    Modified 08/2025 by Pablo González Rusell         -----
 // ----------------------------------------------------------------
 
 #pragma once
@@ -51,21 +52,23 @@ class R3BFootMappingPar : public FairParGenericSet
     void printParams();
 
     /** Accessor functions **/
-    const Int_t GetGeometry() { return fGeo; }
-    const Int_t GetNumDets() { return fNumDet; }
-    const Float_t GetDist2target(Int_t det) { return fDistance2target->GetAt(det - 1); }
-    const Float_t GetAngleTheta(Int_t det) { return fAngleTheta->GetAt(det - 1); }
-    const Float_t GetAnglePhi(Int_t det) { return fAnglePhi->GetAt(det - 1); }
-    const Float_t GetOffsetX(Int_t det) { return fOffsetX->GetAt(det - 1); }
-    const Float_t GetOffsetY(Int_t det) { return fOffsetY->GetAt(det - 1); }
-    const Int_t GetPolPar() { return fPolPar; }
-    const Float_t GetEnevsPosCorr(Int_t order) { return fEnevsPosCorr->GetAt(order - 1); }
+    [[nodiscard]] const Int_t GetGeometry() { return fGeo; }
+    [[nodiscard]] const Int_t GetNumDets() { return fNumDet; }
+    [[nodiscard]] const Float_t GetDist2target(Int_t det) { return fDistance2target->GetAt(det - 1); }
+    [[nodiscard]] const Float_t GetAngleTheta(Int_t det) { return fAngleTheta->GetAt(det - 1); }
+    [[nodiscard]] const Float_t GetAnglePhi(Int_t det) { return fAnglePhi->GetAt(det - 1); }
+    [[nodiscard]] const Float_t GetAnglePsi(Int_t det) { return fAnglePsi->GetAt(det - 1); }
+    [[nodiscard]] const Float_t GetOffsetX(Int_t det) { return fOffsetX->GetAt(det - 1); }
+    [[nodiscard]] const Float_t GetOffsetY(Int_t det) { return fOffsetY->GetAt(det - 1); }
+    [[nodiscard]] const Int_t GetPolPar() { return fPolPar; }
+    [[nodiscard]] const Float_t GetEnevsPosCorr(Int_t order) { return fEnevsPosCorr->GetAt(order - 1); }
 
     void SetGeometry(Int_t geo) { fGeo = geo; }
     void SetNumDets(Int_t numberDet) { fNumDet = numberDet; }
     void SetDist2target(Float_t value, Int_t det) { fDistance2target->AddAt(value, det - 1); }
     void SetAngleTheta(Float_t value, Int_t det) { fAngleTheta->AddAt(value, det - 1); }
     void SetAnglePhi(Float_t value, Int_t det) { fAnglePhi->AddAt(value, det - 1); }
+    void SetAnglePsi(Float_t value, Int_t det) { fAnglePsi->AddAt(value, det - 1); }
     void SetOffsetX(Float_t value, Int_t det) { fOffsetX->AddAt(value, det - 1); }
     void SetOffsetY(Float_t value, Int_t det) { fOffsetY->AddAt(value, det - 1); }
     void SetPolPar(Int_t parPol) { fPolPar = parPol; }
@@ -75,8 +78,9 @@ class R3BFootMappingPar : public FairParGenericSet
     Int_t fGeo;                // Geometry of the foot detectors
     Int_t fNumDet;             // Number of foot detectors (from 1 to 10 for 2021 experiments)
     TArrayF* fDistance2target; // Distance to target
-    TArrayF* fAngleTheta;      // Angle with respect to beam direction
-    TArrayF* fAnglePhi;        // Rotation Angle around the Z direction
+    TArrayF* fAngleTheta;      // Rotation angle around the Y direction (from Z to X in lab frame)
+    TArrayF* fAnglePhi;        // Rotation angle around the Z direction (from X to Y in lab frame)
+    TArrayF* fAnglePsi;        // Rotation angle around the X direction (from Y to Z in lab frame)
     TArrayF* fOffsetX;         // Offset for x
     TArrayF* fOffsetY;         // Offset for y
     Int_t fPolPar;             // Number of parameters for polynomial for Energy Vs Position Correction


### PR DESCRIPTION
- The exec method of the cal2hit class for FOOTs has been split in different private methods.
- Added PsiAngles to the mapPar. 
- Implemented rotation along X axis using PsiAngles.

This PR has backwards compatibility with previous versions that do not use PsiAngles.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
