### PR TITLE
feat(r3bsource/alpide):Add specific data structure for G249

### DIFF
--- a/r3bsource/CMakeLists.txt
+++ b/r3bsource/CMakeLists.txt
@@ -167,7 +167,8 @@ set(STRUCT_HEADERS
     ams/ext_h101_ams.h
     foot/ext_h101_foot.h
     alpide/ext_h101_alpide.h
-    alpide/ext_h101_mosaic.h
+    alpide/ext_h101_mosaic202402.h
+    alpide/ext_h101_mosaic202506.h
     alpide/ext_h101_hmp.h
     music/ext_h101_music.h
     twim/ext_h101_twim.h

--- a/r3bsource/SourceLinkDef.h
+++ b/r3bsource/SourceLinkDef.h
@@ -83,7 +83,6 @@
 #pragma link C++ class R3BMosaicReader+;
 #pragma link C++ class R3BActafReader+;
 
-
 #pragma link C++ class EXT_STR_h101_unpack_t;
 #pragma link C++ class EXT_STR_h101_whiterabbit_onion_t;
 #pragma link C++ class EXT_STR_h101_TPAT_t;
@@ -145,7 +144,8 @@
 #pragma link C++ class EXT_STR_h101_LOS_t;
 #pragma link C++ class EXT_STR_h101_RPC_t;
 #pragma link C++ class EXT_STR_h101_SYNC_CHECK_t;
-#pragma link C++ class EXT_STR_h101_MOSAIC_onion_t;
+#pragma link C++ class EXT_STR_h101_MOSAIC202402_onion_t;
+#pragma link C++ class EXT_STR_h101_MOSAIC202506_onion_t;
 #pragma link C++ class EXT_STR_h101_HMP_onion_t;
 #pragma link C++ class EXT_STR_h101_ACTAF_onion_t;
 

--- a/r3bsource/alpide/R3BMosaicReader.cxx
+++ b/r3bsource/alpide/R3BMosaicReader.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
- *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
- *   Copyright (C) 2019-2025 Members of R3B Collaboration                     *
+ *   Copyright (C) 2024 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2024-2025 Members of R3B Collaboration                     *
  *                                                                            *
  *             This software is distributed under the terms of the            *
  *                 GNU General Public Licence (GPL) version 3,                *
@@ -29,15 +29,25 @@
 extern "C"
 {
 #include "ext_data_client.h"
-#include "ext_h101_mosaic.h"
+#include "ext_h101_mosaic202402.h"
+#include "ext_h101_mosaic202506.h"
 }
 
-R3BMosaicReader::R3BMosaicReader(EXT_STR_h101_MOSAIC_onion* data, size_t offset)
+R3BMosaicReader::R3BMosaicReader(EXT_STR_h101_MOSAIC202402_onion* data, size_t offset)
     : R3BReader("R3BMosaicReader")
-    , fData(data)
-    , fNbMosaic(sizeof(fData->MOSAIC) / sizeof(fData->MOSAIC[0]))
+    , fData2402(data)
+    , fNbMosaic(sizeof(fData2402->MOSAIC) / sizeof(fData2402->MOSAIC[0]))
     , fOffset(offset)
     , fArray(new TClonesArray("R3BAlpideMappedData"))
+{
+}
+
+R3BMosaicReader::R3BMosaicReader(EXT_STR_h101_MOSAIC202506_onion* data, size_t offset)
+    : R3BReader("R3BMosaicReader")
+    , fData2506(data)
+    , fOffset(offset)
+    , fArray(new TClonesArray("R3BAlpideMappedData"))
+    , fVersion(UnpackerMosaicVersion::v202506)
 {
 }
 
@@ -53,14 +63,23 @@ Bool_t R3BMosaicReader::Init(ext_data_struct_info* a_struct_info)
 {
     int okay = 0;
     R3BLOG(info, "");
-    EXT_STR_h101_MOSAIC_ITEMS_INFO(okay, *a_struct_info, fOffset, EXT_STR_h101_MOSAIC, 0);
+
+    if (fVersion == UnpackerMosaicVersion::v202402)
+    {
+        EXT_STR_h101_MOSAIC202402_ITEMS_INFO(okay, *a_struct_info, fOffset, EXT_STR_h101_MOSAIC202402, 0);
+        memset(fData2402, 0, sizeof(*fData2402));
+    }
+    else if (fVersion == UnpackerMosaicVersion::v202506)
+    {
+        EXT_STR_h101_MOSAIC202506_ITEMS_INFO(okay, *a_struct_info, fOffset, EXT_STR_h101_MOSAIC202506, 0);
+        memset(fData2506, 0, sizeof(*fData2506));
+    }
 
     R3BLOG_IF(fatal, !okay, "Failed to setup structure information.");
 
     // Register output array in tree
     FairRootManager::Instance()->Register("AlpideMappedData", "ALPIDE_Map", fArray, !fOnline);
     Reset();
-    memset(fData, 0, sizeof(*fData));
 
     return kTRUE;
 }
@@ -69,22 +88,70 @@ Bool_t R3BMosaicReader::R3BRead()
 {
     R3BLOG(debug1, "Event data: " << fNEvent);
     fNEvent++;
+    if (fVersion == UnpackerMosaicVersion::v202402)
+    {
+        return R3BRead202402();
+    }
+    else if (fVersion == UnpackerMosaicVersion::v202506)
+    {
+        return R3BRead202506();
+    }
+    else
+    {
+        return kFALSE;
+    }
+}
 
+bool R3BMosaicReader::R3BRead202402()
+{
     for (int mosid = 0; mosid < fNbMosaic; mosid++)
     {
-        for (int hits = 0; hits < fData->MOSAIC[mosid].CHIP; hits++)
+        for (int hits = 0; hits < fData2402->MOSAIC[mosid].CHIP; hits++)
         {
-            int fChipId = fData->MOSAIC[mosid].CHIPv[hits];
+            int fChipId = fData2402->MOSAIC[mosid].CHIPv[hits];
 
             int fAlpideId = map_mosaics[mosid] * fNb_sensors_flex + fChipId + 1; // 1-base
             R3BLOG_IF(error, fAlpideId < 1, "Wrong fAlpideId: " << fAlpideId);
 
             fAlpideId = map_sensors[fAlpideId - 1]; // 1-base
 
-            new ((*fArray)[fArray->GetEntriesFast()]) R3BAlpideMappedData(
-                fAlpideId, 0, mosid + 1, fChipId, fData->MOSAIC[mosid].ROWv[hits], fData->MOSAIC[mosid].COLv[hits]);
+            new ((*fArray)[fArray->GetEntriesFast()]) R3BAlpideMappedData(fAlpideId,
+                                                                          0,
+                                                                          mosid + 1,
+                                                                          fChipId,
+                                                                          fData2402->MOSAIC[mosid].ROWv[hits],
+                                                                          fData2402->MOSAIC[mosid].COLv[hits]);
         }
     }
+    return kTRUE;
+}
+
+bool R3BMosaicReader::R3BRead202506()
+{
+    // MOSAIC-3 corresponds to the second flex
+    for (int hits = 0; hits < fData2506->MOSAIC3CHIP; hits++)
+    {
+        int fChipId = fData2506->MOSAIC3CHIPv[hits];
+
+        int fAlpideId = fNb_sensors_flex + (fChipId + 1); // 1-base
+        R3BLOG_IF(error, fAlpideId < 1, "Wrong fAlpideId: " << fAlpideId);
+
+        new ((*fArray)[fArray->GetEntriesFast()])
+            R3BAlpideMappedData(fAlpideId, 0, 2, fChipId, fData2506->MOSAIC3ROWv[hits], fData2506->MOSAIC3COLv[hits]);
+    }
+
+    // MOSAIC-4 corresponds to the first flex
+    for (int hits = 0; hits < fData2506->MOSAIC4CHIP; hits++)
+    {
+        int fChipId = fData2506->MOSAIC4CHIPv[hits];
+
+        int fAlpideId = fChipId + 1; // 1-base
+        R3BLOG_IF(error, fAlpideId < 1, "Wrong fAlpideId: " << fAlpideId);
+
+        new ((*fArray)[fArray->GetEntriesFast()])
+            R3BAlpideMappedData(fAlpideId, 0, 1, fChipId, fData2506->MOSAIC4ROWv[hits], fData2506->MOSAIC4COLv[hits]);
+    }
+
     return kTRUE;
 }
 

--- a/r3bsource/alpide/R3BMosaicReader.h
+++ b/r3bsource/alpide/R3BMosaicReader.h
@@ -1,6 +1,6 @@
 /******************************************************************************
- *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
- *   Copyright (C) 2019-2025 Members of R3B Collaboration                     *
+ *   Copyright (C) 2024 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2024-2025 Members of R3B Collaboration                     *
  *                                                                            *
  *             This software is distributed under the terms of the            *
  *                 GNU General Public Licence (GPL) version 3,                *
@@ -24,15 +24,20 @@
 
 class TClonesArray;
 
-struct EXT_STR_h101_MOSAIC_t;
-typedef struct EXT_STR_h101_MOSAIC_onion_t EXT_STR_h101_MOSAIC_onion;
+struct EXT_STR_h101_MOSAIC202402_t;
+typedef struct EXT_STR_h101_MOSAIC202402_onion_t EXT_STR_h101_MOSAIC202402_onion;
+
+struct EXT_STR_h101_MOSAIC202506_t;
+typedef struct EXT_STR_h101_MOSAIC202506_onion_t EXT_STR_h101_MOSAIC202506_onion;
+
 class ext_data_struct_info;
 
 class R3BMosaicReader : public R3BReader
 {
   public:
     // Standard constructor
-    R3BMosaicReader(EXT_STR_h101_MOSAIC_onion*, size_t);
+    R3BMosaicReader(EXT_STR_h101_MOSAIC202402_onion*, size_t);
+    R3BMosaicReader(EXT_STR_h101_MOSAIC202506_onion*, size_t);
 
     // Destructor
     virtual ~R3BMosaicReader();
@@ -59,10 +64,22 @@ class R3BMosaicReader : public R3BReader
     inline void SetMosaicMapping(const std::vector<int>& mosaicIds) { map_mosaics = mosaicIds; }
 
   private:
+    enum class UnpackerMosaicVersion : int
+    {
+        v202402 = 202402,
+        v202505 = 202505,
+        v202506 = 202506
+    };
+    // Read data from S091 setup
+    auto R3BRead202402() -> bool;
+    // Read data from G249 setup
+    auto R3BRead202506() -> bool;
+
     // An event counter
     unsigned int fNEvent = 1;
     // Reader specific data structure from ucesb
-    EXT_STR_h101_MOSAIC_onion* fData;
+    EXT_STR_h101_MOSAIC202402_onion* fData2402 = nullptr;
+    EXT_STR_h101_MOSAIC202506_onion* fData2506 = nullptr;
     // Number of Mosaics
     int fNbMosaic = 1;
     // Data offset
@@ -73,6 +90,8 @@ class R3BMosaicReader : public R3BReader
     uint16_t fNb_sensors_flex = 6;
     // Output array
     TClonesArray* fArray = nullptr;
+    // Unpacker version
+    UnpackerMosaicVersion fVersion = UnpackerMosaicVersion::v202402;
 
     std::vector<int> map_mosaics = { 0, 0, 0, 0, 0, 0, 1, 2, 3 };
 

--- a/r3bsource/alpide/ext_h101_mosaic202402.h
+++ b/r3bsource/alpide/ext_h101_mosaic202402.h
@@ -1,6 +1,6 @@
 /******************************************************************************
- *   Copyright (C) 2019 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
- *   Copyright (C) 2024 Members of R3B Collaboration                          *
+ *   Copyright (C) 2023 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2023-2025 Members of R3B Collaboration                     *
  *                                                                            *
  *             This software is distributed under the terms of the            *
  *                 GNU General Public Licence (GPL) version 3,                *
@@ -38,7 +38,7 @@ typedef int int32_t;
  * Plain structure (layout as ntuple/root file):
  */
 
-typedef struct EXT_STR_h101_MOSAIC_t
+typedef struct EXT_STR_h101_MOSAIC202402_t
 {
     /* RAW */
     uint32_t MOSAIC1T_HI /* [-1,-1] */;
@@ -123,7 +123,7 @@ typedef struct EXT_STR_h101_MOSAIC_t
     uint32_t MOSAIC9COL /* [0,2000] */;
     uint32_t MOSAIC9COLv[2000 EXT_STRUCT_CTRL(MOSAIC9COL)] /* [0,65535] */;
 
-} EXT_STR_h101_MOSAIC;
+} EXT_STR_h101_MOSAIC202402;
 
 /********************************************************
  *
@@ -131,7 +131,7 @@ typedef struct EXT_STR_h101_MOSAIC_t
  * recovered (recommended):
  */
 
-typedef struct EXT_STR_h101_MOSAIC_onion_t
+typedef struct EXT_STR_h101_MOSAIC202402_onion_t
 {
     /* RAW */
     struct
@@ -147,11 +147,11 @@ typedef struct EXT_STR_h101_MOSAIC_onion_t
         uint32_t COLv[2000 /* COL */];
     } MOSAIC[9];
 
-} EXT_STR_h101_MOSAIC_onion;
+} EXT_STR_h101_MOSAIC202402_onion;
 
 /*******************************************************/
 
-#define EXT_STR_h101_MOSAIC_ITEMS_INFO(ok, si, offset, struct_t, printerr)                                         \
+#define EXT_STR_h101_MOSAIC202402_ITEMS_INFO(ok, si, offset, struct_t, printerr)                                   \
     do                                                                                                             \
     {                                                                                                              \
         ok = 1;                                                                                                    \
@@ -302,5 +302,3 @@ typedef struct EXT_STR_h101_MOSAIC_onion_t
             ok, si, offset, struct_t, printerr, MOSAIC9COLv, UINT32, "MOSAIC9COLv", "MOSAIC9COL", 0 /*flags*/);    \
                                                                                                                    \
     } while (0);
-
-/*******************************************************/

--- a/r3bsource/alpide/ext_h101_mosaic202506.h
+++ b/r3bsource/alpide/ext_h101_mosaic202506.h
@@ -1,0 +1,135 @@
+/******************************************************************************
+ *   Copyright (C) 2025 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
+ *   Copyright (C) 2025 Members of R3B Collaboration                          *
+ *                                                                            *
+ *             This software is distributed under the terms of the            *
+ *                 GNU General Public Licence (GPL) version 3,                *
+ *                    copied verbatim in the file "LICENSE".                  *
+ *                                                                            *
+ * In applying this license GSI does not waive the privileges and immunities  *
+ * granted to it by virtue of its status as an Intergovernmental Organization *
+ * or submit itself to any jurisdiction.                                      *
+ ******************************************************************************/
+
+/********************************************************
+ *
+ * Structure for ext_data_fetch_event() filling.
+ *
+ * Do not edit - automatically generated.
+ */
+
+#pragma once
+
+#ifndef __CINT__
+#include <stdint.h>
+#else
+/* For CINT (old version trouble with stdint.h): */
+#ifndef uint32_t
+typedef unsigned int uint32_t;
+typedef int int32_t;
+#endif
+#endif
+#ifndef EXT_STRUCT_CTRL
+#define EXT_STRUCT_CTRL(x)
+#endif
+
+/********************************************************
+ *
+ * Plain structure (layout as ntuple/root file):
+ */
+
+typedef struct EXT_STR_h101_MOSAIC202506_t
+{
+    /* RAW */
+    uint32_t MOSAIC3T_HI /* [-1,-1] */;
+    uint32_t MOSAIC3T_LO /* [-1,-1] */;
+    uint32_t MOSAIC3TRIG_SYNC /* [0,65535] */;
+    uint32_t MOSAIC3CHIP /* [0,32767] */;
+    uint32_t MOSAIC3CHIPv[32767 EXT_STRUCT_CTRL(MOSAIC3CHIP)] /* [0,255] */;
+    uint32_t MOSAIC3ROW /* [0,32767] */;
+    uint32_t MOSAIC3ROWv[32767 EXT_STRUCT_CTRL(MOSAIC3ROW)] /* [0,65535] */;
+    uint32_t MOSAIC3COL /* [0,32767] */;
+    uint32_t MOSAIC3COLv[32767 EXT_STRUCT_CTRL(MOSAIC3COL)] /* [0,65535] */;
+    uint32_t MOSAIC4T_HI /* [-1,-1] */;
+    uint32_t MOSAIC4T_LO /* [-1,-1] */;
+    uint32_t MOSAIC4TRIG_SYNC /* [0,65535] */;
+    uint32_t MOSAIC4CHIP /* [0,32767] */;
+    uint32_t MOSAIC4CHIPv[32767 EXT_STRUCT_CTRL(MOSAIC4CHIP)] /* [0,255] */;
+    uint32_t MOSAIC4ROW /* [0,32767] */;
+    uint32_t MOSAIC4ROWv[32767 EXT_STRUCT_CTRL(MOSAIC4ROW)] /* [0,65535] */;
+    uint32_t MOSAIC4COL /* [0,32767] */;
+    uint32_t MOSAIC4COLv[32767 EXT_STRUCT_CTRL(MOSAIC4COL)] /* [0,65535] */;
+
+} EXT_STR_h101_MOSAIC202506;
+
+/********************************************************
+ *
+ * Structure with multiple levels of arrays (partially)
+ * recovered (recommended):
+ */
+
+typedef struct EXT_STR_h101_MOSAIC202506_onion_t
+{
+    /* RAW */
+    uint32_t MOSAIC3T_HI;
+    uint32_t MOSAIC3T_LO;
+    uint32_t MOSAIC3TRIG_SYNC;
+    uint32_t MOSAIC3CHIP;
+    uint32_t MOSAIC3CHIPv[32767 /* MOSAIC3CHIP */];
+    uint32_t MOSAIC3ROW;
+    uint32_t MOSAIC3ROWv[32767 /* MOSAIC3ROW */];
+    uint32_t MOSAIC3COL;
+    uint32_t MOSAIC3COLv[32767 /* MOSAIC3COL */];
+    uint32_t MOSAIC4T_HI;
+    uint32_t MOSAIC4T_LO;
+    uint32_t MOSAIC4TRIG_SYNC;
+    uint32_t MOSAIC4CHIP;
+    uint32_t MOSAIC4CHIPv[32767 /* MOSAIC4CHIP */];
+    uint32_t MOSAIC4ROW;
+    uint32_t MOSAIC4ROWv[32767 /* MOSAIC4ROW */];
+    uint32_t MOSAIC4COL;
+    uint32_t MOSAIC4COLv[32767 /* MOSAIC4COL */];
+
+} EXT_STR_h101_MOSAIC202506_onion;
+
+/*******************************************************/
+
+#define EXT_STR_h101_MOSAIC202506_ITEMS_INFO(ok, si, offset, struct_t, printerr)                                   \
+    do                                                                                                             \
+    {                                                                                                              \
+        ok = 1;                                                                                                    \
+        /* RAW */                                                                                                  \
+        EXT_STR_ITEM_INFO2(ok, si, offset, struct_t, printerr, MOSAIC3T_HI, UINT32, "MOSAIC3T_HI", 0 /*flags*/);   \
+        EXT_STR_ITEM_INFO2(ok, si, offset, struct_t, printerr, MOSAIC3T_LO, UINT32, "MOSAIC3T_LO", 0 /*flags*/);   \
+        EXT_STR_ITEM_INFO2_LIM(                                                                                    \
+            ok, si, offset, struct_t, printerr, MOSAIC3TRIG_SYNC, UINT32, "MOSAIC3TRIG_SYNC", 65535, 0 /*flags*/); \
+        EXT_STR_ITEM_INFO2_LIM(                                                                                    \
+            ok, si, offset, struct_t, printerr, MOSAIC3CHIP, UINT32, "MOSAIC3CHIP", 32767, 0 /*flags*/);           \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                    \
+            ok, si, offset, struct_t, printerr, MOSAIC3CHIPv, UINT32, "MOSAIC3CHIPv", "MOSAIC3CHIP", 0 /*flags*/); \
+        EXT_STR_ITEM_INFO2_LIM(                                                                                    \
+            ok, si, offset, struct_t, printerr, MOSAIC3ROW, UINT32, "MOSAIC3ROW", 32767, 0 /*flags*/);             \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                    \
+            ok, si, offset, struct_t, printerr, MOSAIC3ROWv, UINT32, "MOSAIC3ROWv", "MOSAIC3ROW", 0 /*flags*/);    \
+        EXT_STR_ITEM_INFO2_LIM(                                                                                    \
+            ok, si, offset, struct_t, printerr, MOSAIC3COL, UINT32, "MOSAIC3COL", 32767, 0 /*flags*/);             \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                    \
+            ok, si, offset, struct_t, printerr, MOSAIC3COLv, UINT32, "MOSAIC3COLv", "MOSAIC3COL", 0 /*flags*/);    \
+        EXT_STR_ITEM_INFO2(ok, si, offset, struct_t, printerr, MOSAIC4T_HI, UINT32, "MOSAIC4T_HI", 0 /*flags*/);   \
+        EXT_STR_ITEM_INFO2(ok, si, offset, struct_t, printerr, MOSAIC4T_LO, UINT32, "MOSAIC4T_LO", 0 /*flags*/);   \
+        EXT_STR_ITEM_INFO2_LIM(                                                                                    \
+            ok, si, offset, struct_t, printerr, MOSAIC4TRIG_SYNC, UINT32, "MOSAIC4TRIG_SYNC", 65535, 0 /*flags*/); \
+        EXT_STR_ITEM_INFO2_LIM(                                                                                    \
+            ok, si, offset, struct_t, printerr, MOSAIC4CHIP, UINT32, "MOSAIC4CHIP", 32767, 0 /*flags*/);           \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                    \
+            ok, si, offset, struct_t, printerr, MOSAIC4CHIPv, UINT32, "MOSAIC4CHIPv", "MOSAIC4CHIP", 0 /*flags*/); \
+        EXT_STR_ITEM_INFO2_LIM(                                                                                    \
+            ok, si, offset, struct_t, printerr, MOSAIC4ROW, UINT32, "MOSAIC4ROW", 32767, 0 /*flags*/);             \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                    \
+            ok, si, offset, struct_t, printerr, MOSAIC4ROWv, UINT32, "MOSAIC4ROWv", "MOSAIC4ROW", 0 /*flags*/);    \
+        EXT_STR_ITEM_INFO2_LIM(                                                                                    \
+            ok, si, offset, struct_t, printerr, MOSAIC4COL, UINT32, "MOSAIC4COL", 32767, 0 /*flags*/);             \
+        EXT_STR_ITEM_INFO2_ZZP(                                                                                    \
+            ok, si, offset, struct_t, printerr, MOSAIC4COLv, UINT32, "MOSAIC4COLv", "MOSAIC4COL", 0 /*flags*/);    \
+                                                                                                                   \
+    } while (0);


### PR DESCRIPTION
Added a new data structure for the experiment G249 to read only two mosaics and avoid the usual problems with the mapping

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
