### PR TITLE
New charge calibration function + minor error

### DIFF
--- a/ssd/calibration/R3BFootStripCal2Hit.cxx
+++ b/ssd/calibration/R3BFootStripCal2Hit.cxx
@@ -367,6 +367,20 @@ void R3BFootStripCal2Hit::EtaCorrectionAndChargeCal()
         {
 
             int asicId = static_cast<int>(ClusterPos[i][j] / (fNumStrips / 10.));
+            int equivStrip = static_cast<int>(ClusterPos[i][j]);
+
+            // Avoid inter-asic clusters
+            bool isBadAsic = false;
+            if (fInterClusterWindow > 0)
+                for (int iwin = -fInterClusterWindow; iwin <= fInterClusterWindow; iwin++)
+                    if ((equivStrip + iwin) % static_cast<int>(fNumStrips / fNumAsic) == 0)
+                        isBadAsic = true;
+
+            if (isBadAsic)
+            {
+                ClusterCharge[i][j] = std::nan("");
+                continue;
+            }
 
             int generalIndex = i * fNumAsic + asicId;
             double energyCorrected = -1;
@@ -420,7 +434,13 @@ void R3BFootStripCal2Hit::EtaCorrectionAndChargeCal()
 
             // Get the coefficients for this asic
             auto name = Form("fitFunc_foot_%i_asic_%i", i, asicId);
-            auto polType = Form("pol%i", fNumParsCal - 1);
+
+            TString polType = Form("pol%i", fNumParsCal - 1);
+
+            // Use a power-law relation between charge and energy
+            if (fUsePowerLawCal)
+                polType = "[0]*pow(x,[1])";
+
             auto fitFunc = std::make_unique<TF1>(name, polType);
 
             auto chargeParams = fCharCalPar;
@@ -428,13 +448,10 @@ void R3BFootStripCal2Hit::EtaCorrectionAndChargeCal()
             if (Eta[i][j] == 0)
                 chargeParams = fCharCalParSM;
 
-            for (size_t iPol = 0; iPol < fNumParsCal; iPol++)
-            {
+            for (auto iPol = 0; iPol < fNumParsCal; iPol++)
                 fitFunc->SetParameter(iPol, chargeParams[generalIndex][iPol]);
-            }
 
             charge = fitFunc->Eval(energyCorrected);
-
             ClusterESum[i][j] = energyCorrected;
             ClusterCharge[i][j] = charge;
         }

--- a/ssd/calibration/R3BFootStripCal2Hit.h
+++ b/ssd/calibration/R3BFootStripCal2Hit.h
@@ -61,19 +61,26 @@ class R3BFootStripCal2Hit : public FairTask
     void SetTimesSigmas(Double_t sigmas) { fTimesSigmas = sigmas; };
 
     /** Accessor for selecting online mode **/
-    inline void SetOnline(Bool_t option) { fOnline = option; }
+    void SetOnline(Bool_t option) { fOnline = option; }
 
     /** Accessor for selecting max. number of clusters per FOOT detector **/
-    inline void SetMaxNumClusters(int max) { fMaxNumClusters = max; }
+    void SetMaxNumClusters(int max) { fMaxNumClusters = max; }
 
     /** Accessor to set up the threshold for the cluster energy sum **/
-    inline void SetClusterEnergy(double thsum) { fThSum = thsum; }
+    void SetClusterEnergy(double thsum) { fThSum = thsum; }
 
     // Method for setting the maximum number of strips for each cluster
-    inline void SetMaxNumStrips(int max) { fMaxNumStrips = max; }
+    void SetMaxNumStrips(int max) { fMaxNumStrips = max; }
 
     // Method to disable transformation of hits to lab coordinates (default: true)
-    inline void SetTransform2Lab(bool flag) { fTransform2Lab = flag; }
+    void SetTransform2Lab(bool flag) { fTransform2Lab = flag; }
+
+    // Method to set the number of inter-cluster strips that need to be disrigarded
+    void SetInterClusterWindow(int val) { fInterClusterWindow = val; }
+
+    // Method to use the power-law algoritm (Z = aE**gamma) instead of the default linear
+    // calibration
+    void SetUsePowerLawCal() { fUsePowerLawCal = true; }
 
   private:
     void SetParameter();
@@ -97,6 +104,8 @@ class R3BFootStripCal2Hit : public FairTask
 
     int fMaxNumClusters = 10;
     int fMaxNumStrips = 640;
+    int fInterClusterWindow = 2;
+    bool fUsePowerLawCal = false;
 
     std::vector<double> fDistTarget;
     std::vector<double> fAngleTheta;

--- a/ssd/pars/R3BFootHitPar.cxx
+++ b/ssd/pars/R3BFootHitPar.cxx
@@ -141,11 +141,13 @@ Bool_t R3BFootHitPar::getParams(FairParamList* list)
     }
 
     // We assume that the calibration parameters are the same for all multiplicities
-    R3BLOG_IF(warn,
-              !(list->fill("footCharCalParSM", fCharCalParSM)),
-              "R3BFootHitPar::Could not initialize footCharCalParSM. Single multiplicity calibration will not be used");
-
-    list->fill("footCharCalPar", fCharCalParSM);
+    if (!(list->fill("footCharCalParSM", fCharCalParSM)))
+    {
+        R3BLOG(
+            warn,
+            "R3BFootHitPar::Could not initialize footCharCalParSM. Single multiplicity calibration will not be used");
+        list->fill("footCharCalPar", fCharCalParSM);
+    }
 
     if (!(list->fill("footEtaCorrPar", fEtaCorrPar)))
     {


### PR DESCRIPTION
feat(foot): New calibration function. Instead of using a linear/polynomial calibration a function Z = a * E ** gamma is used. NB, the linear version is still, the default one. To use it add these lines in the online/unpacker:

```c++
auto *cal2hit = new R3BFootStripCal2Hit();
cal2hit->SetUsePowerLawCal();
```

fix(foot): SM Params were never used because of a bug. This is solved now and they will be loaded.

feat(foot): Introduced a inter asic window of 2 strips. Since the last strip of each ASIC is dead particles impinging there will generate two separated clusters with less energy than expected. These clusters are now disregarded but this functionality can be deactivated. 

```c++
cal2hit->SetInterClusterWindow(-1);
```

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
