### PR TITLE
fix(gconfig): Change limit density for low density materials to inclu…

### DIFF
--- a/gconfig/g4config.in
+++ b/gconfig/g4config.in
@@ -38,6 +38,10 @@
 #/stepping/verbose 0
 #/control/verbose 0
 
+# Set the limit density for low density materials
+# to include air (use for correct stepping).
+/mcDet/setLimitDensity 2.e-3 g/cm3
+
 # Store secondaries
 #/mcTracking/saveSecondaries DoNotSave
 #/mcTracking/saveSecondaries SaveInStep


### PR DESCRIPTION
…de air in the g4config.in.

This PR fixes issue #1321. G4VMC uses a high step for non-low density materiales and this limit much above air. This PR changes the limit to 2.e-3 g/cm3, so air is included.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
