### PR TITLE
feat(g249 tracking): Add method to select the VFTX.

### DIFF
--- a/ssd/calibration/R3BFootHit2Track.cxx
+++ b/ssd/calibration/R3BFootHit2Track.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
  *   Copyright (C) 2025 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
- *   Copyright (C) 2019-2025 Members of R3B Collaboration                     *
+ *   Copyright (C) 2019-2026 Members of R3B Collaboration                     *
  *                                                                            *
  *             This software is distributed under the terms of the            *
  *                 GNU General Public Licence (GPL) version 3,                *
@@ -165,8 +165,10 @@ void R3BFootHit2Track::Exec(Option_t* /*option*/)
     for (auto j = 0; j < nFrsHits; ++j)
     {
         auto frs_item = dynamic_cast<R3BFrsData*>(fFrsData->At(j));
-        if (frs_item->GetStaId() != 2)
+
+        if (frs_item->GetStaId() != vftxNumber)
             continue; // 2 - new VFTX with 10ps resolution
+
         frsZ = frs_item->GetZ();
         frsAoQ = frs_item->GetAq();
     }

--- a/ssd/calibration/R3BFootHit2Track.h
+++ b/ssd/calibration/R3BFootHit2Track.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *   Copyright (C) 2025 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
- *   Copyright (C) 2019-2025 Members of R3B Collaboration                     *
+ *   Copyright (C) 2019-2026 Members of R3B Collaboration                     *
  *                                                                            *
  *             This software is distributed under the terms of the            *
  *                 GNU General Public Licence (GPL) version 3,                *
@@ -78,6 +78,8 @@ class R3BFootHit2Track : public FairTask
     void PrepareMinimizer(); // reset and set limits for the minimizer
     bool RunMinimizer();     // execute minimzation
 
+    void SetVFTXNumber(int nb) { vftxNumber = nb; };
+
     R3BTrackingParticle* AddTrack(const R3BTrackingParticle& p);
     void Transform_Point(TString flag, TVector3& hit_point, TVector3* offset, TVector3* rotation);
     bool FitParticle(R3BTrackingParticle& part, TrackDirection direction); // flag = "in" or "out"
@@ -141,6 +143,9 @@ class R3BFootHit2Track : public FairTask
     TrackDirection fInOutFlag;
     R3BEventHeader* fHeader = nullptr;
 
-  public:
-    ClassDefOverride(R3BFootHit2Track, 1);
+  private:
+    // Select the VFTX
+    int vftxNumber = 2;
+
+    ClassDefOverride(R3BFootHit2Track, 2);
 };

--- a/tracking/R3BTrackingG249.cxx
+++ b/tracking/R3BTrackingG249.cxx
@@ -1,6 +1,6 @@
 /******************************************************************************
  *   Copyright (C) 2025 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
- *   Copyright (C) 2025 Members of R3B Collaboration                          *
+ *   Copyright (C) 2025-2026 Members of R3B Collaboration                     *
  *                                                                            *
  *             This software is distributed under the terms of the            *
  *                 GNU General Public Licence (GPL) version 3,                *
@@ -254,7 +254,7 @@ void R3BTrackingG249::Exec(Option_t* /*option*/)
     {
         auto frs_item = dynamic_cast<R3BFrsData*>(frs_DataItems->At(j));
         R3BLOG_IF(fatal, !frs_item, "ERROR in the FRS data");
-        if (frs_item->GetStaId() != 2)
+        if (frs_item->GetStaId() != vftxNumber)
             continue; // 2 - new VFTX with 10ps resolution
         frsZ = frs_item->GetZ();
         frsAoQ = frs_item->GetAq();
@@ -693,4 +693,4 @@ double R3BTrackingG249::AlignmentError(const double* par)
     return v;
 }
 
-ClassImp(R3BTrackingG249);
+ClassImp(R3BTrackingG249)

--- a/tracking/R3BTrackingG249.h
+++ b/tracking/R3BTrackingG249.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  *   Copyright (C) 2025 GSI Helmholtzzentrum für Schwerionenforschung GmbH    *
- *   Copyright (C) 2025 Members of R3B Collaboration                          *
+ *   Copyright (C) 2025-2026 Members of R3B Collaboration                     *
  *                                                                            *
  *             This software is distributed under the terms of the            *
  *                 GNU General Public Licence (GPL) version 3,                *
@@ -13,8 +13,7 @@
 
 // Created on 16/09/2025 by V.Panin
 
-#ifndef R3BTRACKINGG249
-#define R3BTRACKINGG249
+#pragma once
 
 #include "FairTask.h"
 #include "R3BEventHeader.h"
@@ -73,6 +72,9 @@ class R3BTrackingG249 : public FairTask
     void SetAnglesFib32(double x, double y, double z) { f32_angles.SetXYZ(x, y, z); } // rad
     void SetAnglesFib33(double x, double y, double z) { f33_angles.SetXYZ(x, y, z); } // rad
     void SetAnglesTofd(double x, double y, double z) { tofd_angles.SetXYZ(x, y, z); } // rad
+
+    // Setter for the VFTX number
+    void SetVFTXNumber(int nb) { vftxNumber = nb; }
 
     // Get lab positions and angles (needed by alignment function)
     inline TVector3 GetPositionLOS() { return los_position; }   // cm
@@ -187,6 +189,8 @@ class R3BTrackingG249 : public FairTask
     std::unique_ptr<ROOT::Math::Minimizer> minimizer;
 
   private:
+    int vftxNumber = 2;
+
     //-- Input hit data from the TClonesArray
     // do not change the order, add new det in the end
     enum DetectorInstances
@@ -291,8 +295,5 @@ class R3BTrackingG249 : public FairTask
 
     TH2F* h2_lab_XZ;
 
-  public:
-    ClassDefOverride(R3BTrackingG249, 1)
+    ClassDefOverride(R3BTrackingG249, 2)
 };
-
-#endif


### PR DESCRIPTION
Classes R3BFootHit2Track and R3BTrackingG249 only use data taken with the second VFTX. This PR adds a method to select the VFTX. The second VFTX is the default one, though.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
