### PR TITLE
Changes to CALIFA clustering algorithm

### DIFF
--- a/califa/calibration/R3BCalifaCrystalCal2Cluster.cxx
+++ b/califa/calibration/R3BCalifaCrystalCal2Cluster.cxx
@@ -265,29 +265,31 @@ void R3BCalifaCrystalCal2Cluster::Exec(Option_t* /*opt*/)
         cryEnergy = dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i))->GetEnergy();
 
         if (cryEnergy >= fCrystalThreshold)
+        {
             allCrystalVec.push_back(dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i)));
 
-        /* -------- Real data ------- */
-        if (!fSimulation)
-        {
-            if (cryEnergy >= fGammaClusterThreshold && !std::isnan(cryEnergy))
-                gammaCandidatesVec.push_back(dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i)));
+            /* -------- Real data ------- */
+            if (!fSimulation)
+            {
+                if (cryEnergy >= fGammaClusterThreshold && !std::isnan(cryEnergy))
+                    gammaCandidatesVec.push_back(dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i)));
 
-            if (cryId > fTotalCrystals && cryEnergy >= fProtonClusterThreshold)
-                protonCandidatesVec.push_back(dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i)));
+                if (cryId > fTotalCrystals && cryEnergy >= fProtonClusterThreshold)
+                    protonCandidatesVec.push_back(dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i)));
 
-            if (cryId <= fTotalCrystals && std::isnan(cryEnergy))
-                saturatedCandidatesVec.push_back(dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i)));
-        }
+                if (cryId <= fTotalCrystals && std::isnan(cryEnergy))
+                    saturatedCandidatesVec.push_back(dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i)));
+            }
 
-        /* -------- Simulation data ------- */
-        else
-        {
-            if (cryEnergy >= fGammaClusterThreshold && cryEnergy < fProtonClusterThreshold)
-                gammaCandidatesVec.push_back(dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i)));
+            /* -------- Simulation data ------- */
+            else
+            {
+                if (cryEnergy >= fGammaClusterThreshold && cryEnergy < fProtonClusterThreshold)
+                    gammaCandidatesVec.push_back(dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i)));
 
-            if (cryEnergy >= fProtonClusterThreshold)
-                protonCandidatesVec.push_back(dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i)));
+                if (cryEnergy >= fProtonClusterThreshold)
+                    protonCandidatesVec.push_back(dynamic_cast<R3BCalifaCrystalCalData*>(fCrystalCalData->At(i)));
+            }
         }
     }
 
@@ -378,8 +380,13 @@ void R3BCalifaCrystalCal2Cluster::Exec(Option_t* /*opt*/)
 
                 angles = R3BCalifaGeometry::Instance()->GetAngles(thisCryId);
 
-                if (InsideClusterWindow(mother_angles, angles))
+                // add to gamma or proton cluster depending on crystal id
+
+                if (InsideClusterWindow(mother_angles, angles) && thisCryId <= fTotalCrystals)
                     addCrystal2Cluster(&cluster, allCrystalVec.at(j), "gamma", &usedCrystals, fTotalCrystals);
+
+                if (InsideClusterWindow(mother_angles, angles) && thisCryId > fTotalCrystals)
+                    addCrystal2Cluster(&cluster, allCrystalVec.at(j), "proton", &usedCrystals, fTotalCrystals);
             }
         }
 

--- a/califa/calibration/R3BCalifaCrystalCal2Cluster.h
+++ b/califa/calibration/R3BCalifaCrystalCal2Cluster.h
@@ -93,13 +93,14 @@ class R3BCalifaCrystalCal2Cluster : public FairTask
     Int_t fGeometryVersion = 2024; // Selecting the geometry of the CALIFA calorimeter
     Int_t fTotalCrystals = 2544;
 
+    // Note: threshold values are in [MeV] for simulation data and in [keV] for experimental data
     Double_t fCrystalThreshold = 0.; // Minimum energy requested in a crystal to be included in a cluster
     Double_t fProtonClusterThreshold =
-        50.;                              // Minimum energy in a crystal to be considered as a proton cluster candidate
+        31.;                              // Minimum energy in a crystal to be considered as a proton cluster candidate
     Double_t fGammaClusterThreshold = 0.; // Minimum energy in a crystal to be considered as a gamma cluster candidate
     // Double_t fProtonThreshold;            // Defines the cut energy between proton and gamma readout
 
-    Double_t fRoundWindow = 0.25; // Cluster window
+    Double_t fRoundWindow = 0.25; // Cluster window [rad]
     bool fSimulation = false;     // Simulation flag
 
     Bool_t fRand = 0.; // Flag to set randomization procedure


### PR DESCRIPTION
**R3BCalifaCrystalCal2Cluster.cxx**: Fixed bug where the global cluster threshold was earlier not being used for gamma and proton cluster candidates; applied condition based crystal ID to categorize clusters as 'gamma' or 'proton' (which removes the extra 31 MeV cluster seen in simulations)
**R3BCalifaCrystalCal2Cluster.h**: Modified default value of the proton cluster threshold to match the gamma saturation threshold (31 MeV instead of 50 MeV) set in the CALIFA digitzer