### PR TITLE
actaf/online: bool to save or not the histos in file

### DIFF
--- a/actaf/online/R3BActafOnlineSpectra.cxx
+++ b/actaf/online/R3BActafOnlineSpectra.cxx
@@ -1404,87 +1404,90 @@ void R3BActafOnlineSpectra::FinishEvent()
 
 void R3BActafOnlineSpectra::FinishTask()
 {
-    if (fMappedItems)
+    if (saveHistos)
     {
-        fh2_ERaw_map->Write();
-        fh2_Baseline_map->Write();
-        fh2_MaxPos_map->Write();
-        fh2_Risetime_map->Write();
-        fh2_ModVsCh_map->Write();
-        fh1_sigmaInit->Write();
-        fh1_sigmaFilt->Write();
-        fh2_sigmaInitVsPad->Write();
-        fh2_RmsMapVsPad->Write();
-        fh2_sigmaFiltVsPad->Write();
-        fh2_meanInitVsPad->Write();
-        fh2_meanFiltVsPad->Write();
-        fh1_DetMask->Write();
-        fh2_timetag_signal->Write();
-        for (const auto& hist : fh2_RawTraces)
+        if (fMappedItems)
         {
-            hist->Write();
+            fh2_ERaw_map->Write();
+            fh2_Baseline_map->Write();
+            fh2_MaxPos_map->Write();
+            fh2_Risetime_map->Write();
+            fh2_ModVsCh_map->Write();
+            fh1_sigmaInit->Write();
+            fh1_sigmaFilt->Write();
+            fh2_sigmaInitVsPad->Write();
+            fh2_RmsMapVsPad->Write();
+            fh2_sigmaFiltVsPad->Write();
+            fh2_meanInitVsPad->Write();
+            fh2_meanFiltVsPad->Write();
+            fh1_DetMask->Write();
+            fh2_timetag_signal->Write();
+            for (const auto& hist : fh2_RawTraces)
+            {
+                hist->Write();
+            }
+            for (const auto& hist : fh2_CorrectedTraces)
+            {
+                hist->Write();
+            }
+            for (const auto& hist : fh2_FilteredTraces)
+            {
+                hist->Write();
+            }
+            for (const auto& hist : fh2_mawVsECal)
+            {
+                hist->Write();
+            }
+            for (const auto& hist : fh1_RawE)
+            {
+                hist->Write();
+            }
+            for (const auto& hist : fh1_Baseline)
+            {
+                hist->Write();
+            }
+            for (const auto& hist : fh1_Sync)
+            {
+                hist->Write();
+            }
+            for (const auto& hist : fh1_WrSync)
+            {
+                hist->Write();
+            }
+            for (auto* gr : fgraph_rates)
+            {
+                if (gr)
+                    gr->Write();
+            }
         }
-        for (const auto& hist : fh2_CorrectedTraces)
-        {
-            hist->Write();
-        }
-        for (const auto& hist : fh2_FilteredTraces)
-        {
-            hist->Write();
-        }
-        for (const auto& hist : fh2_mawVsECal)
-        {
-            hist->Write();
-        }
-        for (const auto& hist : fh1_RawE)
-        {
-            hist->Write();
-        }
-        for (const auto& hist : fh1_Baseline)
-        {
-            hist->Write();
-        }
-        for (const auto& hist : fh1_Sync)
-        {
-            hist->Write();
-        }
-        for (const auto& hist : fh1_WrSync)
-        {
-            hist->Write();
-        }
-        for (auto* gr : fgraph_rates)
-        {
-            if (gr)
-                gr->Write();
-        }
-    }
 
-    if (fCalItems)
-    {
-        fh2_Ecal_cal->Write();
-        fh2_zPos_cal->Write();
-        fh2_tLeading_cal->Write();
-        fh2_maxAmp_cal->Write();
-        fh2_tSync_cal->Write();
-    }
+        if (fCalItems)
+        {
+            fh2_Ecal_cal->Write();
+            fh2_zPos_cal->Write();
+            fh2_tLeading_cal->Write();
+            fh2_maxAmp_cal->Write();
+            fh2_tSync_cal->Write();
+        }
 
-    if (fHitItems)
-    {
-        for (auto& h : fh1_RingCounts)
-            h->Write();
+        if (fHitItems)
+        {
+            for (auto& h : fh1_RingCounts)
+                h->Write();
 
-        for (auto& h : fh2_XYPos)
-            h->Write();
+            for (auto& h : fh2_XYPos)
+                h->Write();
 
-        for (auto& h : fh2_XYPos_Evts_Automatic)
-            h->Write();
+            for (auto& h : fh2_XYPos_Evts_Automatic)
+                h->Write();
 
-        for (auto& h : fh1_PhiCounts)
-            h->Write();
+            for (auto& h : fh1_PhiCounts)
+                h->Write();
 
-        fh1_CountsPerSide->Write();
+            fh1_CountsPerSide->Write();
 
-        fh2_Phi1VsPhi2->Write();
+            fh2_Phi1VsPhi2->Write();
+        }
     }
 }
 ClassImp(R3BActafOnlineSpectra)

--- a/actaf/online/R3BActafOnlineSpectra.h
+++ b/actaf/online/R3BActafOnlineSpectra.h
@@ -152,6 +152,8 @@ class R3BActafOnlineSpectra : public FairTask
 
     void SetUpdateRate(int num) { updateRate = num; }
 
+    void SetSaveHistos(bool save) { saveHistos = save; }
+
   private:
     void SetParameter();
 
@@ -268,6 +270,9 @@ class R3BActafOnlineSpectra : public FairTask
     std::array<std::array<double, fPads>, maxEventViewerBatch> eventCountsX;
     std::array<std::array<double, fPads>, maxEventViewerBatch> eventCountsY;
     std::array<std::array<double, fPads>, maxEventViewerBatch> eventCountsE;
+
+    // Bool for saving the histograms in the output file
+    bool saveHistos = true;
 
   public:
     ClassDefOverride(R3BActafOnlineSpectra, 1);


### PR DESCRIPTION
Implemented a true/false option in the actaf online task to choose whether the histograms are saved in the output file or not. It was seen that closing the online macro was extremely slow and when the histograms are not saved this issue is solved. This roots in the fact that there are lots of histograms with a very fine binning for seeing the tracks.

The method can be called from the online macro as SetSaveHistos (true by default).
---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
