### PR TITLE
feat(califa): Add (optional) new parameter ToT eff.

### DIFF
--- a/califa/pars/R3BCalifaCrystalPars4Sim.cxx
+++ b/califa/pars/R3BCalifaCrystalPars4Sim.cxx
@@ -11,13 +11,14 @@
 
 R3BCalifaCrystalPars4Sim::R3BCalifaCrystalPars4Sim(const char* name, const char* title, const char* context)
     : FairParGenericSet(name, title, context)
-    , fNumCrystals(4864)
-    , fNumParams4Sim(3) /* Crystal ID & Reso & Threshold */
+    , fNumCrystals(5088)
+    , fNumParams4Sim(4) /* Crystal ID & Reso & Threshold & ToTEff */
 {
 
     fCrystalIDArray = new TArrayI(fNumCrystals);
-    fThresholdArray = new TArrayI(fNumCrystals);
+    fThresholdArray = new TArrayF(fNumCrystals);
     fResolutionArray = new TArrayF(fNumCrystals);
+    fEffToTArray = new TArrayF(fNumCrystals);
 }
 
 R3BCalifaCrystalPars4Sim::~R3BCalifaCrystalPars4Sim()
@@ -28,6 +29,8 @@ R3BCalifaCrystalPars4Sim::~R3BCalifaCrystalPars4Sim()
         delete fThresholdArray;
     if (fResolutionArray)
         delete fResolutionArray;
+    if (fEffToTArray)
+        delete fEffToTArray;
 }
 
 void R3BCalifaCrystalPars4Sim::clear()
@@ -52,6 +55,9 @@ void R3BCalifaCrystalPars4Sim::putParams(FairParamList* list)
 
     fResolutionArray->Set(fNumCrystals);
     list->add("califaResolutionPar", *fResolutionArray);
+
+    fEffToTArray->Set(fNumCrystals);
+    list->add("califaToTEffPar", *fEffToTArray);
 
     list->add("califaCrystalNumberPar", fNumCrystals);
     list->add("califaNumPars4SimPar", fNumParams4Sim);
@@ -96,6 +102,14 @@ Bool_t R3BCalifaCrystalPars4Sim::getParams(FairParamList* list)
         return kFALSE;
     }
 
+    fEffToTArray->Set(fNumCrystals);
+    if (!(list->fill("califaToTEffPar", fEffToTArray)))
+    {
+        LOG(info) << "---Could not initialize califaToTEffPar. Set to 1 by default.";
+        for (int i = 0; i < fNumCrystals; i++)
+            fEffToTArray->SetAt(1., i);
+    }
+
     return kTRUE;
 }
 
@@ -107,12 +121,13 @@ void R3BCalifaCrystalPars4Sim::printParams()
               << " "
               << "Threshold"
               << " "
-              << "Resolution";
+              << "Resolution"
+              << " "
+              << "ToT Efficiency";
 
     for (Int_t i = 0; i < fNumCrystals; i++)
-
     {
         LOG(info) << i + 1 << " " << fCrystalIDArray->GetAt(i) << " " << fThresholdArray->GetAt(i) << " "
-                  << fResolutionArray->GetAt(i);
+                  << fResolutionArray->GetAt(i) << " " << fEffToTArray->GetAt(i);
     }
 }

--- a/califa/pars/R3BCalifaCrystalPars4Sim.h
+++ b/califa/pars/R3BCalifaCrystalPars4Sim.h
@@ -1,5 +1,4 @@
-#ifndef R3BCALIFACRYSTALPARS4SIM_H
-#define R3BCALIFACRYSTALPARS4SIM_H
+#pragma once
 
 #include "FairParGenericSet.h"
 
@@ -42,7 +41,8 @@ class R3BCalifaCrystalPars4Sim : public FairParGenericSet
     const Int_t GetNumParameters4Sim() { return fNumParams4Sim; }
 
     const Float_t GetResolution(Int_t crystal) { return fResolutionArray->GetAt(crystal - 1); }
-    const Int_t GetThreshold(Int_t crystal) { return fThresholdArray->GetAt(crystal - 1); }
+    const Float_t GetThreshold(Int_t crystal) { return fThresholdArray->GetAt(crystal - 1); }
+    const Float_t GetTotEff(Int_t crystal) { return fEffToTArray->GetAt(crystal - 1); }
 
     const Bool_t GetInUse(Int_t crystal)
     {
@@ -60,8 +60,9 @@ class R3BCalifaCrystalPars4Sim : public FairParGenericSet
   private:
     /* Simulation Parameters of Crystals */
     TArrayI* fCrystalIDArray;
-    TArrayI* fThresholdArray;
+    TArrayF* fThresholdArray;
     TArrayF* fResolutionArray;
+    TArrayF* fEffToTArray;
 
     Int_t fNumCrystals;   /* Number of crystals */
     Int_t fNumParams4Sim; /* Number of Simulation parameters in the Sim (CrystalID, Resolution, Threshold, NonUni...) */
@@ -70,7 +71,5 @@ class R3BCalifaCrystalPars4Sim : public FairParGenericSet
 
     R3BCalifaCrystalPars4Sim(const R3BCalifaCrystalPars4Sim&); /*  a copy constructor  */
 
-    ClassDef(R3BCalifaCrystalPars4Sim, 1);
+    ClassDef(R3BCalifaCrystalPars4Sim, 2);
 };
-
-#endif

--- a/califa/sim/R3BCalifaDigitizer.cxx
+++ b/califa/sim/R3BCalifaDigitizer.cxx
@@ -246,19 +246,26 @@ void R3BCalifaDigitizer::FillRealConfig(int nCrystalCals)
     double tempNf = 0;
     double tempNs = 0;
     int tempCryID = 0;
-    int parThres = 0;
+    double parThres = 0;
     bool inUse = false;
+    double ToTeff = 0;
 
     for (int i = 0; i < nCrystalCals; i++)
     {
         tempCryID = (dynamic_cast<R3BCalifaCrystalCalData*>(fCalifaCryCalDataCA->At(i)))->GetCrystalId();
         tempE = (dynamic_cast<R3BCalifaCrystalCalData*>(fCalifaCryCalDataCA->At(i)))->GetEnergy();
 
-        inUse = fSim_Par->GetInUse(tempCryID - 1);
-        fResolution = fSim_Par->GetResolution(tempCryID - 1);
-        parThres = fSim_Par->GetThreshold(tempCryID - 1);
+        inUse = fSim_Par->GetInUse(tempCryID);
+        fResolution = fSim_Par->GetResolution(tempCryID);
+        parThres = fSim_Par->GetThreshold(tempCryID);
+        ToTeff = fSim_Par->GetTotEff(tempCryID);
 
-        if (inUse && parThres < tempE * 1000.)
+        // Metropolis-like algorithm to apply ToT efficiencies
+        // (if no ToT efficiencies are provided, default values are
+        // set to 1 so no correction due to these inefficiencies is performed).
+        double randValue = gRandom->Uniform(0, 1);
+
+        if (inUse && parThres < tempE * 1000. && randValue < ToTeff)
         { // Thresholds are in KeV!!
 
             (dynamic_cast<R3BCalifaCrystalCalData*>(fCalifaCryCalDataCA->At(i)))->SetEnergy(ExpResSmearing(tempE));

--- a/califa/sim/R3BCalifaDigitizer.h
+++ b/califa/sim/R3BCalifaDigitizer.h
@@ -13,9 +13,6 @@
 
 #pragma once
 
-#ifndef R3BCALIFADIGITIZER_H
-#define R3BCALIFADIGITIZER_H 1
-
 #include <FairTask.h>
 #include <R3BCalifa.h>
 #include <R3BCalifaCrystalCalData.h>
@@ -154,7 +151,5 @@ class R3BCalifaDigitizer : public FairTask
                                            double tot_energy = 0.);
 
   public:
-    ClassDefOverride(R3BCalifaDigitizer, 1);
+    ClassDefOverride(R3BCalifaDigitizer, 2);
 };
-
-#endif /* R3BCALIFADIGITIZER_H */


### PR DESCRIPTION
feat(califa): Thresholds for simulations changed from Int_t to Float_t.

feat(califa): Add ToT efficiency in the digitizer.

Modifications in CALIFA simulations:

- Thresholds changed from Int_t to Float_t.
- New parameter: ToT efficiency crystal by crystal (default value set to 1).
- Metropolis-like method to convolute effect of the ToT efficiency.

---

Checklist:

* [x] Rebased against `dev` branch
* [x] My name is in the resp. CONTRIBUTORS/AUTHORS file
* [x] Followed the [pull request guidlines](https://opensource.creativecommons.org/contributing-code/pr-guidelines/) and the [Git workflow](https://github.com/AnarManafov/GitWorkflow/blob/master/GitWorkflow.markdown)
* [x] Followed the [seven rules of great commit messages](https://chris.beams.io/posts/git-commit/#seven-rules)
