### PR TITLE
fix(neuland/calibrations): Fixed a bug when checking if cal[0] and ca…

### DIFF
--- a/neuland/calibration/R3BNeulandCal2Hit.cxx
+++ b/neuland/calibration/R3BNeulandCal2Hit.cxx
@@ -173,7 +173,7 @@ void R3BNeulandCal2Hit::Exec(Option_t*)
 
         std::array<Double_t, 2> tdc;
 
-        if (std::isnan(cal[0]->GetTriggerTime()) || std::isnan(cal[0]->GetTriggerTime()))
+        if (std::isnan(cal[0]->GetTriggerTime()) || std::isnan(cal[1]->GetTriggerTime()))
         {
             tdc = { cal[0]->GetTime() + parameter.GetTimeOffset(1), cal[1]->GetTime() + parameter.GetTimeOffset(2) };
         }


### PR DESCRIPTION
…l[1] were nans. Previously the assertion was done with cal[0] twice.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
