### PR TITLE
Update ext_h101_wrfoot.h to accomodate 16 FOOTs

### DIFF
--- a/r3bsource/foot/ext_h101_wrfoot.h
+++ b/r3bsource/foot/ext_h101_wrfoot.h
@@ -5,20 +5,20 @@
  * Do not edit - automatically generated.
  */
 
-#ifndef __GUARD_H101_WRFOOT_EXT_H101_WRFOOT_H__
-#define __GUARD_H101_WRFOOT_EXT_H101_WRFOOT_H__
+#ifndef __GUARD_H101_WRFOOT_EXT_H101_FOOT_WR_G249_H__
+#define __GUARD_H101_WRFOOT_EXT_H101_FOOT_WR_G249_H__
 
 #ifndef __CINT__
-#include <stdint.h>
+# include <stdint.h>
 #else
 /* For CINT (old version trouble with stdint.h): */
-#ifndef uint32_t
+# ifndef uint32_t
 typedef unsigned int uint32_t;
-typedef int int32_t;
-#endif
+typedef          int  int32_t;
+# endif
 #endif
 #ifndef EXT_STRUCT_CTRL
-#define EXT_STRUCT_CTRL(x)
+# define EXT_STRUCT_CTRL(x)
 #endif
 
 /********************************************************
@@ -28,62 +28,87 @@ typedef int int32_t;
 
 typedef struct EXT_STR_h101_WRFOOT_t
 {
-    /* RAW */
-    uint32_t TIMESTAMP_FOOT1ID /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT1WR_T1 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT1WR_T2 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT1WR_T3 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT1WR_T4 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT2ID /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT2WR_T1 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT2WR_T2 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT2WR_T3 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT2WR_T4 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT3ID /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT3WR_T1 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT3WR_T2 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT3WR_T3 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT3WR_T4 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT4ID /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT4WR_T1 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT4WR_T2 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT4WR_T3 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT4WR_T4 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT5ID /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT5WR_T1 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT5WR_T2 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT5WR_T3 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT5WR_T4 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT6ID /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT6WR_T1 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT6WR_T2 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT6WR_T3 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT6WR_T4 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT7ID /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT7WR_T1 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT7WR_T2 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT7WR_T3 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT7WR_T4 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT8ID /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT8WR_T1 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT8WR_T2 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT8WR_T3 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT8WR_T4 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT9ID /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT9WR_T1 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT9WR_T2 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT9WR_T3 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT9WR_T4 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT10ID /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT10WR_T1 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT10WR_T2 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT10WR_T3 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT10WR_T4 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT11ID /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT11WR_T1 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT11WR_T2 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT11WR_T3 /* [0,65535] */;
-    uint32_t TIMESTAMP_FOOT11WR_T4 /* [0,65535] */;
+  /* RAW */
+  uint32_t TIMESTAMP_FOOT1ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT1WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT1WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT1WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT1WR_T4 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT2ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT2WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT2WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT2WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT2WR_T4 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT3ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT3WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT3WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT3WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT3WR_T4 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT4ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT4WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT4WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT4WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT4WR_T4 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT5ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT5WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT5WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT5WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT5WR_T4 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT6ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT6WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT6WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT6WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT6WR_T4 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT7ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT7WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT7WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT7WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT7WR_T4 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT8ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT8WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT8WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT8WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT8WR_T4 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT9ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT9WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT9WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT9WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT9WR_T4 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT10ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT10WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT10WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT10WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT10WR_T4 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT11ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT11WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT11WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT11WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT11WR_T4 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT12ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT12WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT12WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT12WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT12WR_T4 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT13ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT13WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT13WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT13WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT13WR_T4 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT14ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT14WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT14WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT14WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT14WR_T4 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT15ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT15WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT15WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT15WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT15WR_T4 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT16ID /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT16WR_T1 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT16WR_T2 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT16WR_T3 /* [0,65535] */;
+  uint32_t TIMESTAMP_FOOT16WR_T4 /* [0,65535] */;
 
 } EXT_STR_h101_WRFOOT;
 
@@ -95,134 +120,262 @@ typedef struct EXT_STR_h101_WRFOOT_t
 
 typedef struct EXT_STR_h101_WRFOOT_onion_t
 {
-    /* RAW */
-    struct
-    {
-        uint32_t ID;
-        uint32_t WR_T[4];
-    } TIMESTAMP_FOOT[11];
+  /* RAW */
+  struct {
+    uint32_t ID;
+    uint32_t WR_T[4];
+  } TIMESTAMP_FOOT[16];
 
 } EXT_STR_h101_WRFOOT_onion;
 
 /*******************************************************/
 
-#define EXT_STR_h101_WRFOOT_ITEMS_INFO(ok, si, offset, struct_t, printerr)                                      \
-    do                                                                                                          \
-    {                                                                                                           \
-        ok = 1;                                                                                                 \
-        /* RAW */                                                                                               \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT1ID, UINT32, "TIMESTAMP_FOOT1ID", 65535);         \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT1WR_T1, UINT32, "TIMESTAMP_FOOT1WR_T1", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT1WR_T2, UINT32, "TIMESTAMP_FOOT1WR_T2", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT1WR_T3, UINT32, "TIMESTAMP_FOOT1WR_T3", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT1WR_T4, UINT32, "TIMESTAMP_FOOT1WR_T4", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT2ID, UINT32, "TIMESTAMP_FOOT2ID", 65535);         \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT2WR_T1, UINT32, "TIMESTAMP_FOOT2WR_T1", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT2WR_T2, UINT32, "TIMESTAMP_FOOT2WR_T2", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT2WR_T3, UINT32, "TIMESTAMP_FOOT2WR_T3", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT2WR_T4, UINT32, "TIMESTAMP_FOOT2WR_T4", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT3ID, UINT32, "TIMESTAMP_FOOT3ID", 65535);         \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT3WR_T1, UINT32, "TIMESTAMP_FOOT3WR_T1", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT3WR_T2, UINT32, "TIMESTAMP_FOOT3WR_T2", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT3WR_T3, UINT32, "TIMESTAMP_FOOT3WR_T3", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT3WR_T4, UINT32, "TIMESTAMP_FOOT3WR_T4", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT4ID, UINT32, "TIMESTAMP_FOOT4ID", 65535);         \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT4WR_T1, UINT32, "TIMESTAMP_FOOT4WR_T1", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT4WR_T2, UINT32, "TIMESTAMP_FOOT4WR_T2", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT4WR_T3, UINT32, "TIMESTAMP_FOOT4WR_T3", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT4WR_T4, UINT32, "TIMESTAMP_FOOT4WR_T4", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT5ID, UINT32, "TIMESTAMP_FOOT5ID", 65535);         \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT5WR_T1, UINT32, "TIMESTAMP_FOOT5WR_T1", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT5WR_T2, UINT32, "TIMESTAMP_FOOT5WR_T2", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT5WR_T3, UINT32, "TIMESTAMP_FOOT5WR_T3", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT5WR_T4, UINT32, "TIMESTAMP_FOOT5WR_T4", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT6ID, UINT32, "TIMESTAMP_FOOT6ID", 65535);         \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT6WR_T1, UINT32, "TIMESTAMP_FOOT6WR_T1", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT6WR_T2, UINT32, "TIMESTAMP_FOOT6WR_T2", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT6WR_T3, UINT32, "TIMESTAMP_FOOT6WR_T3", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT6WR_T4, UINT32, "TIMESTAMP_FOOT6WR_T4", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT7ID, UINT32, "TIMESTAMP_FOOT7ID", 65535);         \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT7WR_T1, UINT32, "TIMESTAMP_FOOT7WR_T1", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT7WR_T2, UINT32, "TIMESTAMP_FOOT7WR_T2", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT7WR_T3, UINT32, "TIMESTAMP_FOOT7WR_T3", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT7WR_T4, UINT32, "TIMESTAMP_FOOT7WR_T4", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT8ID, UINT32, "TIMESTAMP_FOOT8ID", 65535);         \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT8WR_T1, UINT32, "TIMESTAMP_FOOT8WR_T1", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT8WR_T2, UINT32, "TIMESTAMP_FOOT8WR_T2", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT8WR_T3, UINT32, "TIMESTAMP_FOOT8WR_T3", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT8WR_T4, UINT32, "TIMESTAMP_FOOT8WR_T4", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT9ID, UINT32, "TIMESTAMP_FOOT9ID", 65535);         \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT9WR_T1, UINT32, "TIMESTAMP_FOOT9WR_T1", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT9WR_T2, UINT32, "TIMESTAMP_FOOT9WR_T2", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT9WR_T3, UINT32, "TIMESTAMP_FOOT9WR_T3", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT9WR_T4, UINT32, "TIMESTAMP_FOOT9WR_T4", 65535);   \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT10ID, UINT32, "TIMESTAMP_FOOT10ID", 65535);       \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT10WR_T1, UINT32, "TIMESTAMP_FOOT10WR_T1", 65535); \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT10WR_T2, UINT32, "TIMESTAMP_FOOT10WR_T2", 65535); \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT10WR_T3, UINT32, "TIMESTAMP_FOOT10WR_T3", 65535); \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT10WR_T4, UINT32, "TIMESTAMP_FOOT10WR_T4", 65535); \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT11ID, UINT32, "TIMESTAMP_FOOT11ID", 65535);       \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT11WR_T1, UINT32, "TIMESTAMP_FOOT11WR_T1", 65535); \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT11WR_T2, UINT32, "TIMESTAMP_FOOT11WR_T2", 65535); \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT11WR_T3, UINT32, "TIMESTAMP_FOOT11WR_T3", 65535); \
-        EXT_STR_ITEM_INFO_LIM(                                                                                  \
-            ok, si, offset, struct_t, printerr, TIMESTAMP_FOOT11WR_T4, UINT32, "TIMESTAMP_FOOT11WR_T4", 65535); \
-                                                                                                                \
-    } while (0);
-#endif /*__GUARD_H101_WRFOOT_EXT_H101_WRFOOT_H__*/
+#define EXT_STR_h101_WRFOOT_ITEMS_INFO(ok,si,offset,struct_t,printerr) do { \
+  ok = 1; \
+  /* RAW */ \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT1ID,               UINT32,\
+                    "TIMESTAMP_FOOT1ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT1WR_T1,            UINT32,\
+                    "TIMESTAMP_FOOT1WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT1WR_T2,            UINT32,\
+                    "TIMESTAMP_FOOT1WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT1WR_T3,            UINT32,\
+                    "TIMESTAMP_FOOT1WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT1WR_T4,            UINT32,\
+                    "TIMESTAMP_FOOT1WR_T4",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT2ID,               UINT32,\
+                    "TIMESTAMP_FOOT2ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT2WR_T1,            UINT32,\
+                    "TIMESTAMP_FOOT2WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT2WR_T2,            UINT32,\
+                    "TIMESTAMP_FOOT2WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT2WR_T3,            UINT32,\
+                    "TIMESTAMP_FOOT2WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT2WR_T4,            UINT32,\
+                    "TIMESTAMP_FOOT2WR_T4",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT3ID,               UINT32,\
+                    "TIMESTAMP_FOOT3ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT3WR_T1,            UINT32,\
+                    "TIMESTAMP_FOOT3WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT3WR_T2,            UINT32,\
+                    "TIMESTAMP_FOOT3WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT3WR_T3,            UINT32,\
+                    "TIMESTAMP_FOOT3WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT3WR_T4,            UINT32,\
+                    "TIMESTAMP_FOOT3WR_T4",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT4ID,               UINT32,\
+                    "TIMESTAMP_FOOT4ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT4WR_T1,            UINT32,\
+                    "TIMESTAMP_FOOT4WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT4WR_T2,            UINT32,\
+                    "TIMESTAMP_FOOT4WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT4WR_T3,            UINT32,\
+                    "TIMESTAMP_FOOT4WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT4WR_T4,            UINT32,\
+                    "TIMESTAMP_FOOT4WR_T4",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT5ID,               UINT32,\
+                    "TIMESTAMP_FOOT5ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT5WR_T1,            UINT32,\
+                    "TIMESTAMP_FOOT5WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT5WR_T2,            UINT32,\
+                    "TIMESTAMP_FOOT5WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT5WR_T3,            UINT32,\
+                    "TIMESTAMP_FOOT5WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT5WR_T4,            UINT32,\
+                    "TIMESTAMP_FOOT5WR_T4",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT6ID,               UINT32,\
+                    "TIMESTAMP_FOOT6ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT6WR_T1,            UINT32,\
+                    "TIMESTAMP_FOOT6WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT6WR_T2,            UINT32,\
+                    "TIMESTAMP_FOOT6WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT6WR_T3,            UINT32,\
+                    "TIMESTAMP_FOOT6WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT6WR_T4,            UINT32,\
+                    "TIMESTAMP_FOOT6WR_T4",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT7ID,               UINT32,\
+                    "TIMESTAMP_FOOT7ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT7WR_T1,            UINT32,\
+                    "TIMESTAMP_FOOT7WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT7WR_T2,            UINT32,\
+                    "TIMESTAMP_FOOT7WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT7WR_T3,            UINT32,\
+                    "TIMESTAMP_FOOT7WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT7WR_T4,            UINT32,\
+                    "TIMESTAMP_FOOT7WR_T4",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT8ID,               UINT32,\
+                    "TIMESTAMP_FOOT8ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT8WR_T1,            UINT32,\
+                    "TIMESTAMP_FOOT8WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT8WR_T2,            UINT32,\
+                    "TIMESTAMP_FOOT8WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT8WR_T3,            UINT32,\
+                    "TIMESTAMP_FOOT8WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT8WR_T4,            UINT32,\
+                    "TIMESTAMP_FOOT8WR_T4",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT9ID,               UINT32,\
+                    "TIMESTAMP_FOOT9ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT9WR_T1,            UINT32,\
+                    "TIMESTAMP_FOOT9WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT9WR_T2,            UINT32,\
+                    "TIMESTAMP_FOOT9WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT9WR_T3,            UINT32,\
+                    "TIMESTAMP_FOOT9WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT9WR_T4,            UINT32,\
+                    "TIMESTAMP_FOOT9WR_T4",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT10ID,              UINT32,\
+                    "TIMESTAMP_FOOT10ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT10WR_T1,           UINT32,\
+                    "TIMESTAMP_FOOT10WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT10WR_T2,           UINT32,\
+                    "TIMESTAMP_FOOT10WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT10WR_T3,           UINT32,\
+                    "TIMESTAMP_FOOT10WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT10WR_T4,           UINT32,\
+                    "TIMESTAMP_FOOT10WR_T4",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT11ID,              UINT32,\
+                    "TIMESTAMP_FOOT11ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT11WR_T1,           UINT32,\
+                    "TIMESTAMP_FOOT11WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT11WR_T2,           UINT32,\
+                    "TIMESTAMP_FOOT11WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT11WR_T3,           UINT32,\
+                    "TIMESTAMP_FOOT11WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT11WR_T4,           UINT32,\
+                    "TIMESTAMP_FOOT11WR_T4",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT12ID,              UINT32,\
+                    "TIMESTAMP_FOOT12ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT12WR_T1,           UINT32,\
+                    "TIMESTAMP_FOOT12WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT12WR_T2,           UINT32,\
+                    "TIMESTAMP_FOOT12WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT12WR_T3,           UINT32,\
+                    "TIMESTAMP_FOOT12WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT12WR_T4,           UINT32,\
+                    "TIMESTAMP_FOOT12WR_T4",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT13ID,              UINT32,\
+                    "TIMESTAMP_FOOT13ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT13WR_T1,           UINT32,\
+                    "TIMESTAMP_FOOT13WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT13WR_T2,           UINT32,\
+                    "TIMESTAMP_FOOT13WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT13WR_T3,           UINT32,\
+                    "TIMESTAMP_FOOT13WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT13WR_T4,           UINT32,\
+                    "TIMESTAMP_FOOT13WR_T4",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT14ID,              UINT32,\
+                    "TIMESTAMP_FOOT14ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT14WR_T1,           UINT32,\
+                    "TIMESTAMP_FOOT14WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT14WR_T2,           UINT32,\
+                    "TIMESTAMP_FOOT14WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT14WR_T3,           UINT32,\
+                    "TIMESTAMP_FOOT14WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT14WR_T4,           UINT32,\
+                    "TIMESTAMP_FOOT14WR_T4",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT15ID,              UINT32,\
+                    "TIMESTAMP_FOOT15ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT15WR_T1,           UINT32,\
+                    "TIMESTAMP_FOOT15WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT15WR_T2,           UINT32,\
+                    "TIMESTAMP_FOOT15WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT15WR_T3,           UINT32,\
+                    "TIMESTAMP_FOOT15WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT15WR_T4,           UINT32,\
+                    "TIMESTAMP_FOOT15WR_T4",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT16ID,              UINT32,\
+                    "TIMESTAMP_FOOT16ID",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT16WR_T1,           UINT32,\
+                    "TIMESTAMP_FOOT16WR_T1",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT16WR_T2,           UINT32,\
+                    "TIMESTAMP_FOOT16WR_T2",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT16WR_T3,           UINT32,\
+                    "TIMESTAMP_FOOT16WR_T3",65535,0/*flags*/); \
+  EXT_STR_ITEM_INFO2_LIM(ok,si,offset,struct_t,printerr,\
+                     TIMESTAMP_FOOT16WR_T4,           UINT32,\
+                    "TIMESTAMP_FOOT16WR_T4",65535,0/*flags*/); \
+  \
+} while (0);
+
+#endif/*__GUARD_H101_WRFOOT_EXT_H101_FOOT_WR_G249_H__*/
 
 /*******************************************************/


### PR DESCRIPTION
Update ext structure to enable reading WR timestamps from 16 FOOTs

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
